### PR TITLE
feat: Pass `allow_val_change` through to `wandb.init(...)`

### DIFF
--- a/src/ezpz/dist.py
+++ b/src/ezpz/dist.py
@@ -1587,6 +1587,7 @@ def setup_wandb(
     start_method: str = "thread",
     outdir: Optional[str | Path | os.PathLike] = None,
     init_timeout: int = 300,
+    allow_val_change: bool = False,
 ):
     """Setup wandb for logging.
 
@@ -1597,6 +1598,7 @@ def setup_wandb(
         start_method (str, optional): The start method for wandb. Defaults to "thread".
         outdir (str | Path | os.PathLike, optional): The output directory. Defaults to None.
         init_timeout (int, optional): The timeout for wandb initialization. Defaults to 300.
+        allow_val_change (bool, optional): Whether to allow value changes in wandb config. Defaults to False.
 
     Example:
         >>> setup_wandb(project_name="my_project", entity="my_entity")
@@ -1666,9 +1668,10 @@ def setup_wandb(
         sync_tensorboard=(tensorboard_dir is not None),  # True,
         project=(project_name if project_name is not None else None),
         # dir=(tensorboard_dir if tensorboard_dir is not None else None),
-        settings=wandb.Settings(
-            start_method=start_method, init_timeout=init_timeout
-        ),
+        # settings=wandb.Settings(
+        #     start_method=start_method, init_timeout=init_timeout
+        # ),
+        allow_val_change=allow_val_change,
     )
     assert run is not None and run is wandb.run
     # run.log_code(HERE.as_posix(), include_fn=include_file)


### PR DESCRIPTION
## Copilot Summary

This pull request introduces a new parameter, `allow_val_change`, to the `setup_wandb` function in `src/ezpz/dist.py`, allowing users to control whether value changes are permitted in the wandb configuration. It also comments out the `settings` parameter configuration for `wandb.Settings`.

### Changes to `setup_wandb` function:

* **New parameter addition**:
  - Added `allow_val_change` as an optional boolean parameter to the `setup_wandb` function, with a default value of `False`. This parameter determines whether value changes in the wandb configuration are allowed. [[1]](diffhunk://#diff-684e0cdce62a75455cca73584add1741af0d1207664ed57c1e7937663c8aaa08R1590) [[2]](diffhunk://#diff-684e0cdce62a75455cca73584add1741af0d1207664ed57c1e7937663c8aaa08R1601)

* **Modification of wandb initialization**:
  - Commented out the `settings` parameter for `wandb.Settings` (which included `start_method` and `init_timeout`) and replaced it with the `allow_val_change` parameter.

## Summary by Sourcery

Add an allow_val_change option to setup_wandb to control wandb configuration value updates and propagate it through while removing the custom wandb.Settings block.

New Features:
- Add allow_val_change optional parameter to setup_wandb and pass it to wandb.init.

Enhancements:
- Comment out the custom wandb.Settings configuration (start_method and init_timeout).