### PR TITLE
fix: Fix imports in `tp/__init__.py` on Aurora

### DIFF
--- a/src/ezpz/tp/__init__.py
+++ b/src/ezpz/tp/__init__.py
@@ -30,9 +30,16 @@ import logging
 
 from typing import List, Optional
 
-from mpi4py import MPI
+import socket
 
-import torch
+# NOTE: Need to swap import order on Polaris (hostname: [x3...])
+if socket.gethostname().startswith('x3'):
+    from mpi4py import MPI
+    import torch
+else:
+    import torch
+    from mpi4py import MPI  # type:ignore
+
 import torch.distributed as tdist
 from datetime import timedelta
 from ezpz.tp.utils import (


### PR DESCRIPTION
## Copilot Summary

This pull request includes a change to the import order in the `src/ezpz/tp/__init__.py` file to handle a specific hostname condition. The change ensures that the `mpi4py` and `torch` modules are imported in the correct order depending on the hostname.

Import order adjustment:

* [`src/ezpz/tp/__init__.py`](diffhunk://#diff-a8de46363ccce1b8f41e582762faf128f7b6a5604661097f513e1b92d12322d9L33-R42): Added a conditional import statement to check if the hostname starts with 'x3' and adjust the import order of `mpi4py` and `torch` accordingly. This is necessary for compatibility with the Polaris environment.