### PR TITLE
feat: Fix `NO_COLOR` toggle do disable colored logs

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -3,32 +3,27 @@ ezpz/__init__.py
 """
 
 from __future__ import absolute_import, annotations, division, print_function
-# import socket
-
-# if "x3" in socket.gethostname():
-from mpi4py import MPI
-
 import logging
 import logging.config
 import os
 import re
+from typing import Optional
+import warnings
+
 import yaml
 
-from typing import Optional
+from mpi4py import MPI
 
 from ezpz import dist
 from ezpz import log
-
-from ezpz.plot import tplot, tplot_dict
 from ezpz import profile
 from ezpz import configs
-
 from ezpz.configs import (
     BACKENDS,
     BIN_DIR,
     CONF_DIR,
-    DS_CONFIG_PATH,
     DS_CONFIG_JSON,
+    DS_CONFIG_PATH,
     DS_CONFIG_YAML,
     FRAMEWORKS,
     GETJOBENV,
@@ -40,8 +35,8 @@ from ezpz.configs import (
     QUARTO_OUTPUTS_DIR,
     SAVEJOBENV,
     SCHEDULERS,
-    UTILS,
     TrainConfig,
+    UTILS,
     command_exists,
     get_logging_config,
     get_scheduler,
@@ -82,10 +77,7 @@ from ezpz.dist import (
     timeit,
     timeitlogit,
 )
-from ezpz.utils import grab_tensor
-
-# from ezpz.jobs import loadjobenv, savejobenv
-# from ezpz import jobs
+from ezpz.history import History, StopWatch, format_pair, summarize_dict
 from ezpz.log import get_file_logger, get_logger
 from ezpz.log.config import NO_COLOR, STYLES
 from ezpz.log.console import (
@@ -98,13 +90,6 @@ from ezpz.log.console import (
     to_bool,
 )
 from ezpz.log.handler import FluidLogRender, RichHandler
-from ezpz.history import (
-    format_pair,
-    summarize_dict,
-    StopWatch,
-    History,
-    # BaseHistory,
-)
 from ezpz.log.style import (
     BEAT_TIME,
     COLORS,
@@ -117,7 +102,9 @@ from ezpz.log.style import (
     print_config,
     printarr,
 )
+from ezpz.plot import tplot, tplot_dict
 from ezpz.profile import PyInstrumentProfiler, get_context_manager
+from ezpz.utils import grab_tensor
 
 try:
     import wandb  # pyright: ignore
@@ -145,11 +132,18 @@ PLAIN = os.environ.get(
     ),
 )
 if (not PLAIN) and TERM not in ["dumb", "unknown"]:
-    log_config = logging.config.dictConfig(get_logging_config())
+    try:
+        log_config = logging.config.dictConfig(get_logging_config())
+    except (ValueError, TypeError, AttributeError) as e:
+        warnings.warn(f"Failed to configure logging: {e}")
+        logging.basicConfig(
+            level=logging.INFO,
+            format="[%(asctime)s][%(levelname)s][%(name)s]: %(message)s",
+        )
 else:
     logging.basicConfig(
-        format="[%(asctime)s][%(levelname)s][%(name)s]: %(message)s",
         level=logging.INFO,
+        format="[%(asctime)s][%(levelname)s][%(name)s]: %(message)s",
     )
 
 

--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -3,32 +3,26 @@ ezpz/__init__.py
 """
 
 from __future__ import absolute_import, annotations, division, print_function
-import socket
-if 'x3' in socket.gethostname():
-    from mpi4py import MPI
+# import socket
+
+# if "x3" in socket.gethostname():
+from mpi4py import MPI
 
 import logging
 import logging.config
 import os
 import re
+import yaml
 
-# import socket
 from typing import Optional
-# from typing import Union
-
-# import numpy as np
-# import rich
-# from rich.console import Console
-# from rich.logging import RichHandler
 
 from ezpz import dist
 from ezpz import log
 
-# from ezpz import plot
 from ezpz.plot import tplot, tplot_dict
 from ezpz import profile
 from ezpz import configs
