### PR TITLE
fix: Fix broken import on Polaris

### DIFF
--- a/src/ezpz/tp/__init__.py
+++ b/src/ezpz/tp/__init__.py
@@ -30,6 +30,8 @@ import logging
 
 from typing import List, Optional
 
+from mpi4py import MPI
+
 import torch
 import torch.distributed as tdist
 from datetime import timedelta


### PR DESCRIPTION
## Copilot Summary

This pull request includes a small change to the `src/ezpz/tp/__init__.py` file. The change adds an import for the `MPI` module from the `mpi4py` package. 

* [`src/ezpz/tp/__init__.py`](diffhunk://#diff-a8de46363ccce1b8f41e582762faf128f7b6a5604661097f513e1b92d12322d9R33-R34): Added import for `MPI` from `mpi4py`.

## Summary by Sourcery

Bug Fixes:
- Fixes a broken import by adding the missing import statement for the `MPI` module from the `mpi4py` package in `src/ezpz/tp/__init__.py`.