### PR TITLE
fix: Fix `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "tensorboard",
     "seaborn",
     "omegaconf",
-    "sentencepiece",
+    # "sentencepiece",
     "ipython",
     "hydra-core",
     "wandb",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removes the `sentencepiece` dependency.