### PR TITLE
feat: Remove breakpoints in `src/ezpz/hf_trainer.py`

### DIFF
--- a/src/ezpz/hf_trainer.py
+++ b/src/ezpz/hf_trainer.py
@@ -352,10 +352,7 @@ def parse_args() -> dict:
         run = ezpz.setup_wandb(project_name="ezpz.hf_trainer")
         assert wandb is not None and run is wandb.run and run is not None
         wandb.run.config.update(ezpz.get_dist_info())  # type:ignore
-        # try:
         wandb.run.config.update(training_args.to_dict())
-        # except Exception:
-        #     ezpz.breakpoint(0)
     # NOTE:
     #   Sending telemetry.
     #   Tracking the example usage helps us better allocate resources to
@@ -507,9 +504,6 @@ def main():
                     trust_remote_code=model_args.trust_remote_code,
                 )
             except ValueError:
-                from ezpz import breakpoint
-
-                breakpoint(0)
                 # In some cases, the dataset doesn't support slicing.
                 # In this case, we just use the full training set as validation set.
                 raw_datasets[validation_split_name] = load_dataset(  # type:ignore


### PR DESCRIPTION
## Copilot Summary

This pull request includes changes to the `src/ezpz/hf_trainer.py` file to clean up the code by removing commented-out and unnecessary code blocks.

Code cleanup:

* [`src/ezpz/hf_trainer.py`](diffhunk://#diff-9e4f90b34cef860a504924744816d4a81e62b3ba4cbc1f7d2998563220964f46L355-L358): Removed commented-out code in the `parse_args` function that was previously used for error handling.
* [`src/ezpz/hf_trainer.py`](diffhunk://#diff-9e4f90b34cef860a504924744816d4a81e62b3ba4cbc1f7d2998563220964f46L510-L512): Removed the import and call to the `breakpoint` function in the `main` function, which was used for debugging purposes.

## Summary by Sourcery

Remove debugging code and commented-out sections from the Hugging Face trainer module

Enhancements:
- Removed commented-out error handling code in the argument parsing function
- Eliminated debugging breakpoint calls in the main function

Chores:
- Clean up unnecessary code and remove debugging breakpoints in the Hugging Face trainer implementation