### PR TITLE
fix: Fix imports on Polaris

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -13,8 +13,8 @@ import socket
 
 if socket.gethostname().startswith("x3"):
     # NOTE: Need to swap import order on Polaris (hostname: [x3...])
-    import torch  # type:ignore
     from mpi4py import MPI  # type:ignore  # noqa: F401
+    import torch  # type:ignore
 else:
     import torch
     from mpi4py import MPI


### PR DESCRIPTION
## Copilot Summary

This pull request includes a minor change to the `src/ezpz/__init__.py` file. The change adjusts the import order of `torch` and `mpi4py` for compatibility with systems where the hostname starts with "x3".

## Summary by Sourcery

Bug Fixes:
- Swap the import order of torch and mpi4py on hostnames starting with "x3" to resolve compatibility issues on Polaris