-# from ezpz import utils
+
 from ezpz.configs import (
     BACKENDS,
     BIN_DIR,
@@ -93,7 +87,7 @@ from ezpz.utils import grab_tensor
 # from ezpz.jobs import loadjobenv, savejobenv
 # from ezpz import jobs
 from ezpz.log import get_file_logger, get_logger
-from ezpz.log.config import DEFAULT_STYLES, NO_COLOR, STYLES
+from ezpz.log.config import NO_COLOR, STYLES
 from ezpz.log.console import (
     Console,
     get_console,
@@ -140,8 +134,6 @@ except Exception:
 #     loader.exec_module(module)
 #     return module
 
-from mpi4py import MPI
-
 TERM = os.environ.get("TERM", None)
 PLAIN = os.environ.get(
     "NO_COLOR",
@@ -152,54 +144,16 @@ PLAIN = os.environ.get(
         ),
     ),
 )
-COLORFUL = not PLAIN
-# if not PLAIN and TERM not in ["dumb", "unknown"]:
-if COLORFUL and TERM not in ["dumb", "unknown"]:
-    # try:
+if (not PLAIN) and TERM not in ["dumb", "unknown"]:
     log_config = logging.config.dictConfig(get_logging_config())
-    # except Exception:
-        # pass
 else:
     logging.basicConfig(
-        format='[%(asctime)s][%(levelname)s][%(name)s]: %(message)s',
-        level=logging.INFO
+        format="[%(asctime)s][%(levelname)s][%(name)s]: %(message)s",
+        level=logging.INFO,
     )
-    print("Disabling color from logs!")
-
-# LOGGING_CONFIG = { 
-#     'version': 1,
-#     # 'disable_existing_loggers': True,
-#     'formatters': {
-#         'standard': {
-#             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
-#         },
-#     },
-#     # 'handlers': {
-#     #     'default': {
-#     #         'level': 'INFO',
-#     #         'formatter': 'standard',
-#     #         'class': 'logging.StreamHandler',
-#     #         'stream': 'ext://sys.stdout',  # Default is stderr
-#     #     },
-#     # },
-#     'loggers': {
-#         '': {  # root logger
-#             # 'handlers': ['default'],
-#             'level': 'INFO',
-#             # 'propagate': False
-#         },
-#         # '__main__': {  # if __name__ == '__main__'
-#         #     'handlers': ['default'],
-#         #     'level': 'DEBUG',
-#         #     'propagate': False
-#         # },
-#     }
-# }
-# log_config = logging.config.dictConfig(LOGGING_CONFIG)
 
 
 logger = logging.getLogger(__name__)
-
 # logger.setLevel("INFO")
 logging.getLogger("sh").setLevel("WARNING")
 
@@ -241,7 +195,7 @@ __all__ = [
     "CONF_DIR",
     "Console",
     "CustomLogging",
-    "DEFAULT_STYLES",
+    # "DEFAULT_STYLES",
     "DS_CONFIG_PATH",
     "DS_CONFIG_JSON",
     "DS_CONFIG_YAML",
@@ -261,7 +215,6 @@ __all__ = [
     "SCHEDULERS",
     "STYLES",
     "UTILS",
-    "BaseHistory",
     "History",
     "PyInstrumentProfiler",
     "StopWatch",
@@ -332,7 +285,7 @@ __all__ = [
     "tplot_dict",
     "timeitlogit",
     "to_bool",
-    "utils",
+    # "utils",
 ]
 
 
@@ -361,7 +314,9 @@ def get_console_from_logger(logger: logging.Logger) -> Console:
     return get_console()
 
 
-def get_rich_logger(name: Optional[str] = None, level: str = "INFO") -> logging.Logger:
+def get_rich_logger(
+    name: Optional[str] = None, level: str = "INFO"
+) -> logging.Logger:
     from ezpz.log.handler import RichHandler
 
     # log: logging.Logger = get_logger(name=name, level=level)
@@ -404,7 +359,9 @@ def get_rich_logger(name: Optional[str] = None, level: str = "INFO") -> logging.
 #     return log
 
 
-def get_enrich_logging_config_as_yaml(name: str = "enrich", level: str = "INFO") -> str:
+def get_enrich_logging_config_as_yaml(
+    name: str = "enrich", level: str = "INFO"
+) -> str:
     return rf"""
     ---
     # version: 1
@@ -426,8 +383,6 @@ def get_logger_new(
     name: str,
     level: str = "INFO",
 ):
-    import yaml
-
     config = yaml.safe_load(
         get_enrich_logging_config_as_yaml(name=name, level=level),
     )

--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -152,15 +152,55 @@ PLAIN = os.environ.get(
         ),
     ),
 )
-if not PLAIN and TERM not in ["dumb", "unknown"]:
-    try:
-        log_config = logging.config.dictConfig(get_logging_config())
-    except Exception:
-        pass
+COLORFUL = not PLAIN
+# if not PLAIN and TERM not in ["dumb", "unknown"]:
+if COLORFUL and TERM not in ["dumb", "unknown"]:
+    # try:
+    log_config = logging.config.dictConfig(get_logging_config())
+    # except Exception:
+        # pass
 else:
+    logging.basicConfig(
+        format='[%(asctime)s][%(levelname)s][%(name)s]: %(message)s',
+        level=logging.INFO
+    )
     print("Disabling color from logs!")
 
+# LOGGING_CONFIG = { 
+#     'version': 1,
+#     # 'disable_existing_loggers': True,
+#     'formatters': {
+#         'standard': {
+#             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+#         },
+#     },
+#     # 'handlers': {
+#     #     'default': {
+#     #         'level': 'INFO',
+#     #         'formatter': 'standard',
+#     #         'class': 'logging.StreamHandler',
+#     #         'stream': 'ext://sys.stdout',  # Default is stderr
+#     #     },
+#     # },
+#     'loggers': {
+#         '': {  # root logger
+#             # 'handlers': ['default'],
+#             'level': 'INFO',
+#             # 'propagate': False
+#         },
+#         # '__main__': {  # if __name__ == '__main__'
+#         #     'handlers': ['default'],
+#         #     'level': 'DEBUG',
+#         #     'propagate': False
+#         # },
+#     }
+# }
+# log_config = logging.config.dictConfig(LOGGING_CONFIG)
+
+
 logger = logging.getLogger(__name__)
+
+# logger.setLevel("INFO")
 logging.getLogger("sh").setLevel("WARNING")
 
 


### PR DESCRIPTION
To disable coloring log outputs (default), we can use the `NO_COLOR=1` environment variable, e.g.:

```bash
NO_COLOR=1 launch python3 -m ezpz.test_dist
```

Compare:

<img width="49%" src="https://github.com/user-attachments/assets/500875bc-2c9a-4df5-b073-09be2d012378"> <img width="49%" src="https://github.com/user-attachments/assets/4edfeeb7-5d7c-4880-8ae2-23fff2aa0505">

## Summary by Sourcery

Fix the `NO_COLOR` environment variable to disable colored logs and enhance logging configuration error handling.

Bug Fixes:
- Fix the `NO_COLOR` environment variable to properly disable colored logs.

Enhancements:
- Improve error handling in logging configuration by catching specific exceptions and providing warnings.