### PR TITLE
Update dist.py

### DIFF
--- a/src/ezpz/dist.py
+++ b/src/ezpz/dist.py
@@ -527,7 +527,7 @@ def get_torch_backend_on_xpu() -> str:
     """
     torch_version = get_torch_version_as_float()
     assert torch.xpu.is_available()
-    if torch_version >= 2.5:
+    if torch_version > 2.5:
         return 'xccl'
     return 'ccl'
 


### PR DESCRIPTION
## Copilot Summary

This pull request includes a small change to the `src/ezpz/dist.py` file. The change updates the condition in the `get_torch_backend_on_xpu` function to use a strict greater-than comparison for the `torch_version`.

* [`src/ezpz/dist.py`](diffhunk://#diff-684e0cdce62a75455cca73584add1741af0d1207664ed57c1e7937663c8aaa08L530-R530): Changed the comparison from `torch_version >= 2.5` to `torch_version > 2.5` in the `get_torch_backend_on_xpu` function.

## Summary by Sourcery

Bug Fixes:
- Modify the torch version comparison in `get_torch_backend_on_xpu` to use a strict greater-than comparison instead of greater-than-or-equal-to