### PR TITLE
chore: Update `src/ezpz/log/__init__.py`

### DIFF
--- a/src/ezpz/log/__init__.py
+++ b/src/ezpz/log/__init__.py
@@ -193,8 +193,10 @@ def get_logger(
         else level
     )
     # level = os.environ.get("LOG_LEVEL", "INFO") if level is None else level
-    if colored_logs and use_colored_logs():
-        logging.config.dictConfig(get_logging_config())
+    # if colored_logs and use_colored_logs():
+    if not colored_logs:
+        os.environ["NO_COLOR"] = "1"
+    logging.config.dictConfig(get_logging_config())
     logger = logging.getLogger(name if name is not None else __name__)
     if rank_zero_only:
         if int(rank) == 0:


### PR DESCRIPTION
## Copilot Summary

This pull request modifies the logging behavior in the `get_logger` function to handle colored logs differently. The most important change ensures that the environment variable `NO_COLOR` is set when colored logs are disabled.

### Logging behavior changes:

* [`src/ezpz/log/__init__.py`](diffhunk://#diff-ef198353b44f11b037dea1f2271152d303aaa3ae069a634d758bb80e8972c2fbL196-R198): Updated the `get_logger` function to set the `NO_COLOR` environment variable when `colored_logs` is disabled, replacing the previous conditional check for colored logs.

## Summary by Sourcery

Chores:
- Modify logging configuration in get_logger function to handle colored logs more explicitly