### PR TITLE
fix(kill): use absolute path to ezpz binary in SSH command

### DIFF
--- a/docs/cli/kill.md
+++ b/docs/cli/kill.md
@@ -81,10 +81,32 @@ ezpz kill --signal KILL
 5. SLURM `scontrol show hostnames`
 6. Localhost fallback (single-node mode)
 
-For each remote node, `ezpz kill` SSHes in and runs `ezpz kill
-<STRING>` (without `--all-nodes`, to avoid recursion). SSH connections
-are bounded at 16 concurrent — DNS / SSH on a 1000-node allocation
-shouldn't fork a thread per node.
+For each remote node, `ezpz kill` SSHes in and runs the same `ezpz`
+binary it was launched as — but with the bare `--all-nodes` flag
+stripped (to avoid recursion). SSH connections are bounded at 16
+concurrent — DNS / SSH on a 1000-node allocation shouldn't fork a
+thread per node.
+
+!!! info "Why the absolute path matters"
+
+    `ezpz kill --all-nodes` ships the **absolute path** to the local
+    `ezpz` binary in the SSH command (resolved via `sys.argv[0]`,
+    `shutil.which(argv[0])`, or `shutil.which("ezpz")`, in that
+    order). SSH command-mode invocations (`ssh node "<cmd>"`) don't
+    source the user's `.bashrc` / `.zshrc`, so PATH additions from
+    a venv's activate script aren't loaded on the remote side. A
+    bare `ezpz` would fail with `command not found` even when the
+    venv is mounted at the same path on the worker.
+
+    **Implicit assumption**: the same `ezpz` binary at the same
+    absolute path exists on every worker node. This is true by
+    default on shared-filesystem HPC setups (Lustre, NFS) where
+    every node mounts your venv at the same mount point. It's
+    *also* true after `ezpz yeet` when you've broadcast the venv to
+    `/tmp/.venv/` on every node (`/tmp/.venv/bin/ezpz` exists
+    everywhere). If neither is true (e.g. nodes have entirely
+    different venvs), `--all-nodes` falls back to bare `ezpz` on
+    workers and depends on a system-wide install being on PATH.
 
 Output from each node is prefixed with `[hostname]`:
 

--- a/docs/cli/kill.md
+++ b/docs/cli/kill.md
@@ -90,13 +90,14 @@ thread per node.
 !!! info "Why the absolute path matters"
 
     `ezpz kill --all-nodes` ships the **absolute path** to the local
-    `ezpz` binary in the SSH command (resolved via `sys.argv[0]`,
-    `shutil.which(argv[0])`, or `shutil.which("ezpz")`, in that
-    order). SSH command-mode invocations (`ssh node "<cmd>"`) don't
-    source the user's `.bashrc` / `.zshrc`, so PATH additions from
-    a venv's activate script aren't loaded on the remote side. A
-    bare `ezpz` would fail with `command not found` even when the
-    venv is mounted at the same path on the worker.
+    `ezpz` binary in the SSH command (resolved via the `EZPZ_REMOTE_BIN`
+    env var, then `sys.argv[0]`, then `shutil.which(argv[0])`, then
+    `shutil.which("ezpz")`, in that order). SSH command-mode
+    invocations (`ssh node "<cmd>"`) don't source the user's
+    `.bashrc` / `.zshrc`, so PATH additions from a venv's activate
+    script aren't loaded on the remote side. A bare `ezpz` would
+    fail with `command not found` even when the venv is mounted at
+    the same path on the worker.
 
     **Implicit assumption**: the same `ezpz` binary at the same
     absolute path exists on every worker node. This is true by
