### PR TITLE
feat: Use `uv` for venvs in `bin/utils.sh`

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -618,13 +618,9 @@ ezpz_setup_uv_venv() {
     VENV_DIR="${WORKING_DIR}/venvs/$(ezpz_get_machine_name)/${env_name}"
     fpactivate="${VENV_DIR}/bin/activate"
     mn=$(ezpz_get_machine_name)
-    if [[ -f "${fpactivate}" ]]; then
-        log_message INFO "  - Found ${fpactivate}"
-        # shellcheck disable=SC1090
-        [ -f "${fpactivate}" ] && source "${fpactivate}"
-    else
-        uv venv --python="$(which python3)" --system-site-packages "${VENV_DIR}"
-    fi
+    [ ! -f "${fpactivate}" ] && log_message INFO "  - Creating venv in ${VENV_DIR} on ${mn}..." && uv venv --python="$(which python3)" --system-site-packages "${VENV_DIR}"
+    # shellcheck disable=SC1090
+    [ -f "${fpactivate}" ] && log_message INFO "  - Activating: ${fpactivate}" && source "${fpactivate}"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Copilot Summary

## Summary by Sourcery

Use uv venv for creating and activating Python virtual environments in bin/utils.sh, replacing the previous custom logic

New Features:
- Integrate uv venv to create Python virtual environments with system site packages

Enhancements:
- Simplify the conditional flow for virtualenv creation and activation
- Add informative log messages for venv creation and activation steps