### PR TITLE
Potential fix for code scanning alert no. 2: Binding a socket to all network interfaces

### DIFF
--- a/src/ezpz/dist.py
+++ b/src/ezpz/dist.py
@@ -222,7 +222,7 @@ def get_free_port() -> int:
     import socket
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/saforem2/ezpz/security/code-scanning/2](https://github.com/saforem2/ezpz/security/code-scanning/2)

In general, to avoid binding to all interfaces when only local access is intended, bind sockets explicitly to the loopback interface (`"127.0.0.1"` for IPv4) rather than `""` or `"0.0.0.0"`. When the socket is only used to query the OS for a free port, there is no need to make it reachable from other hosts.

The best minimal fix here is to modify `get_free_port` so that it binds to `"127.0.0.1"` instead of `""`, leaving all other logic intact. This maintains its purpose—asking the OS to choose an available port—while guaranteeing that the ephemeral socket used for querying is only bound on localhost and eliminating the CodeQL warning. No additional imports or helper methods are needed, and no callers need to change because the function signature and return type stay the same.

Concretely, in `src/ezpz/dist.py`, within `get_free_port`, replace the line `s.bind(("", 0))` with `s.bind(("127.0.0.1", 0))`. The rest of the function, including `getsockname()[1]`, remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Restrict get_free_port socket binding to 127.0.0.1 instead of all interfaces to avoid exposing the temporary listening socket.