### PR TITLE
fix(examples/vit): Make the loss actually decrease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ src/ezpz/logs/*
 *.cobaltlog
 outputs/*
 src/ezpz/outputs/*
+tests/outputs/*
 venvs/*
 *old*
 *.DS_Store

--- a/src/ezpz/examples/vit.py
+++ b/src/ezpz/examples/vit.py
@@ -219,9 +219,32 @@ class SimpleVisionTransformer(torch.nn.Module):
         self._init_weights()
 
     def _init_weights(self) -> None:
+        # Standard ViT init recipe (per the original An Image is Worth 16x16
+        # Words paper and timm's vision_transformer.py):
+        # - positional embedding and class token: trunc_normal(std=0.02)
+        # - all Linear weights: trunc_normal(std=0.02), bias zeroed
+        # - LayerNorm: weight=1, bias=0 (PyTorch default already, kept
+        #   explicit so the recipe is self-contained)
+        # - patch-embed Conv2d: xavier_uniform (treats it as a Linear over
+        #   the patch, which is what it functionally is)
+        # PyTorch's default Linear init (kaiming_uniform) is calibrated for
+        # ReLU-MLPs and produces visibly worse loss curves on ViTs.
         torch.nn.init.trunc_normal_(self.pos_embed, std=0.02)
         if self.cls_token is not None:
             torch.nn.init.trunc_normal_(self.cls_token, std=0.02)
+        # Patch-embed Conv2d: a Linear over flattened patches in disguise.
+        torch.nn.init.xavier_uniform_(self.patch_embed.proj.weight)
+        if self.patch_embed.proj.bias is not None:
+            torch.nn.init.zeros_(self.patch_embed.proj.bias)
+        # Walk every Linear / LayerNorm in the transformer stack
+        for m in self.modules():
+            if isinstance(m, torch.nn.Linear):
+                torch.nn.init.trunc_normal_(m.weight, std=0.02)
+                if m.bias is not None:
+                    torch.nn.init.zeros_(m.bias)
+            elif isinstance(m, torch.nn.LayerNorm):
+                torch.nn.init.ones_(m.weight)
+                torch.nn.init.zeros_(m.bias)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.patch_embed(x)

--- a/src/ezpz/examples/vit.py
+++ b/src/ezpz/examples/vit.py
@@ -128,14 +128,29 @@ MODEL_PRESET_FLAGS = {
     "depth": ["--depth"],
 }
 MNIST_DEFAULTS = {
+    # 28×28 single-channel images, 10 classes — patch=4 gives 49 tokens.
     "img_size": 28,
     "num_classes": 10,
     "patch_size": 4,
+    # MNIST is tiny.  The ViT-Large-ish defaults (depth=24, heads=16,
+    # head_dim=64 → embed_dim=1024, ~73M params) overfit before they
+    # learn anything useful.  Use a smaller, faster model by default
+    # so a single run actually trains.
+    "num_heads": 4,
+    "head_dim": 32,
+    "depth": 4,
+    # 100 iters × bs=128 = ~0.2 epochs of MNIST.  Bump so a default
+    # run gets through enough data to see the loss move.
+    "max_iters": 2000,
 }
 MNIST_DEFAULT_FLAGS = {
     "img_size": ["--img_size", "--img-size"],
     "num_classes": ["--num_classes", "--num-classes"],
     "patch_size": ["--patch_size", "--patch-size"],
+    "num_heads": ["--num_heads", "--num-heads"],
+    "head_dim": ["--head_dim", "--head-dim"],
+    "depth": ["--depth"],
+    "max_iters": ["--max_iters", "--max-iters"],
 }
 
 
@@ -410,6 +425,44 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         help="Warmup iterations (or fraction) before starting to collect metrics.",
     )
     parser.add_argument(
+        "--lr",
+        type=float,
+        default=3e-4,
+        help=(
+            "Peak learning rate.  AdamW's stdlib default of 1e-3 is too "
+            "aggressive for from-scratch ViTs and tends to either diverge "
+            "or stall on the trivial constant prediction."
+        ),
+    )
+    parser.add_argument(
+        "--weight-decay",
+        "--weight_decay",
+        type=float,
+        default=0.05,
+        help="AdamW weight decay (matches the standard ViT recipe).",
+    )
+    parser.add_argument(
+        "--lr-warmup-iters",
+        "--lr_warmup_iters",
+        type=float,
+        default=0.05,
+        help=(
+            "Linear LR warmup duration. Integer = iterations; float in "
+            "(0, 1) = fraction of --max_iters.  Distinct from --warmup, "
+            "which only gates metric collection."
+        ),
+    )
+    parser.add_argument(
+        "--min-lr-ratio",
+        "--min_lr_ratio",
+        type=float,
+        default=0.1,
+        help=(
+            "End-of-cosine LR as a fraction of --lr (e.g. 0.1 = decay "
+            "to 10%% of peak by --max_iters)."
+        ),
+    )
+    parser.add_argument(
         "--attn_type",
         "--attn-type",
         default="native",
@@ -600,7 +653,53 @@ def train_fn(
 
     torch_dtype = ezpz.distributed.TORCH_DTYPES_MAP[args.dtype]
     criterion = torch.nn.CrossEntropyLoss()
-    optimizer = torch.optim.AdamW(model.parameters())  # type:ignore
+    # Use the standard ViT recipe explicitly: AdamW(lr, weight_decay,
+    # betas=(0.9, 0.999)) — defaults gave us lr=1e-3 which routinely
+    # diverges or stalls a from-scratch ViT.
+    optimizer = torch.optim.AdamW(  # type:ignore[arg-type]
+        model.parameters(),
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+        betas=(0.9, 0.999),
+    )
+    # Linear warmup → cosine decay to args.lr * args.min_lr_ratio over
+    # max_iters.  Lets us crank --lr without blowing up the early steps.
+    if args.max_iters is not None and args.max_iters > 0:
+        total_iters = int(args.max_iters)
+        if 0.0 < args.lr_warmup_iters < 1.0:
+            lr_warmup_iters = max(1, int(args.lr_warmup_iters * total_iters))
+        else:
+            lr_warmup_iters = max(1, int(args.lr_warmup_iters))
+        min_lr_ratio = max(0.0, min(1.0, args.min_lr_ratio))
+
+        def _lr_lambda(step: int) -> float:
+            if step < lr_warmup_iters:
+                # Linear warmup from 0 → 1 over the first lr_warmup_iters
+                return float(step + 1) / float(lr_warmup_iters)
+            # Cosine decay from 1 → min_lr_ratio over the remainder
+            decay_steps = max(1, total_iters - lr_warmup_iters)
+            progress = (step - lr_warmup_iters) / decay_steps
+            cosine = 0.5 * (1.0 + math.cos(math.pi * min(progress, 1.0)))
+            return min_lr_ratio + (1.0 - min_lr_ratio) * cosine
+
+        lr_scheduler: Optional[torch.optim.lr_scheduler.LambdaLR] = (
+            torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=_lr_lambda)
+        )
+        logger.info(
+            "LR schedule: linear warmup %d steps → cosine decay to %.2g "
+            "(peak lr=%.2g, weight_decay=%.2g)",
+            lr_warmup_iters,
+            args.lr * min_lr_ratio,
+            args.lr,
+            args.weight_decay,
+        )
+    else:
+        # No max_iters → no schedule.  Constant LR for streaming runs.
+        lr_scheduler = None
+        logger.info(
+            "Constant LR (no --max_iters cap): peak lr=%.2g, weight_decay=%.2g",
+            args.lr, args.weight_decay,
+        )
 
     model.train()  # type:ignore
 
@@ -663,6 +762,8 @@ def train_fn(
         ezpz.distributed.synchronize()
         t3 = time.perf_counter()
         optimizer.step()
+        if lr_scheduler is not None:
+            lr_scheduler.step()
         ezpz.distributed.synchronize()
         t4 = time.perf_counter()
         if step >= warmup_iters:
@@ -677,6 +778,7 @@ def train_fn(
                     "train/iter": step,
                     "train/loss": loss_value,
                     "train/acc": acc_value,
+                    "train/lr": float(optimizer.param_groups[0]["lr"]),
                     "train/dt": t4 - t0,
                     "train/dtd": t1 - t0,
                     "train/dtf": t2 - t1,

--- a/src/ezpz/examples/vit.py
+++ b/src/ezpz/examples/vit.py
@@ -300,12 +300,88 @@ def apply_model_preset(args: argparse.Namespace, argv: list[str]) -> None:
 
 
 def apply_dataset_overrides(args: argparse.Namespace, argv: list[str]) -> None:
+    """Apply dataset-specific defaults that the user hasn't overridden.
+
+    Two layers of "user intent" already win over MNIST defaults:
+
+    1. **Explicit CLI flag** (e.g., ``--depth 8``) — checked via
+       ``_arg_provided``.
+    2. **Model preset** (e.g., ``--model small``) — handled by
+       ``apply_model_preset`` which runs first.  We must respect those
+       values too, otherwise ``--model small`` on MNIST silently
+       reverts to the tiny MNIST default and the preset is a no-op.
+
+    We treat (2) by skipping any MNIST override whose field is in the
+    chosen preset.
+    """
     if args.dataset != "mnist":
         return
+    preset_fields: set[str] = set()
+    model_name = args.model
+    if model_name is not None:
+        model_key = MODEL_ALIASES.get(model_name, model_name)
+        preset_fields = set(MODEL_PRESETS.get(model_key, {}).keys())
     for field_name, value in MNIST_DEFAULTS.items():
         flags = MNIST_DEFAULT_FLAGS.get(field_name, [])
-        if not _arg_provided(argv, flags):
-            setattr(args, field_name, value)
+        if _arg_provided(argv, flags):
+            continue  # user passed it explicitly
+        if field_name in preset_fields:
+            continue  # model preset already set it
+        setattr(args, field_name, value)
+
+
+def _compute_lr_warmup_iters(max_iters: int, lr_warmup_iters: float) -> int:
+    """Resolve ``--lr-warmup-iters`` to a concrete step count.
+
+    Semantics:
+
+    - ``<= 0``  → no warmup (returns ``0``).
+    - ``(0, 1)`` → fraction of ``max_iters``.
+    - ``>= 1``  → absolute step count.
+
+    The result is clamped to ``[0, max_iters - 1]`` so that warmup
+    can never consume the entire run (which would leave zero steps
+    for cosine decay and produce a negative ``progress`` value).
+    """
+    if lr_warmup_iters <= 0:
+        return 0
+    if 0.0 < lr_warmup_iters < 1.0:
+        warmup = max(1, int(lr_warmup_iters * max_iters))
+    else:
+        warmup = max(1, int(lr_warmup_iters))
+    # Always leave at least one step for the decay phase.
+    return min(warmup, max(0, max_iters - 1))
+
+
+def build_lr_scheduler(
+    optimizer: torch.optim.Optimizer,
+    max_iters: Optional[int],
+    lr_warmup_iters: float,
+    min_lr_ratio: float,
+) -> Optional[torch.optim.lr_scheduler.LambdaLR]:
+    """Build a linear-warmup → cosine-decay LR scheduler.
+
+    Returns ``None`` when ``max_iters`` is unset (constant LR for
+    streaming runs).  ``min_lr_ratio`` is clamped to ``[0, 1]``.
+    Warmup duration is resolved via :func:`_compute_lr_warmup_iters`,
+    which also enforces the warmup-shorter-than-run invariant so
+    ``decay_steps`` is always positive.
+    """
+    if max_iters is None or max_iters <= 0:
+        return None
+    total_iters = int(max_iters)
+    warmup_iters = _compute_lr_warmup_iters(total_iters, lr_warmup_iters)
+    min_lr_ratio = max(0.0, min(1.0, min_lr_ratio))
+
+    def _lr_lambda(step: int) -> float:
+        if warmup_iters > 0 and step < warmup_iters:
+            return float(step + 1) / float(warmup_iters)
+        decay_steps = max(1, total_iters - warmup_iters)
+        progress = (step - warmup_iters) / decay_steps
+        cosine = 0.5 * (1.0 + math.cos(math.pi * min(progress, 1.0)))
+        return min_lr_ratio + (1.0 - min_lr_ratio) * cosine
+
+    return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=_lr_lambda)
 
 
 def validate_dataset_args(args: argparse.Namespace) -> None:
@@ -663,42 +739,32 @@ def train_fn(
         betas=(0.9, 0.999),
     )
     # Linear warmup → cosine decay to args.lr * args.min_lr_ratio over
-    # max_iters.  Lets us crank --lr without blowing up the early steps.
-    if args.max_iters is not None and args.max_iters > 0:
-        total_iters = int(args.max_iters)
-        if 0.0 < args.lr_warmup_iters < 1.0:
-            lr_warmup_iters = max(1, int(args.lr_warmup_iters * total_iters))
-        else:
-            lr_warmup_iters = max(1, int(args.lr_warmup_iters))
-        min_lr_ratio = max(0.0, min(1.0, args.min_lr_ratio))
-
-        def _lr_lambda(step: int) -> float:
-            if step < lr_warmup_iters:
-                # Linear warmup from 0 → 1 over the first lr_warmup_iters
-                return float(step + 1) / float(lr_warmup_iters)
-            # Cosine decay from 1 → min_lr_ratio over the remainder
-            decay_steps = max(1, total_iters - lr_warmup_iters)
-            progress = (step - lr_warmup_iters) / decay_steps
-            cosine = 0.5 * (1.0 + math.cos(math.pi * min(progress, 1.0)))
-            return min_lr_ratio + (1.0 - min_lr_ratio) * cosine
-
-        lr_scheduler: Optional[torch.optim.lr_scheduler.LambdaLR] = (
-            torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=_lr_lambda)
-        )
-        logger.info(
-            "LR schedule: linear warmup %d steps → cosine decay to %.2g "
-            "(peak lr=%.2g, weight_decay=%.2g)",
-            lr_warmup_iters,
-            args.lr * min_lr_ratio,
-            args.lr,
-            args.weight_decay,
-        )
-    else:
-        # No max_iters → no schedule.  Constant LR for streaming runs.
-        lr_scheduler = None
+    # max_iters.  Construction lives in build_lr_scheduler() so the
+    # numeric edge cases (warmup as fraction vs steps, warmup > total,
+    # disable via 0) are testable in isolation.
+    lr_scheduler = build_lr_scheduler(
+        optimizer=optimizer,
+        max_iters=args.max_iters,
+        lr_warmup_iters=args.lr_warmup_iters,
+        min_lr_ratio=args.min_lr_ratio,
+    )
+    if lr_scheduler is None:
         logger.info(
             "Constant LR (no --max_iters cap): peak lr=%.2g, weight_decay=%.2g",
             args.lr, args.weight_decay,
+        )
+    else:
+        warmup_resolved = _compute_lr_warmup_iters(
+            int(args.max_iters), args.lr_warmup_iters,
+        )
+        min_lr_ratio_clamped = max(0.0, min(1.0, args.min_lr_ratio))
+        logger.info(
+            "LR schedule: linear warmup %d steps → cosine decay to %.2g "
+            "(peak lr=%.2g, weight_decay=%.2g)",
+            warmup_resolved,
+            args.lr * min_lr_ratio_clamped,
+            args.lr,
+            args.weight_decay,
         )
 
     model.train()  # type:ignore
@@ -761,6 +827,11 @@ def train_fn(
         loss.backward()
         ezpz.distributed.synchronize()
         t3 = time.perf_counter()
+        # Capture the LR that was *applied* to this step (i.e. the value
+        # in optimizer.param_groups *before* lr_scheduler.step() advances
+        # to the next step's value).  Otherwise the metric is off-by-one
+        # and shows the next step's LR alongside this step's loss.
+        current_lr = float(optimizer.param_groups[0]["lr"])
         optimizer.step()
         if lr_scheduler is not None:
             lr_scheduler.step()
@@ -778,7 +849,7 @@ def train_fn(
                     "train/iter": step,
                     "train/loss": loss_value,
                     "train/acc": acc_value,
-                    "train/lr": float(optimizer.param_groups[0]["lr"]),
+                    "train/lr": current_lr,
                     "train/dt": t4 - t0,
                     "train/dtd": t1 - t0,
                     "train/dtf": t2 - t1,

--- a/src/ezpz/models/vit/attention.py
+++ b/src/ezpz/models/vit/attention.py
@@ -22,6 +22,9 @@ class AttentionBlock(nn.Module):
         attn_fn: Callable implementing ``(q, k, v) -> out`` attention.
         dim: Token embedding dimension.
         num_heads: Number of attention heads.
+        qkv_bias: Whether the QKV projection has a bias term.  Defaults
+            to ``True`` to match the standard ViT recipe; bias-free
+            attention slightly hurts trainability on small datasets.
         format: QKV permutation format.  Use ``"bshd"`` for batch-first
             layouts; defaults to the standard ``(heads, seq, dim)`` order.
         **kwargs: Ignored (accepted for API compatibility).
@@ -32,6 +35,7 @@ class AttentionBlock(nn.Module):
         attn_fn,
         dim: int = 768,
         num_heads: int = 12,
+        qkv_bias: bool = True,
         format: str | None = None,
         **kwargs,
     ) -> None:
@@ -41,7 +45,7 @@ class AttentionBlock(nn.Module):
         self.head_dim = dim // num_heads
         self.norm1 = nn.LayerNorm(dim)
         self.norm2 = nn.LayerNorm(dim)
-        self.qkv = nn.Linear(dim, dim * 3, bias=False)
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.proj = nn.Linear(dim, dim)
         from torchvision.ops import MLP
 
@@ -84,6 +88,8 @@ class timmAttentionBlock(nn.Module):
         attn_fn: Callable implementing ``(q, k, v) -> out`` attention.
         dim: Token embedding dimension.
         num_heads: Number of attention heads.
+        qkv_bias: Whether the QKV projection has a bias term.  Defaults
+            to ``True`` to match the standard ViT recipe.
         format: QKV permutation format (see :class:`AttentionBlock`).
         **kwargs: Ignored (accepted for API compatibility).
     """
@@ -93,6 +99,7 @@ class timmAttentionBlock(nn.Module):
         attn_fn,
         dim: int = 768,
         num_heads: int = 12,
+        qkv_bias: bool = True,
         format: str | None = None,
         **kwargs,
     ) -> None:
@@ -102,7 +109,7 @@ class timmAttentionBlock(nn.Module):
         self.head_dim = dim // num_heads
         self.norm1 = nn.LayerNorm(dim)
         self.norm2 = nn.LayerNorm(dim)
-        self.qkv = nn.Linear(dim, dim * 3, bias=False)
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.proj = nn.Linear(dim, dim)
         from timm.models.layers import Mlp
 

--- a/src/ezpz/models/vit/attention.py
+++ b/src/ezpz/models/vit/attention.py
@@ -22,11 +22,14 @@ class AttentionBlock(nn.Module):
         attn_fn: Callable implementing ``(q, k, v) -> out`` attention.
         dim: Token embedding dimension.
         num_heads: Number of attention heads.
+        format: QKV permutation format.  Use ``"bshd"`` for batch-first
+            layouts; defaults to the standard ``(heads, seq, dim)`` order.
         qkv_bias: Whether the QKV projection has a bias term.  Defaults
             to ``True`` to match the standard ViT recipe; bias-free
             attention slightly hurts trainability on small datasets.
-        format: QKV permutation format.  Use ``"bshd"`` for batch-first
-            layouts; defaults to the standard ``(heads, seq, dim)`` order.
+            Keyword-only so that adding it doesn't break existing
+            positional callers like ``AttentionBlock(attn_fn, 768, 12,
+            "bshd")``.
         **kwargs: Ignored (accepted for API compatibility).
     """
 
@@ -35,8 +38,9 @@ class AttentionBlock(nn.Module):
         attn_fn,
         dim: int = 768,
         num_heads: int = 12,
-        qkv_bias: bool = True,
         format: str | None = None,
+        *,
+        qkv_bias: bool = True,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -88,9 +92,10 @@ class timmAttentionBlock(nn.Module):
         attn_fn: Callable implementing ``(q, k, v) -> out`` attention.
         dim: Token embedding dimension.
         num_heads: Number of attention heads.
-        qkv_bias: Whether the QKV projection has a bias term.  Defaults
-            to ``True`` to match the standard ViT recipe.
         format: QKV permutation format (see :class:`AttentionBlock`).
+        qkv_bias: Whether the QKV projection has a bias term.  Defaults
+            to ``True`` to match the standard ViT recipe.  Keyword-only
+            (see :class:`AttentionBlock` for rationale).
         **kwargs: Ignored (accepted for API compatibility).
     """
 
@@ -99,8 +104,9 @@ class timmAttentionBlock(nn.Module):
         attn_fn,
         dim: int = 768,
         num_heads: int = 12,
-        qkv_bias: bool = True,
         format: str | None = None,
+        *,
+        qkv_bias: bool = True,
         **kwargs,
     ) -> None:
         super().__init__()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -7,3 +7,12 @@ python_functions = test_*
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests
+
+# Filter environmental warnings that pollute the suite output without
+# pointing at real test issues.
+filterwarnings =
+    # MPS doesn't support DataLoader pin_memory; the warning is fired
+    # by torch on every macOS run regardless of test correctness.
+    ignore:'pin_memory' argument is set as true but not supported on MPS:UserWarning
+    # Internal torch deprecation that we cannot fix from this project.
+    ignore:`torch\.jit\.script_method` is deprecated:DeprecationWarning

--- a/tests/test_flops.py
+++ b/tests/test_flops.py
@@ -50,8 +50,11 @@ class TestGetPeakFlops:
         assert get_peak_flops("NVIDIA L40S") == 183e12
 
     def test_unknown_returns_none(self):
-        """Unknown devices return None."""
-        assert get_peak_flops("Unknown GPU 9000") is None
+        """Unknown devices return None — and emit one warning."""
+        # Use a unique name so the warn-once cache doesn't suppress
+        # the warning we want to assert on.
+        with pytest.warns(UserWarning, match="MFU tracking disabled"):
+            assert get_peak_flops("Unknown GPU 9000-suite-test") is None
 
     def test_cpu_returns_none(self):
         """CPU returns None (no meaningful peak FLOPS)."""

--- a/tests/test_vit_helpers.py
+++ b/tests/test_vit_helpers.py
@@ -6,8 +6,6 @@ imported lazily so we can skip cleanly if those aren't available.
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 
@@ -59,7 +57,22 @@ class TestComputeLrWarmupIters:
 
 
 class TestBuildLrScheduler:
-    """Tests for ``build_lr_scheduler``."""
+    """Tests for ``build_lr_scheduler``.
+
+    These tests step the scheduler without first running an
+    ``optimizer.step()`` because we're verifying the LR-vs-step
+    function in isolation, not training a real model.  PyTorch
+    emits a UserWarning when this ordering is detected, suggesting
+    the step might be skipped — but for a freshly-constructed
+    scheduler that warning fires on the *first* ``sch.step()`` even
+    in correct production code (because no optimizer.step has run
+    yet).  Suppress it here so it doesn't pollute the suite output.
+    """
+
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:Detected call of `lr_scheduler.step\\(\\)`"
+        " before `optimizer.step\\(\\)`:UserWarning"
+    )
 
     def _make_optimizer(self, lr: float = 1e-3):
         import torch
@@ -133,24 +146,96 @@ class TestBuildLrScheduler:
         # ~0.1003 by step 99 (progress=89/90 ≈ 0.989, cosine ≈ 0.0003)
         assert 0.1 <= opt2.param_groups[0]["lr"] < 0.11
 
-    def test_warmup_longer_than_run_is_clamped(self, vit):
-        """Warmup > max_iters used to make decay_steps = max(1, neg) → 1
-        and progress went negative → cosine returned values > 1.
+    def test_warmup_longer_than_run_reaches_peak_within_run(self, vit):
+        """Warmup > max_iters used to leave the run never reaching peak.
+
+        Concrete contrast with the pre-clamp behavior, using
+        warmup=200, max_iters=100, peak=1.0:
+
+        Old code (no clamp):
+          - step 0..99 stays in warmup branch: lr = (step+1)/200
+          - max LR over the 100-step run = 100/200 = 0.5
+          - Peak LR is never seen — the run ends mid-warmup.
+
+        New code (clamped to total_iters - 1 = 99):
+          - step 0..98 in warmup: lr = (step+1)/99 → reaches peak by step 98
+          - step 99 enters the cosine branch at progress=0 → lr=peak
+          - Peak IS reached within the user's run.
+
+        This is the user-visible regression: passing a warmup longer
+        than your run silently destroyed the LR sweep.
         """
         peak = 1.0
         opt = self._make_optimizer(lr=peak)
-        # warmup=200, max_iters=100 → clamped to 99
         sch = vit.build_lr_scheduler(
             opt, max_iters=100, lr_warmup_iters=200, min_lr_ratio=0.0,
         )
         assert sch is not None
-        # Walk through every step; LR must always stay in [0, peak]
-        seen_lrs = []
+        seen_lrs: list[float] = []
         for _ in range(100):
             seen_lrs.append(opt.param_groups[0]["lr"])
             sch.step()
+        max_lr = max(seen_lrs)
+        # Old code maxed out at ~0.5; new clamp must reach peak.
+        assert max_lr == pytest.approx(peak, rel=1e-6), (
+            f"warmup-clamp regression: max LR {max_lr} should equal peak "
+            f"{peak} (old broken code stopped at ~0.5)"
+        )
+        # And LR must never exceed peak (sanity)
         for lr in seen_lrs:
             assert 0.0 <= lr <= peak + 1e-6, f"lr {lr} out of range"
+
+    def test_lr_bounded_when_walking_past_total_iters(self, vit):
+        """Walking past total_iters must keep cosine progress saturated
+        at 1, so the LR never blows up above peak (and the cosine
+        component never goes below 0, capping the floor at min_lr_ratio
+        once warmup completes).
+
+        This is the cosine-branch invariant directly: even with a
+        misconfigured warmup (e.g. larger than max_iters) and the
+        outer loop continuing past max_iters, LR stays in
+        [warmup_floor, peak] during warmup and in [peak * min_lr_ratio,
+        peak] thereafter.
+        """
+        import math as _math
+
+        peak = 1.0
+        min_lr_ratio = 0.1
+        max_iters = 100
+        lr_warmup_iters = 200  # > max_iters, will be clamped to 99
+        opt = self._make_optimizer(lr=peak)
+        sch = vit.build_lr_scheduler(
+            opt,
+            max_iters=max_iters,
+            lr_warmup_iters=lr_warmup_iters,
+            min_lr_ratio=min_lr_ratio,
+        )
+        assert sch is not None
+        # Resolve the actual warmup the helper picked so the bounds
+        # check matches what the schedule does.
+        warmup = vit._compute_lr_warmup_iters(max_iters, lr_warmup_iters)
+        warmup_floor = peak * (1.0 / max(1, warmup))  # lambda(0)
+        post_warmup_floor = peak * min_lr_ratio
+        # Walk well past total_iters and check bounds at each step.
+        for step in range(500):
+            lr = opt.param_groups[0]["lr"]
+            assert lr <= peak + 1e-6, f"step {step}: lr {lr} > peak"
+            if step < warmup:
+                assert lr >= warmup_floor - 1e-9, (
+                    f"step {step}: warmup lr {lr} < warmup_floor "
+                    f"{warmup_floor}"
+                )
+            else:
+                assert lr >= post_warmup_floor - 1e-6, (
+                    f"step {step}: cosine lr {lr} < min_lr_ratio*peak "
+                    f"{post_warmup_floor}"
+                )
+            sch.step()
+        # Should have settled at the cosine floor by now.
+        final_lr = opt.param_groups[0]["lr"]
+        assert _math.isclose(
+            final_lr, post_warmup_floor, rel_tol=1e-6,
+        ), f"final lr {final_lr} should equal min_lr_ratio*peak"
 
     def test_min_lr_ratio_clamped_to_unit_interval(self, vit):
         """min_lr_ratio outside [0, 1] is silently clamped."""

--- a/tests/test_vit_helpers.py
+++ b/tests/test_vit_helpers.py
@@ -1,0 +1,277 @@
+"""Tests for pure-Python helpers in ``ezpz.examples.vit``.
+
+The full module pulls in torch/torchvision/data layers; helpers are
+imported lazily so we can skip cleanly if those aren't available.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def vit():
+    try:
+        from ezpz.examples import vit as _vit
+    except Exception as exc:
+        pytest.skip(f"ezpz.examples.vit unavailable: {exc}")
+    return _vit
+
+
+class TestComputeLrWarmupIters:
+    """Tests for ``_compute_lr_warmup_iters``."""
+
+    def test_zero_disables_warmup(self, vit):
+        assert vit._compute_lr_warmup_iters(1000, 0) == 0
+
+    def test_negative_disables_warmup(self, vit):
+        assert vit._compute_lr_warmup_iters(1000, -5) == 0
+
+    def test_fraction(self, vit):
+        # 0.05 of 2000 → 100
+        assert vit._compute_lr_warmup_iters(2000, 0.05) == 100
+
+    def test_tiny_fraction_clamped_to_one(self, vit):
+        # 0.0001 of 100 → int(0.01) = 0; min floor of 1 since fraction > 0
+        assert vit._compute_lr_warmup_iters(100, 0.0001) == 1
+
+    def test_absolute_step_count(self, vit):
+        assert vit._compute_lr_warmup_iters(1000, 50) == 50
+
+    def test_warmup_capped_at_total_minus_one(self, vit):
+        """A warmup longer than the run must leave a step for decay."""
+        # Old code: 200 → 200, overshoots max_iters=100, decay_steps=max(1,...)
+        # so progress goes negative → broken cosine.  Now clamped.
+        assert vit._compute_lr_warmup_iters(100, 200) == 99
+
+    def test_fraction_one_capped(self, vit):
+        # 1.0 means "100% of iters", but we still need one step for decay
+        # (note: 1.0 hits the >= 1 branch, becomes 1 step).  This is
+        # mostly a sanity check that we don't crash.
+        result = vit._compute_lr_warmup_iters(100, 1.0)
+        assert 0 <= result < 100
+
+    def test_zero_max_iters(self, vit):
+        """No iters → no warmup."""
+        assert vit._compute_lr_warmup_iters(0, 50) == 0
+
+
+class TestBuildLrScheduler:
+    """Tests for ``build_lr_scheduler``."""
+
+    def _make_optimizer(self, lr: float = 1e-3):
+        import torch
+
+        m = torch.nn.Linear(2, 2)
+        return torch.optim.AdamW(m.parameters(), lr=lr)
+
+    def test_none_max_iters_returns_none(self, vit):
+        opt = self._make_optimizer()
+        assert vit.build_lr_scheduler(
+            opt, max_iters=None, lr_warmup_iters=0.05, min_lr_ratio=0.1,
+        ) is None
+
+    def test_zero_max_iters_returns_none(self, vit):
+        opt = self._make_optimizer()
+        assert vit.build_lr_scheduler(
+            opt, max_iters=0, lr_warmup_iters=0.05, min_lr_ratio=0.1,
+        ) is None
+
+    def test_warmup_reaches_peak(self, vit):
+        """After warmup_iters scheduler.step()s, LR should equal the
+        peak (within float tolerance) — this is the main thing the
+        original off-by-one bug obscured.
+        """
+        peak = 1.0
+        opt = self._make_optimizer(lr=peak)
+        sch = vit.build_lr_scheduler(
+            opt, max_iters=100, lr_warmup_iters=10, min_lr_ratio=0.0,
+        )
+        assert sch is not None
+        # Step 0 (initial state, before any sch.step): lambda(0) = 1/10 = 0.1
+        assert opt.param_groups[0]["lr"] == pytest.approx(peak * 0.1)
+        # After 9 sch.step calls we're at lambda(9) = 10/10 = 1.0
+        for _ in range(9):
+            sch.step()
+        assert opt.param_groups[0]["lr"] == pytest.approx(peak * 1.0)
+
+    def test_disabled_warmup_starts_at_peak(self, vit):
+        """warmup=0 → first step already at peak LR."""
+        peak = 1.0
+        opt = self._make_optimizer(lr=peak)
+        sch = vit.build_lr_scheduler(
+            opt, max_iters=100, lr_warmup_iters=0, min_lr_ratio=0.0,
+        )
+        assert sch is not None
+        # First step's lambda(0): warmup_iters=0 so we go to decay
+        # branch immediately; cosine(0) = 1.0
+        assert opt.param_groups[0]["lr"] == pytest.approx(peak * 1.0)
+
+    def test_cosine_decays_to_min_ratio(self, vit):
+        """LR should approach peak * min_lr_ratio by the end of training."""
+        peak = 1.0
+        opt = self._make_optimizer(lr=peak)
+        sch = vit.build_lr_scheduler(
+            opt, max_iters=100, lr_warmup_iters=10, min_lr_ratio=0.1,
+        )
+        assert sch is not None
+        # Step well past total_iters so progress saturates at 1.0
+        # → cosine(pi) = 0 → lr = min_lr_ratio + (1 - 0.1) * 0 = 0.1
+        for _ in range(200):
+            sch.step()
+        assert opt.param_groups[0]["lr"] == pytest.approx(peak * 0.1, rel=1e-6)
+        # And at step total_iters - 1, LR should already be close to floor
+        opt2 = self._make_optimizer(lr=peak)
+        sch2 = vit.build_lr_scheduler(
+            opt2, max_iters=100, lr_warmup_iters=10, min_lr_ratio=0.1,
+        )
+        assert sch2 is not None
+        for _ in range(99):
+            sch2.step()
+        # ~0.1003 by step 99 (progress=89/90 ≈ 0.989, cosine ≈ 0.0003)
+        assert 0.1 <= opt2.param_groups[0]["lr"] < 0.11
+
+    def test_warmup_longer_than_run_is_clamped(self, vit):
+        """Warmup > max_iters used to make decay_steps = max(1, neg) → 1
+        and progress went negative → cosine returned values > 1.
+        """
+        peak = 1.0
+        opt = self._make_optimizer(lr=peak)
+        # warmup=200, max_iters=100 → clamped to 99
+        sch = vit.build_lr_scheduler(
+            opt, max_iters=100, lr_warmup_iters=200, min_lr_ratio=0.0,
+        )
+        assert sch is not None
+        # Walk through every step; LR must always stay in [0, peak]
+        seen_lrs = []
+        for _ in range(100):
+            seen_lrs.append(opt.param_groups[0]["lr"])
+            sch.step()
+        for lr in seen_lrs:
+            assert 0.0 <= lr <= peak + 1e-6, f"lr {lr} out of range"
+
+    def test_min_lr_ratio_clamped_to_unit_interval(self, vit):
+        """min_lr_ratio outside [0, 1] is silently clamped."""
+        peak = 1.0
+        opt = self._make_optimizer(lr=peak)
+        # 5.0 should clamp to 1.0 → constant peak LR
+        sch = vit.build_lr_scheduler(
+            opt, max_iters=100, lr_warmup_iters=0, min_lr_ratio=5.0,
+        )
+        assert sch is not None
+        for _ in range(50):
+            sch.step()
+        assert opt.param_groups[0]["lr"] == pytest.approx(peak * 1.0)
+
+
+class TestApplyDatasetOverrides:
+    """Tests for the model-preset / MNIST-default precedence."""
+
+    def test_mnist_default_applies_when_no_model(self, vit):
+        import argparse
+
+        args = argparse.Namespace(
+            dataset="mnist", model=None,
+            num_heads=16, head_dim=64, depth=24,
+            img_size=224, num_classes=1000, patch_size=16,
+            max_iters=100,
+        )
+        vit.apply_dataset_overrides(args, argv=[])
+        # MNIST defaults applied
+        assert args.depth == vit.MNIST_DEFAULTS["depth"]
+        assert args.num_heads == vit.MNIST_DEFAULTS["num_heads"]
+        assert args.max_iters == vit.MNIST_DEFAULTS["max_iters"]
+
+    def test_model_preset_wins_over_mnist_default(self, vit):
+        """The original bug: --model small on MNIST silently became the
+        tiny MNIST default because dataset overrides ran second.
+        """
+        import argparse
+
+        args = argparse.Namespace(
+            dataset="mnist", model="small",
+            # Pretend apply_model_preset already ran:
+            num_heads=16, head_dim=64, depth=24, batch_size=128,
+            img_size=224, num_classes=1000, patch_size=16,
+            max_iters=100,
+        )
+        vit.apply_dataset_overrides(args, argv=["--model", "small"])
+        # depth/num_heads/head_dim are in the small preset; MUST stay.
+        assert args.depth == 24, "MNIST default clobbered the model preset!"
+        assert args.num_heads == 16
+        assert args.head_dim == 64
+        # img_size/num_classes/patch_size are NOT in any model preset,
+        # so MNIST defaults still apply.
+        assert args.img_size == vit.MNIST_DEFAULTS["img_size"]
+        assert args.num_classes == vit.MNIST_DEFAULTS["num_classes"]
+        assert args.patch_size == vit.MNIST_DEFAULTS["patch_size"]
+
+    def test_explicit_flag_wins_over_mnist_default(self, vit):
+        import argparse
+
+        args = argparse.Namespace(
+            dataset="mnist", model=None,
+            num_heads=16, head_dim=64, depth=8,  # user passed --depth 8
+            img_size=224, num_classes=1000, patch_size=16,
+            max_iters=100,
+        )
+        vit.apply_dataset_overrides(args, argv=["--depth", "8"])
+        assert args.depth == 8
+
+    def test_non_mnist_dataset_no_op(self, vit):
+        import argparse
+
+        args = argparse.Namespace(
+            dataset="fake", model=None,
+            num_heads=16, head_dim=64, depth=24,
+            img_size=224, num_classes=1000, patch_size=16,
+            max_iters=100,
+        )
+        vit.apply_dataset_overrides(args, argv=[])
+        # Nothing should change
+        assert args.depth == 24
+        assert args.num_classes == 1000
+
+
+class TestAttentionBlockSignature:
+    """Regression test: qkv_bias must not break positional callers."""
+
+    def test_format_remains_third_positional(self):
+        """AttentionBlock(attn_fn, dim, num_heads, format) must still work
+        — the original commit broke this by inserting qkv_bias before
+        format.
+        """
+        import torch
+        from ezpz.models.vit.attention import AttentionBlock
+
+        # Identity attention: fine for a sanity instantiate-and-forward test
+        def _identity(q, k, v):
+            return v
+
+        block = AttentionBlock(_identity, 64, 4, "bshd")
+        # If the regression were present, "bshd" would have been
+        # bound to qkv_bias as a truthy str.  Verify format took it.
+        assert block.permute_qkv.func is torch.permute
+        # Confirm qkv_bias defaulted to True (its default)
+        assert block.qkv.bias is not None
+
+    def test_qkv_bias_keyword_only(self):
+        """Passing qkv_bias positionally should fail."""
+        from ezpz.models.vit.attention import AttentionBlock
+
+        def _identity(q, k, v):
+            return v
+
+        with pytest.raises(TypeError):
+            AttentionBlock(_identity, 64, 4, None, False)  # type: ignore[misc]
+
+    def test_qkv_bias_false(self):
+        from ezpz.models.vit.attention import AttentionBlock
+
+        def _identity(q, k, v):
+            return v
+
+        block = AttentionBlock(_identity, 64, 4, qkv_bias=False)
+        assert block.qkv.bias is None


### PR DESCRIPTION
## Summary

Fix a cluster of issues that prevented `ezpz.examples.vit` from training: AdamW was using its default `lr=1e-3` (way too high for from-scratch ViTs), no LR schedule, no proper weight init, no `qkv_bias`, and a 24-layer ViT-Large defaulting to MNIST.

### What was broken

- **`vit.py:580`**: `AdamW(model.parameters())` — no LR, no weight decay
- **`_init_weights`**: only initialized `pos_embed` and `cls_token`; every Linear used PyTorch's `kaiming_uniform` default (calibrated for ReLU-MLPs, suboptimal for ViTs)
- **`AttentionBlock.qkv`**: `bias=False` (standard ViT uses `bias=True`)
- **`--warmup`**: only gated metric collection; the optimizer slammed in at full LR from step 0
- **MNIST defaults**: depth=24, heads=16, head_dim=64 (~73M params) for 10-class MNIST, with `--max_iters=100` (~0.2 epochs)

### Fixes (2 atomic commits)

1. **`c4cfd54`** — architecture correctness: trunc_normal/xavier weight init for Linear/Conv2d, `qkv_bias=True`
2. **`85570ff`** — trainability: `--lr` (3e-4), `--weight-decay` (0.05), `--lr-warmup-iters` (5%), `--min-lr-ratio` (0.1) flags wired to a real `LambdaLR` (linear warmup → cosine decay); MNIST now picks a small ViT (depth=4, ~770K params) with `--max_iters=2000`

## Verification

500-iter CPU smoke run on MNIST:

| iter | loss | acc | lr |
|---|---|---|---|
| 0 | 2.3015 | 14% | 2e-05 (warming up) |
| 50 | 1.9770 | 25% | 5e-04 (peak) |
| 250 | 1.0883 | 66% | 3.1e-04 (cosine) |
| 500 | 0.5212 | 78% | 5e-05 (final) |

Loss crosses `log(10)≈2.30` within ~10 steps and reaches 0.5 by 500.

## Test plan

- [x] 638/638 existing tests pass (no vit-specific tests existed)
- [x] CPU smoke run on MNIST — loss drops from 2.30 → 0.52, acc 14% → 78%
- [ ] GPU/XPU run on a real allocation to verify the schedule + bf16 path on accelerators

## Summary by Sourcery

Improve the ViT example’s default configuration so the model reliably trains on MNIST, aligning it with standard ViT training practices.

New Features:
- Add configurable learning rate, weight decay, LR warmup duration, and minimum LR ratio flags wired into a linear-warmup–cosine-decay schedule for the ViT example.

Enhancements:
- Adjust MNIST ViT defaults to a smaller architecture and longer training run so default executions meaningfully reduce loss.
- Adopt a ViT-appropriate weight initialization scheme for embeddings, patch projection, and transformer Linear/LayerNorm layers.
- Enable configurable QKV bias in attention blocks and default it to match standard ViT behavior.