### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
         </details>
 
     - Minimal example
-      \[[ezpz / examples / `minimal.py`](https://github.com/saforem2/ezpz/blob/main/examples/minimal.py)\]:
+      \[[ezpz / examples / `minimal.py`](https://github.com/saforem2/ezpz/blob/main/src/ezpz/examples/minimal.py)\]:
 
         ```bash
         ezpz-launch -m ezpz.examples.minimal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
 
 ## 🐣 Getting Started
 
-1. 🏖️ **Setup** environment[^magic] (see [Shell Environment](./shell-environment.md)):
+
+1. 🏖️ **Setup** environment[^magic] (see [Shell Environment](https://saforem2.github.io/ezpz/shell-environment/)):
 
     ```bash
     source <(curl -L https://bit.ly/ezpz-utils) && ezpz_setup_env
@@ -20,13 +21,13 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
        and (`&&`) call `ezpz_setup_env` to setup your
        python environment.
 
-1. 🐍 **Install** `ezpz` (see [💾 Code Reference / ezpz](./Code-Reference/init-reference.md))
+1. 🐍 **Install** `ezpz` (see [💾  / ezpz](https://saforem2.github.io/ezpz/Code-Reference/))
 
     ```bash
     python3 -m pip install "git+https://github.com/saforem2/ezpz"
     ```
 
-1. 🚀 **Launch** python  **_from_** python using `ezpz-launch` (see [Launch](./launch.md)).
+1. 🚀 **Launch** python  **_from_** python using `ezpz-launch` (see [Launch](https://saforem2.github.io/ezpz/launch/)).
 
     Examples, launching:
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
 
 ## 🐣 Getting Started
 
-
-> ![NOTE]  
-> - 🧑‍💻 **Hands-On** See my recent slides on:
->   [**_Large Language Models on Aurora_**](https://saforem2.github.io/ezpz/slides-2025-05-07/)  \[2025-05-07\]  
->   for a detailed walk-through of some of the various features of `ezpz`.
-
-
-
 1. \[🏖️ **Setup**\] environment[^magic] (see [**Shell Environment**](https://saforem2.github.io/ezpz/shell-environment/)):
 
     ```bash
@@ -792,6 +784,14 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
 
     </details>
 
-
     😎 2 ez.
 
+## 🧑‍💻 Hands On
+
+- See my recent talk on:
+  [**_LLMs on Aurora_: Hands On with `ezpz`**](https://saforem2.github.io/ezpz/slides-2025-05-07/)  
+  for a detailed walk-through containing examples and use cases.
+
+  - [🎥 YouTube](https://www.youtube.com/watch?v=15ZK9REQiBo)
+  - [Slides (html)](https://samforeman.me/talks/incite-hackathon-2025/ezpz/)
+  - [Slides (reveal.js)](https://samforeman.me/talks/incite-hackathon-2025/ezpz/slides)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
 ## 🐣 Getting Started
 
 
-1. 🏖️ **Setup** environment[^magic] (see [Shell Environment](https://saforem2.github.io/ezpz/shell-environment/)):
+> ![NOTE]
+> 🧑‍💻 **Hands-On**: See my recent slides on
+> [**Large Language Models on Aurora**](https://saforem2.github.io/ezpz/slides-2025-05-07/)
+> for a detailed walk-through of some of the various features of `ezpz`.
+
+
+
+1. 🏖️ **Setup** environment[^magic] (see [**Shell Environment**](https://saforem2.github.io/ezpz/shell-environment/)):
 
     ```bash
     source <(curl -L https://bit.ly/ezpz-utils) && ezpz_setup_env
@@ -21,13 +28,13 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
        and (`&&`) call `ezpz_setup_env` to setup your
        python environment.
 
-1. 🐍 **Install** `ezpz` (see [💾  / ezpz](https://saforem2.github.io/ezpz/Code-Reference/))
+1. 🐍 **Install** `ezpz` (see [**Python API**](https://saforem2.github.io/ezpz/Code-Reference/)):
 
     ```bash
     python3 -m pip install "git+https://github.com/saforem2/ezpz"
     ```
 
-1. 🚀 **Launch** python  **_from_** python using `ezpz-launch` (see [Launch](https://saforem2.github.io/ezpz/launch/)).
+1. 🚀 **Launch** python  **_from_** python using `ezpz-launch` (see [**Launch**](https://saforem2.github.io/ezpz/launch/)).
 
     Examples, launching:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
 
 ## 🐣 Getting Started
 
-1. \[🏖️ **Setup**\] environment[^magic] (see [**Shell Environment**](https://saforem2.github.io/ezpz/shell-environment/)):
+1. 🏖️ **Setup** environment[^magic] (see [**Shell Environment**](https://saforem2.github.io/ezpz/shell-environment/)):
 
     ```bash
     source <(curl -L https://bit.ly/ezpz-utils) && ezpz_setup_env
@@ -20,13 +20,13 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
        and (`&&`) call `ezpz_setup_env` to setup your
        python environment.
 
-1. \[🐍 **Install**\] `ezpz` (see [**Python API**](https://saforem2.github.io/ezpz/Code-Reference/)):
+1. 🐍 **Install** `ezpz` (see [**Python API**](https://saforem2.github.io/ezpz/Code-Reference/)):
 
     ```bash
     python3 -m pip install "git+https://github.com/saforem2/ezpz"
     ```
 
-1. \[🚀 **Launch**\] python  **_from_** python using `ezpz-launch` (see [**Launch**](https://saforem2.github.io/ezpz/launch/)).
+1. 🚀 **Launch** python  **_from_** python using `ezpz-launch` (see [**Launch**](https://saforem2.github.io/ezpz/launch/)).
 
     ```bash
     # arbitrary python string, for example

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
 ## 🐣 Getting Started
 
 
-> ![NOTE]
-> 🧑‍💻 **Hands-On**: See my recent slides on
-> [**Large Language Models on Aurora**](https://saforem2.github.io/ezpz/slides-2025-05-07/)
-> for a detailed walk-through of some of the various features of `ezpz`.
+> ![NOTE]  
+> - 🧑‍💻 **Hands-On** See my recent slides on:
+>   [**_Large Language Models on Aurora_**](https://saforem2.github.io/ezpz/slides-2025-05-07/)  \[2025-05-07\]  
+>   for a detailed walk-through of some of the various features of `ezpz`.
 
 
 
-1. 🏖️ **Setup** environment[^magic] (see [**Shell Environment**](https://saforem2.github.io/ezpz/shell-environment/)):
+1. \[🏖️ **Setup**\] environment[^magic] (see [**Shell Environment**](https://saforem2.github.io/ezpz/shell-environment/)):
 
     ```bash
     source <(curl -L https://bit.ly/ezpz-utils) && ezpz_setup_env
@@ -28,15 +28,20 @@ See [🍋 `ezpz` docs](https://saforem2.github.io/ezpz) for additional informati
        and (`&&`) call `ezpz_setup_env` to setup your
        python environment.
 
-1. 🐍 **Install** `ezpz` (see [**Python API**](https://saforem2.github.io/ezpz/Code-Reference/)):
+1. \[🐍 **Install**\] `ezpz` (see [**Python API**](https://saforem2.github.io/ezpz/Code-Reference/)):
 
     ```bash
     python3 -m pip install "git+https://github.com/saforem2/ezpz"
     ```
 
-1. 🚀 **Launch** python  **_from_** python using `ezpz-launch` (see [**Launch**](https://saforem2.github.io/ezpz/launch/)).
+1. \[🚀 **Launch**\] python  **_from_** python using `ezpz-launch` (see [**Launch**](https://saforem2.github.io/ezpz/launch/)).
 
-    Examples, launching:
+    ```bash
+    # arbitrary python string, for example
+    ezpz-launch -c "'import ezpz; ezpz.setup_torch()'"
+    ```
+
+    <details closed><summary>Examples, launching:</summary>
 
     - _Any_ `*.py` module ([`ezpz/test_dist.py`](https://github.com/saforem2/ezpz/blob/main/src/ezpz/test_dist.py), in this example):
 


### PR DESCRIPTION
## Copilot Summary

This pull request updates the links in the `README.md` file to point to the new hosted documentation for the `ezpz` project. These changes ensure that users are directed to the correct and more accessible documentation URLs.

Documentation updates:

* Updated the "Setup environment" link to point to the hosted documentation at `https://saforem2.github.io/ezpz/shell-environment/` instead of the local `./shell-environment.md` file. (`README.md`, [README.mdL11-R12](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R12))
* Updated the "Install ezpz" link to point to `https://saforem2.github.io/ezpz/Code-Reference/` instead of the local `./Code-Reference/init-reference.md` file. (`README.md`, [README.mdL23-R30](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R30))
* Updated the "Launch" link to point to `https://saforem2.github.io/ezpz/launch/` instead of the local `./launch.md` file. (`README.md`, [README.mdL23-R30](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R30))

## Summary by Sourcery

Update the README to point to the hosted ezpz documentation and add a Hands On section with external talk resources

Documentation:
- Update "Setup environment" link to the hosted shell environment documentation
- Update "Install ezpz" link to the hosted Python API reference
- Update "Launch" link to the hosted launch documentation
- Add a "Hands On" section linking to the LLMs on Aurora talk slides and video