### PR TITLE
feat: Add CPU bindings for {Aurora,Sunspot}

### DIFF
--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -177,21 +177,28 @@ def get_pbs_launch_cmd(
             f"--hostfile={hfp.as_posix()}",
         ]
         machine_name = ezpz.get_machine()
-        if machine_name.lower() in {"aurora", "sunspot"}:
-            CPU_BIND_INTEL_XPU: str = "list:2-4:10-12:18-20:26-28:34-36:42-44:54-56:62-64:70-72:78-80:86-88:94-96"
-            cmd_list.extend(
-                [
-                    "--no-vni",
-                    f"--cpu-bind=verbose,{CPU_BIND_INTEL_XPU}",
-                ]
+        cpu_bind = os.environ.get("CPU_BIND", None)
+        if cpu_bind is not None:
+            logger.warning(f"Detected CPU_BIND from environment: {cpu_bind}")
+            cmd_list.append(
+                f"--cpu-bind=verbose,{cpu_bind.replace('--cpu-bind=', '')}"
             )
         else:
-            cmd_list.extend(
-                [
-                    "--cpu-bind=depth",
-                    "--depth=8",
-                ]
-            )
+            if machine_name.lower() in {"aurora", "sunspot"}:
+                CPU_BIND_INTEL_XPU: str = "list:2-4:10-12:18-20:26-28:34-36:42-44:54-56:62-64:70-72:78-80:86-88:94-96"
+                cmd_list.extend(
+                    [
+                        "--no-vni",
+                        f"--cpu-bind=verbose,{CPU_BIND_INTEL_XPU}",
+                    ]
+                )
+            else:
+                cmd_list.extend(
+                    [
+                        "--cpu-bind=depth",
+                        "--depth=8",
+                    ]
+                )
 
     return " ".join(cmd_list)
 


### PR DESCRIPTION
## Copilot Summary

This pull request adds logic to the `get_pbs_launch_cmd` function in `src/ezpz/pbs.py` to support reading the `CPU_BIND` environment variable and adjusting the launch command accordingly. If `CPU_BIND` is set, it is used in the command and a warning is logged; otherwise, the default binding for certain machines is applied.

Enhancements for CPU binding configuration:

* [`src/ezpz/pbs.py`](diffhunk://#diff-9c94f2a0e3df08b2d02683d3353233f9459a41d06c612d99bc561f22c1accbbfR180-R186): Added support for detecting the `CPU_BIND` environment variable, logging its presence, and appending it to the PBS launch command. If not set, the function retains its existing logic for machine-specific defaults.

## Summary by Sourcery

Add support for an environment variable override for CPU binding in the PBS launch command, logging its usage and preserving existing machine-specific defaults when unset

Enhancements:
- Read CPU_BIND from the environment to override hardcoded CPU binding and emit a warning
- Retain legacy CPU binding logic for Aurora, Sunspot, and default depth-based binding when CPU_BIND is not set