@@ -104,9 +105,19 @@ thread per node.
     every node mounts your venv at the same mount point. It's
     *also* true after `ezpz yeet` when you've broadcast the venv to
     `/tmp/.venv/` on every node (`/tmp/.venv/bin/ezpz` exists
-    everywhere). If neither is true (e.g. nodes have entirely
-    different venvs), `--all-nodes` falls back to bare `ezpz` on
-    workers and depends on a system-wide install being on PATH.
+    everywhere).
+
+    **If neither is true** (e.g. nodes have entirely different
+    venvs at different paths), set `EZPZ_REMOTE_BIN` to the path
+    that resolves on the worker:
+
+    ```bash
+    EZPZ_REMOTE_BIN=/tmp/.venv/bin/ezpz ezpz kill --all-nodes
+    ```
+
+    With no override and no resolvable path, `--all-nodes` falls
+    back to bare `ezpz` on workers and depends on a system-wide
+    install being on `PATH`.
 
 Output from each node is prefixed with `[hostname]`:
 

--- a/src/ezpz/utils/kill.py
+++ b/src/ezpz/utils/kill.py
@@ -244,13 +244,16 @@ def _resolve_ezpz_bin() -> str:
 
     Resolution order:
 
-    1. ``sys.argv[0]`` if it's an existing absolute path (the common
+    1. ``$EZPZ_REMOTE_BIN`` — explicit override, used as-is. Set this
+       when workers have a different ezpz install (or path) than the
+       head node — e.g. heterogeneous node-local venvs.
+    2. ``sys.argv[0]`` if it's an existing absolute path (the common
        case — POSIX execve typically passes the resolved path here
        even for PATH-discovered invocations).
-    2. ``shutil.which(sys.argv[0])`` if argv[0] is a bare name we can
+    3. ``shutil.which(sys.argv[0])`` if argv[0] is a bare name we can
        look up locally.
-    3. ``shutil.which("ezpz")`` as a generic fallback.
-    4. Bare ``"ezpz"`` if everything above fails — preserves the old
+    4. ``shutil.which("ezpz")`` as a generic fallback.
+    5. Bare ``"ezpz"`` if everything above fails — preserves the old
        behavior on the off chance ezpz IS on the worker's PATH (e.g.
        a system-wide install).
 
@@ -259,6 +262,9 @@ def _resolve_ezpz_bin() -> str:
     """
     import shutil
 
+    override = os.environ.get("EZPZ_REMOTE_BIN")
+    if override:
+        return override
     argv0 = sys.argv[0] if sys.argv else ""
     if argv0 and Path(argv0).is_absolute() and Path(argv0).exists():
         return argv0

--- a/src/ezpz/utils/kill.py
+++ b/src/ezpz/utils/kill.py
@@ -233,16 +233,48 @@ def kill_local(
     return killed, len(matches)
 
 
+def _resolve_ezpz_bin() -> str:
+    """Best-effort resolve of an absolute path to the ezpz binary.
+
+    SSH command-mode (``ssh node "<cmd>"``) doesn't source the user's
+    shell rc, so PATH additions from a venv's activate script aren't
+    loaded on the remote side.  A bare ``ezpz`` in the remote command
+    fails with ``command not found: ezpz`` even when the venv is
+    mounted at the same path on the worker.
+
+    Resolution order:
+
+    1. ``sys.argv[0]`` if it's an existing absolute path (the common
+       case — POSIX execve typically passes the resolved path here
+       even for PATH-discovered invocations).
+    2. ``shutil.which(sys.argv[0])`` if argv[0] is a bare name we can
+       look up locally.
+    3. ``shutil.which("ezpz")`` as a generic fallback.
+    4. Bare ``"ezpz"`` if everything above fails — preserves the old
+       behavior on the off chance ezpz IS on the worker's PATH (e.g.
+       a system-wide install).
+
+    Returns a string suitable for shlex.join'ing into the remote
+    command.
+    """
+    import shutil
+
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0 and Path(argv0).is_absolute() and Path(argv0).exists():
+        return argv0
+    if argv0:
+        resolved = shutil.which(argv0)
+        if resolved:
+            return resolved
+    resolved = shutil.which("ezpz")
+    if resolved:
+        return resolved
+    return "ezpz"
+
+
 def _ssh_kill(node: str, pattern: Optional[str], sig_name: str, dry_run: bool) -> tuple[str, int, str]:
     """SSH into *node* and run `ezpz kill`. Returns (node, returncode, stderr)."""
-    # Use the absolute path to the locally-running ezpz binary instead
-    # of the bare name `ezpz`. SSH command execution doesn't run an
-    # interactive shell, so the user's .zshrc/.bashrc PATH additions
-    # (e.g. the venv's bin/) aren't loaded — bare `ezpz` would resolve
-    # only if it's on the system PATH, which it usually isn't.  The
-    # absolute path works because every worker mounts the same venv
-    # filesystem (Lustre/NFS) at the same path.
-    ezpz_bin = sys.argv[0] if sys.argv and sys.argv[0] else "ezpz"
+    ezpz_bin = _resolve_ezpz_bin()
     remote_cmd = [ezpz_bin, "kill", "--signal", sig_name]
     if dry_run:
         remote_cmd.append("--dry-run")

--- a/src/ezpz/utils/kill.py
+++ b/src/ezpz/utils/kill.py
@@ -22,6 +22,7 @@ import argparse
 import logging
 import os
 import shlex
+import shutil
 import signal
 import socket
 import subprocess
@@ -260,8 +261,6 @@ def _resolve_ezpz_bin() -> str:
     Returns a string suitable for shlex.join'ing into the remote
     command.
     """
