### PR TITLE
feat: Add `ezpz.utils.breakpoint` to `__all__` in `__init__.py`

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -154,7 +154,14 @@ from ezpz.tp import (
 )
 from ezpz.plot import tplot, tplot_dict
 from ezpz.profile import PyInstrumentProfiler, get_context_manager
-from ezpz.utils import grab_tensor
+from ezpz.utils import (
+    breakpoint,
+	grab_tensor,
+	save_dataset,
+	dataset_to_h5pyfile,
+	dataset_from_h5pyfile,
+	dict_from_h5pyfile
+)
 from jaxtyping import ScalarLike
 from mpi4py import MPI
 import numpy as np
@@ -272,13 +279,17 @@ __all__ = [
     'UTILS',
     'add_columns',
     'build_layout',
+    'breakpoint',
     'check',
     'cleanup',
     'command_exists',
     'configs',
     # 'initialize_tensor_parallel',
     # 'tensor_parallel_is_initialized',
+    'dataset_from_h5pyfile',
+    'dataset_to_h5pyfile',
     'destroy_tensor_parallel',
+    'dict_from_h5pyfile',
     'dist',
     'ensure_divisibility',
     'flatten_dict',
@@ -341,6 +352,7 @@ __all__ = [
     'profile',
     'query_environment',
     'run_bash_command',
+    'save_dataset',
     'seed_everything',
     'setup',
     'setup_tensorflow',


### PR DESCRIPTION
## Copilot Summary

This pull request includes several updates to the `src/ezpz/__init__.py` file, primarily focusing on expanding the list of utility functions imported and exported by the module. These changes enhance the module's functionality by including additional dataset handling and debugging utilities.

### Enhancements to utility functions:

* Expanded the import of utility functions to include `breakpoint`, `save_dataset`, `dataset_to_h5pyfile`, `dataset_from_h5pyfile`, and `dict_from_h5pyfile`.
* Added `breakpoint`, `dataset_from_h5pyfile`, `dataset_to_h5pyfile`, and `dict_from_h5pyfile` to the list of exported utilities.
* Added `save_dataset` to the list of exported utilities.