### PR TITLE
feat: Add `synchronize` method to `ezpz.dist`

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -41,6 +41,7 @@ from ezpz.dist import (
     setup_torch_DDP,
     setup_torch_distributed,
     setup_wandb,
+    synchronize,
     timeit,
     timeitlogit,
 )
@@ -349,6 +350,7 @@ __all__ = [
     'setup_wandb',
     'should_do_markup',
     'summarize_dict',
+    'synchronize',
     'timeit',
     'timeitlogit',
     'to_bool',

--- a/src/ezpz/dist.py
+++ b/src/ezpz/dist.py
@@ -362,6 +362,16 @@ def print_dist_setup(
             )
     return dist_str
 
+def synchronize(device: torch.device | int | str = 'cuda'):
+    return (
+            torch.cuda.synchronize(device) if torch.cuda.is_available()
+            else (
+                torch.xpu.synchronize(device) if torch.xpu.is_available()
+                else torch.mps.synchronize() if torch.backends.mps.is_available()
+                else torch.cpu.synchronize(device)
+            )
+    )
+
 
 def setup(
     framework: str = 'pytorch',
@@ -1053,6 +1063,7 @@ def setup_wandb(
         import sys
 
         frame = sys._getframe().f_back
+        assert frame is not None
         calling_module = frame.f_code.co_filename
         fp = Path(calling_module)
         project_name = f'{fp.parent.stem}.{fp.stem}'


### PR DESCRIPTION
## Copilot Summary

This pull request includes several changes to the `src/ezpz` module, focusing on adding a new `synchronize` function and improving the robustness of the `setup_wandb` function. The most important changes include adding the `synchronize` function to the module's public API and implementing the function itself, as well as adding an assertion to ensure the `frame` is not `None` in `setup_wandb`.

### Additions and Improvements:

* [`src/ezpz/__init__.py`](diffhunk://#diff-1bc06f12ec4b24d201c0381246b3f7706853b528e592e8656b0c53150accaedfR44): Added `synchronize` to the list of imports and the module's public API. [[1]](diffhunk://#diff-1bc06f12ec4b24d201c0381246b3f7706853b528e592e8656b0c53150accaedfR44) [[2]](diffhunk://#diff-1bc06f12ec4b24d201c0381246b3f7706853b528e592e8656b0c53150accaedfR353)
* [`src/ezpz/dist.py`](diffhunk://#diff-684e0cdce62a75455cca73584add1741af0d1207664ed57c1e7937663c8aaa08R365-R374): Implemented the `synchronize` function to handle synchronization across different devices (`torch.cuda`, `torch.xpu`, `torch.mps`, and `torch.cpu`).
* [`src/ezpz/dist.py`](diffhunk://#diff-684e0cdce62a75455cca73584add1741af0d1207664ed57c1e7937663c8aaa08R1066): Added an assertion in the `setup_wandb` function to ensure `frame` is not `None` before accessing its attributes.

## Summary by Sourcery

New Features:
- Expose a `synchronize` method in `ezpz.dist` to synchronize across different devices (CUDA, XPU, MPS, CPU).