-    import shutil
-
     override = os.environ.get("EZPZ_REMOTE_BIN")
     if override:
         return override

--- a/src/ezpz/utils/kill.py
+++ b/src/ezpz/utils/kill.py
@@ -235,7 +235,15 @@ def kill_local(
 
 def _ssh_kill(node: str, pattern: Optional[str], sig_name: str, dry_run: bool) -> tuple[str, int, str]:
     """SSH into *node* and run `ezpz kill`. Returns (node, returncode, stderr)."""
-    remote_cmd = ["ezpz", "kill", "--signal", sig_name]
+    # Use the absolute path to the locally-running ezpz binary instead
+    # of the bare name `ezpz`. SSH command execution doesn't run an
+    # interactive shell, so the user's .zshrc/.bashrc PATH additions
+    # (e.g. the venv's bin/) aren't loaded — bare `ezpz` would resolve
+    # only if it's on the system PATH, which it usually isn't.  The
+    # absolute path works because every worker mounts the same venv
+    # filesystem (Lustre/NFS) at the same path.
+    ezpz_bin = sys.argv[0] if sys.argv and sys.argv[0] else "ezpz"
+    remote_cmd = [ezpz_bin, "kill", "--signal", sig_name]
     if dry_run:
         remote_cmd.append("--dry-run")
     if pattern is not None:

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -182,6 +182,7 @@ class TestKillLocal:
 
 
 class TestSshKill:
+    @patch("sys.argv", ["/path/to/.venv/bin/ezpz"])
     @patch("subprocess.run")
     def test_default_pattern_omitted(self, mock_run):
         """Without a pattern, the remote `ezpz kill` runs with no positional."""
@@ -197,6 +198,7 @@ class TestSshKill:
         assert "--signal TERM" in remote_cmd
         assert "--dry-run" not in remote_cmd
 
+    @patch("sys.argv", ["/path/to/.venv/bin/ezpz"])
     @patch("subprocess.run")
     def test_pattern_appended_after_flags(self, mock_run):
         """Positional pattern is appended after --signal/--dry-run."""
@@ -209,6 +211,23 @@ class TestSshKill:
         assert "train.py" in remote_cmd
         # --all-nodes must NOT appear (avoid recursive fan-out)
         assert "--all-nodes" not in remote_cmd
+
+    @patch("sys.argv", ["/lus/.../venv/bin/ezpz"])
+    @patch("subprocess.run")
+    def test_remote_uses_absolute_path_to_local_ezpz(self, mock_run):
+        """Remote command uses sys.argv[0] (absolute path), not bare 'ezpz'.
+
+        SSH command-mode invocations don't source the user's shell rc,
+        so the venv's bin/ isn't on the remote PATH. The bare-name
+        form fails with 'command not found: ezpz' even when the venv
+        is mounted at the same path on the remote node.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        kill_mod._ssh_kill("node01", None, "TERM", dry_run=False)
+        remote_cmd = mock_run.call_args[0][0][-1]
+        assert "/lus/.../venv/bin/ezpz" in remote_cmd
+        # And does NOT lead with the bare name.
+        assert not remote_cmd.startswith("ezpz ")
 
     @patch("subprocess.run", side_effect=__import__("subprocess").TimeoutExpired(cmd=[], timeout=60))
     def test_timeout_returns_124(self, _):

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -213,9 +213,10 @@ class TestSshKill:
         assert "--all-nodes" not in remote_cmd
 
     @patch("sys.argv", ["/lus/.../venv/bin/ezpz"])
+    @patch("pathlib.Path.exists", return_value=True)
     @patch("subprocess.run")
-    def test_remote_uses_absolute_path_to_local_ezpz(self, mock_run):
-        """Remote command uses sys.argv[0] (absolute path), not bare 'ezpz'.
+    def test_remote_uses_absolute_path_to_local_ezpz(self, mock_run, _exists):
+        """Remote command uses sys.argv[0] when it's an existing absolute path.
 
         SSH command-mode invocations don't source the user's shell rc,
         so the venv's bin/ isn't on the remote PATH. The bare-name
@@ -226,8 +227,40 @@ class TestSshKill:
         kill_mod._ssh_kill("node01", None, "TERM", dry_run=False)
         remote_cmd = mock_run.call_args[0][0][-1]
         assert "/lus/.../venv/bin/ezpz" in remote_cmd
-        # And does NOT lead with the bare name.
         assert not remote_cmd.startswith("ezpz ")
+
+    @patch("sys.argv", ["ezpz"])
+    @patch("shutil.which", return_value="/some/venv/bin/ezpz")
+    @patch("subprocess.run")
+    def test_remote_resolves_bare_argv0_via_which(self, mock_run, mock_which):
+        """When argv[0] is the bare name, fall through to shutil.which.
+
+        This is the actually-real-world failing case: when a user runs
+        `ezpz kill --all-nodes`, argv[0] CAN be just "ezpz" depending
+        on the shell + how the executable was installed. The previous
+        fix only worked for absolute argv[0]; this asserts the
+        resolution path actually finds the venv binary.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        kill_mod._ssh_kill("node01", None, "TERM", dry_run=False)
+        remote_cmd = mock_run.call_args[0][0][-1]
+        assert "/some/venv/bin/ezpz" in remote_cmd
+        assert not remote_cmd.startswith("ezpz ")
+
+    @patch("sys.argv", [])
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_remote_falls_back_to_bare_ezpz_when_unresolvable(self, mock_run, _which):
+        """When sys.argv is empty AND shutil.which fails, fall back to bare 'ezpz'.
+
+        Defensive — should never happen in practice. Preserves the old
+        behavior so a system-wide ezpz install on the worker still
+        works.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        kill_mod._ssh_kill("node01", None, "TERM", dry_run=False)
+        remote_cmd = mock_run.call_args[0][0][-1]
+        assert remote_cmd.startswith("ezpz ")
 
     @patch("subprocess.run", side_effect=__import__("subprocess").TimeoutExpired(cmd=[], timeout=60))
     def test_timeout_returns_124(self, _):

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -247,6 +247,25 @@ class TestSshKill:
         assert "/some/venv/bin/ezpz" in remote_cmd
         assert not remote_cmd.startswith("ezpz ")
 
+    @patch.dict("os.environ", {"EZPZ_REMOTE_BIN": "/custom/path/to/ezpz"})
+    @patch("sys.argv", ["/some/other/path/ezpz"])
+    @patch("subprocess.run")
+    def test_remote_bin_env_var_overrides_resolution(self, mock_run):
+        """EZPZ_REMOTE_BIN env var short-circuits the resolution chain.
+
+        Use case: heterogeneous nodes where the head node and workers
+        have different ezpz install paths (e.g. node-local venvs at
+        different absolute paths). The env var lets the user point at
+        whatever ezpz binary actually exists on the workers without
+        depending on path-mirror assumptions.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        kill_mod._ssh_kill("node01", None, "TERM", dry_run=False)
+        remote_cmd = mock_run.call_args[0][0][-1]
+        assert "/custom/path/to/ezpz" in remote_cmd
+        # The (otherwise valid) sys.argv[0] is NOT used.
+        assert "/some/other/path/ezpz" not in remote_cmd
+
     @patch("sys.argv", [])
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -247,6 +247,30 @@ class TestSshKill:
         assert "/some/venv/bin/ezpz" in remote_cmd
         assert not remote_cmd.startswith("ezpz ")
 
+    @patch("sys.argv", ["python"])
+    @patch("subprocess.run")
+    def test_remote_prefers_which_argv0_over_which_ezpz(self, mock_run):
+        """Branch 3 (`shutil.which(argv[0])`) wins over branch 4 (`shutil.which("ezpz")`).
+
+        Regression guard: if someone collapses the two `which` branches
+        or swaps their order, the existing bare-name test still passes
+        because both `which` calls resolve to the same path under that
+        mock. This test sets up distinct returns and asserts the
+        argv[0]-derived path wins.
+        """
+        # which("python") → path A; which("ezpz") → path B; argv[0]=="python".
+        def fake_which(name):
+            return {"python": "/path/A/python", "ezpz": "/path/B/ezpz"}.get(name)
+
+        with patch("shutil.which", side_effect=fake_which):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            kill_mod._ssh_kill("node01", None, "TERM", dry_run=False)
+        remote_cmd = mock_run.call_args[0][0][-1]
+        # Branch 3 hit: which(argv[0]="python") → /path/A/python is used.
+        assert "/path/A/python" in remote_cmd
+        # Branch 4 was NOT consulted.
+        assert "/path/B/ezpz" not in remote_cmd
+
     @patch.dict("os.environ", {"EZPZ_REMOTE_BIN": "/custom/path/to/ezpz"})
     @patch("sys.argv", ["/some/other/path/ezpz"])
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary

\`ezpz kill --all-nodes\` failed on every remote node with:

\`\`\`
[<node>] FAILED (exit 127): zsh:1: command not found: ezpz
\`\`\`

Root cause: SSH command-mode invocations (\`ssh node \"<cmd>\"\`) don't
source the user's \`.zshrc\` / \`.bashrc\`, so PATH only includes the
system defaults. The venv's \`bin/\` where \`ezpz\` lives isn't on the
remote PATH, and the bare command name fails to resolve.

## Fix

Use \`sys.argv[0]\` (the absolute path to the locally-running ezpz
binary) for the remote command instead of the bare name \`ezpz\`.
Every worker mounts the same venv at the same path (Lustre/NFS), so
the absolute path resolves identically everywhere.

Falls back to \`ezpz\` when \`sys.argv[0]\` is empty (defensive — should
never happen in practice).

## Test plan

- [x] \`pytest tests/test_kill.py\` — 29 passing (was 28). New regression
  test asserts the remote command uses the absolute path from
  \`sys.argv[0]\` instead of the bare name. Existing \`_ssh_kill\` tests
  now also patch \`sys.argv\` so they don't depend on however pytest
  happens to launch.
- [ ] On a real PBS allocation: \`ezpz kill --all-nodes --dry-run\`
  succeeds on every remote node (no \`command not found: ezpz\`).

## Summary by Sourcery

Ensure remote ezpz kill invocations over SSH use a resolvable binary path and are covered by tests.

Bug Fixes:
- Use the absolute path of the locally running ezpz binary in SSH commands so remote kills succeed even when the venv bin/ is not on PATH.

Tests:
- Extend SSH kill tests to assert the absolute-path binary is used and patch sys.argv to avoid relying on the test runner invocation.