### PR TITLE
fix(launch): Remove output filtering, add --line-buffer to mpiexec

### DIFF
--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -274,7 +274,7 @@ def build_launch_parser(
         "--filter",
         type=str,
         nargs="+",
-        help="Filter output lines by these strings.",
+        help="Deprecated: output filtering has been removed. This flag is ignored.",
     )
     parser.add_argument(
         "-n",

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -482,13 +482,10 @@ def launch(
     logger.info("Executing:\n" + "\n  ".join([f"{i}" for i in cmd_list]))
     t0 = time.perf_counter()
 
-    filters = [] if filters is None else filters
-    if ezpz.get_machine().lower() in {"aurora", "sunspot"}:
-        filters += get_aurora_filters()
-
     logger.info(f"Execution started @ {ezpz.get_timestamp()}...")
     cmd_start = time.perf_counter()
-    retcode = run_command(command=cmd, filters=filters)
+    proc = subprocess.run(cmd, check=False)
+    retcode = proc.returncode
     cmd_finish = time.perf_counter()
     _log_json_log_file(logger)
     logger.info(f"----[🍋 ezpz.launch][stop][{ezpz.get_timestamp()}]----")
@@ -576,9 +573,6 @@ def run(argv: Sequence[str] | None = None) -> int:
     fallback_cmd.extend(_cpu_bind_launcher_args(selected_cpu_bind))
     fallback_cmd.extend(getattr(args, "launcher_args", []))
     fallback_cmd.extend(command_parts)
-    filters = getattr(args, "filter", [])
-    if ezpz.get_machine().lower() in {"aurora", "sunspot"}:
-        filters += get_aurora_filters()
 
     print("\n") if ezpz.get_rank() == 0 else None
     logger.info(f"----[🍋 ezpz.launch][started][{ezpz.get_timestamp()}]----")
@@ -589,11 +583,8 @@ def run(argv: Sequence[str] | None = None) -> int:
     )
     logger.info(f"Execution started @ {ezpz.get_timestamp()}...")
     cmd_start = time.perf_counter()
-    if filters:
-        retcode = run_command(command=fallback_cmd, filters=filters)
-    else:
-        proc = subprocess.run(fallback_cmd, check=False)
-        retcode = proc.returncode
+    proc = subprocess.run(fallback_cmd, check=False)
+    retcode = proc.returncode
     cmd_finish = time.perf_counter()
     _log_json_log_file(logger)
     logger.info(f"----[🍋 ezpz.launch][stop][{ezpz.get_timestamp()}]----")

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -482,6 +482,7 @@ def launch(
     logger.info("Executing:\n" + "\n  ".join([f"{i}" for i in cmd_list]))
     t0 = time.perf_counter()
 
+    os.environ["EZPZ_RUN_COMMAND"] = str(cmd)
     logger.info(f"Execution started @ {ezpz.get_timestamp()}...")
     cmd_start = time.perf_counter()
     proc = subprocess.run(cmd, check=False)
@@ -581,6 +582,7 @@ def run(argv: Sequence[str] | None = None) -> int:
         "No active scheduler detected; falling back to local mpirun: %s",
         " ".join(shlex.quote(part) for part in fallback_cmd),
     )
+    os.environ["EZPZ_RUN_COMMAND"] = " ".join(fallback_cmd)
     logger.info(f"Execution started @ {ezpz.get_timestamp()}...")
     cmd_start = time.perf_counter()
     proc = subprocess.run(fallback_cmd, check=False)

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -350,6 +350,7 @@ def get_pbs_launch_cmd(
     cmd_list = [
         "mpiexec",
         "--envall",
+        "--line-buffer",
         f"--np={ngpus}",
         f"--ppn={ngpu_per_host}",
         f"--hostfile={hostfile_str}",

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -44,7 +44,7 @@ def test_get_pbs_launch_cmd_defaults_full_machine(patch_topology, monkeypatch):
 
     assert (
         cmd
-        == f"mpiexec --envall --np=16 --ppn=4 --hostfile={hostfile} --cpu-bind=depth --depth=8"
+        == f"mpiexec --envall --line-buffer --np=16 --ppn=4 --hostfile={hostfile} --cpu-bind=depth --depth=8"
     )
 
 


### PR DESCRIPTION
## Summary

The Aurora log filters were silently dropping training output by piping stdout through a substring-match filter. Any line containing a filter string (e.g. "AttributeError", "registered at") was swallowed — including real training logs from torchtitan and other frameworks.

- **Remove all output filtering** from both launch paths (PBS and fallback). Use `subprocess.run` directly so output flows to the terminal and PBS output file unfiltered.
- **Add `--line-buffer`** to `mpiexec` on PBS systems so output appears immediately instead of being buffered until the process exits.

## Test plan

- [x] 532 tests pass
- [ ] Verify on Aurora that training output is visible in PBS output file
- [ ] Verify `--line-buffer` produces real-time output on Polaris/Aurora

## Summary by Sourcery

Remove log output filtering from ezpz launch paths and enable line-buffered MPI output on PBS systems.

New Features:
- Enable line-buffered output for mpiexec on PBS-based launches via the --line-buffer flag.

Bug Fixes:
- Ensure training and runtime logs are no longer silently dropped by removing stdout filtering from both PBS and fallback launch paths.

Tests:
- Update PBS launch command tests to expect the new --line-buffer mpiexec flag.