### PR TITLE
fix: `ezpz/bin/utils.sh`

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -2735,7 +2735,7 @@ ezpz_check_working_dir() {
 # Call utils_main when the script is sourced to set WORKING_DIR.
 # If it fails, print an error but allow sourcing to continue (individual functions might still work).
 if ! ezpz_check_working_dir; then
-  log_mesasge ERROR "Failed to set WORKING_DIR. Please check your environment."
+  log_message ERROR "Failed to set WORKING_DIR. Please check your environment."
 fi
 
 # If DEBUG mode was enabled, turn off command tracing now that setup is done.


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Corrected the misspelled log_message function call (from log_mesasge to log_message) in ezpz_check_working_dir error handler