### PR TITLE
fix(typing): add TYPE_CHECKING re-exports + py.typed marker (closes #133)

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from .__about__ import __version__  # re-exported symbol
 
@@ -20,7 +20,102 @@ if socket.getfqdn().startswith("x3"):
     import torch  # noqa
 
 # ---------------------------------------------------------------------------
-# Public re-exports
+# Static re-exports for type checkers and editor tooling
+# ---------------------------------------------------------------------------
+#
+# At runtime, attribute access on `ezpz.foo` flows through `__getattr__`
+# below — it walks `_MODULE_SEARCH_ORDER` to find which submodule
+# defines `foo` and imports lazily.  That preserves the "import ezpz
+# stays fast" property (no eager torch/mpi4py import).
+#
+# But Pyright / Pylance / Jedi / LSP servers can't follow `__getattr__`
+# resolution.  Users reported (issue #133) that `ezpz.setup_torch` and
+# friends don't show up in completion, auto-import, or symbol search —
+# even though they work at runtime.
+#
+# Fix: a `TYPE_CHECKING` block with explicit re-exports.  Type checkers
+# evaluate this branch (TYPE_CHECKING is True at analysis time), so
+# they see real `from .module import name` statements and can resolve
+# everything statically.  At runtime, TYPE_CHECKING is False and the
+# imports are skipped — `__getattr__` still does the lazy work.
+#
+# Standard pattern; same shape pandas/numpy/sqlalchemy use.
+# noqa: F401  — these imports are pure re-exports for static analysis.
+if TYPE_CHECKING:
+    # -- distributed: rank / topology / device / lifecycle / collectives --
+    from .distributed import (  # noqa: F401
+        all_reduce,
+        barrier,
+        broadcast,
+        cleanup,
+        get_cpus_per_node,
+        get_device_properties,
+        get_dist_info,
+        get_gpus_per_node,
+        get_hostname,
+        get_local_rank,
+        get_machine,
+        get_node_index,
+        get_num_nodes,
+        get_rank,
+        get_torch_backend,
+        get_torch_device,
+        get_torch_device_type,
+        get_world_size,
+        get_world_size_in_use,
+        get_world_size_total,
+        log_dict_as_bulleted_list,
+        print_dist_setup,
+        query_environment,
+        seed_everything,
+        setup_mlflow,
+        setup_torch,
+        setup_wandb,
+        synchronize,
+        timeitlogit,
+        verify_wandb,
+        wrap_model,
+        wrap_model_for_ddp,
+        wrap_model_for_fsdp,
+        wrap_model_for_fsdp2,
+    )
+    # -- utils: helpers + memory + tarball plumbing --
+    #
+    # NOTE: the memory-tracking helpers (`get_memory_metrics`,
+    # `get_current_memory_*`, `reset_peak_memory_stats`,
+    # `format_memory_summary`, `is_memory_metric_key`) land in PR #134
+    # — they'll be added to this block by that PR's own merge.
+    from .utils import (  # noqa: F401
+        Color,
+        DistributedPdb,
+        ForkedPdb,
+        NoColor,
+        check_for_tarball,
+        format_pair,
+        get_max_memory_allocated,
+        get_max_memory_reserved,
+        get_timestamp,
+        grab_tensor,
+        make_tarfile,
+        model_summary,
+        summarize_dict,
+    )
+    # -- log: structured logging --
+    from .log import get_logger  # noqa: F401
+    # -- history: distributed metric tracking --
+    from .history import History  # noqa: F401
+    # -- flops: MFU + peak FLOPS database --
+    from .flops import compute_mfu, try_estimate  # noqa: F401
+    # -- configs: scheduler / machine detection --
+    from .configs import get_scheduler  # noqa: F401
+    # -- launch: scheduler-aware launcher --
+    from .launch import (  # noqa: F401
+        get_active_jobid,
+        get_nodelist_of_active_job,
+    )
+
+# ---------------------------------------------------------------------------
+# Lazy module loading (runtime path)
 # ---------------------------------------------------------------------------
 
 _LAZY_MODULES: Dict[str, str] = {
@@ -63,7 +158,46 @@ _MODULE_SEARCH_ORDER: tuple[str, ...] = (
     # "ezpz.test",
 )
 
-__all__ = ["__version__", *sorted(_LAZY_MODULES.keys())]  # type:ignore
+# Symbols re-exported via the TYPE_CHECKING block above.  Listing them
+# in __all__ makes them discoverable to `dir(ezpz)`, `from ezpz import *`,
+# and stub-aware tools.  The runtime resolution is unchanged — these all
+# come from the lazy __getattr__ walker below.
+_STATIC_REEXPORTS: tuple[str, ...] = (
+    # distributed
+    "all_reduce", "barrier", "broadcast", "cleanup",
+    "get_cpus_per_node", "get_device_properties", "get_dist_info",
+    "get_gpus_per_node", "get_hostname", "get_local_rank",
+    "get_machine", "get_node_index", "get_num_nodes", "get_rank",
+    "get_torch_backend", "get_torch_device", "get_torch_device_type",
+    "get_world_size", "get_world_size_in_use", "get_world_size_total",
+    "log_dict_as_bulleted_list", "print_dist_setup", "query_environment",
+    "seed_everything", "setup_mlflow", "setup_torch", "setup_wandb",
+    "synchronize", "timeitlogit", "verify_wandb",
+    "wrap_model", "wrap_model_for_ddp",
+    "wrap_model_for_fsdp", "wrap_model_for_fsdp2",
+    # utils (memory-tracking helpers added by PR #134)
+    "Color", "DistributedPdb", "ForkedPdb", "NoColor",
+    "check_for_tarball", "format_pair",
+    "get_max_memory_allocated", "get_max_memory_reserved",
+    "get_timestamp", "grab_tensor", "make_tarfile",
+    "model_summary", "summarize_dict",
+    # log
+    "get_logger",
+    # history
+    "History",
+    # flops
+    "compute_mfu", "try_estimate",
+    # configs
+    "get_scheduler",
+    # launch
+    "get_active_jobid", "get_nodelist_of_active_job",
+)
+
+__all__ = [
+    "__version__",
+    *sorted(_LAZY_MODULES.keys()),
+    *_STATIC_REEXPORTS,
+]  # type:ignore
 
 _IMPORT_CACHE: Dict[str, ModuleType] = {}
 

--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -197,7 +197,7 @@ __all__ = [
     "__version__",
     *sorted(_LAZY_MODULES.keys()),
     *_STATIC_REEXPORTS,
-]  # type:ignore
+]  # type: ignore
 
 _IMPORT_CACHE: Dict[str, ModuleType] = {}
 

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -1,0 +1,180 @@
+"""Tests for the static re-exports added in fix for issue #133.
+
+The lazy `__getattr__` resolution in `ezpz/__init__.py` keeps `import
+ezpz` fast (no eager torch / mpi4py imports), but type checkers and
+LSP-based editors (Pyright, Pylance, Jedi) can't follow `__getattr__`
+indirection. This module verifies that:
+
+1. Every symbol declared in the `TYPE_CHECKING` re-export block ALSO
+   resolves at runtime via the lazy walker — so the static view and
+   runtime view stay in sync. If someone adds a re-export and the
+   underlying function isn't actually on the named submodule, this
+   test catches it.
+
+2. `__all__` lists every re-export — so `dir(ezpz)` and `from ezpz
+   import *` work.
+
+3. The `py.typed` marker file ships in the package — PEP 561 marker
+   that tells type checkers to use the package's inline types.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import ezpz
+
+
+# Symbols that should be discoverable at the top level. Keep this in
+# sync with the TYPE_CHECKING block in ezpz/__init__.py. Each (name,
+# module) pair: the name as it appears on `ezpz.<name>`, and the
+# submodule it actually lives in (so we can verify both ends).
+EXPECTED_STATIC_REEXPORTS = [
+    # -- distributed --
+    ("setup_torch", "ezpz.distributed"),
+    ("get_rank", "ezpz.distributed"),
+    ("get_local_rank", "ezpz.distributed"),
+    ("get_world_size", "ezpz.distributed"),
+    ("get_torch_device", "ezpz.distributed"),
+    ("get_torch_device_type", "ezpz.distributed"),
+    ("get_torch_backend", "ezpz.distributed"),
+    ("wrap_model", "ezpz.distributed"),
+    ("wrap_model_for_ddp", "ezpz.distributed"),
+    ("wrap_model_for_fsdp", "ezpz.distributed"),
+    ("wrap_model_for_fsdp2", "ezpz.distributed"),
+    ("synchronize", "ezpz.distributed"),
+    ("barrier", "ezpz.distributed"),
+    ("broadcast", "ezpz.distributed"),
+    ("all_reduce", "ezpz.distributed"),
+    ("cleanup", "ezpz.distributed"),
+    ("timeitlogit", "ezpz.distributed"),
+    ("setup_wandb", "ezpz.distributed"),
+    ("setup_mlflow", "ezpz.distributed"),
+    ("get_hostname", "ezpz.distributed"),
+    ("get_device_properties", "ezpz.distributed"),
+    ("seed_everything", "ezpz.distributed"),
+    # -- utils --
+    ("get_timestamp", "ezpz.utils"),
+    ("format_pair", "ezpz.utils"),
+    ("summarize_dict", "ezpz.utils"),
+    ("model_summary", "ezpz.utils"),
+    ("get_max_memory_allocated", "ezpz.utils"),
+    ("get_max_memory_reserved", "ezpz.utils"),
+    ("check_for_tarball", "ezpz.utils"),
+    ("make_tarfile", "ezpz.utils"),
+    ("Color", "ezpz.utils"),
+    ("NoColor", "ezpz.utils"),
+    # -- log --
+    ("get_logger", "ezpz.log"),
+    # -- history --
+    ("History", "ezpz.history"),
+    # -- flops --
+    ("compute_mfu", "ezpz.flops"),
+    ("try_estimate", "ezpz.flops"),
+    # -- configs --
+    ("get_scheduler", "ezpz.configs"),
+    # -- launch --
+    ("get_active_jobid", "ezpz.launch"),
+    ("get_nodelist_of_active_job", "ezpz.launch"),
+]
+
+
+class TestStaticReexports:
+    """Each TYPE_CHECKING re-export should also resolve at runtime."""
+
+    def test_every_reexport_resolves(self):
+        """If a symbol is statically re-exported, it must be importable.
+
+        This catches the case where someone adds a name to the
+        TYPE_CHECKING block but the underlying submodule doesn't
+        define it (or has renamed it). Without this test, type
+        checkers would happily resolve `ezpz.foo`, then users would
+        hit `AttributeError` at runtime.
+        """
+        missing = []
+        for name, expected_module in EXPECTED_STATIC_REEXPORTS:
+            if not hasattr(ezpz, name):
+                missing.append(name)
+        assert not missing, (
+            f"Statically re-exported but not resolvable at runtime: "
+            f"{missing}"
+        )
+
+    def test_every_reexport_comes_from_advertised_submodule(self):
+        """Sanity-check that each symbol lives where the docstring says.
+
+        e.g. `ezpz.setup_torch` should resolve to a callable defined in
+        `ezpz.distributed`, not (say) `ezpz.utils`. Protects against
+        accidental moves that would silently change the import target.
+        """
+        mismatches = []
+        for name, expected_module in EXPECTED_STATIC_REEXPORTS:
+            obj = getattr(ezpz, name)
+            actual_module = getattr(obj, "__module__", None)
+            if actual_module != expected_module:
+                mismatches.append((name, expected_module, actual_module))
+        assert not mismatches, (
+            "Re-exports defined in unexpected modules: "
+            + ", ".join(
+                f"{name} expected {exp} got {act}"
+                for name, exp, act in mismatches
+            )
+        )
+
+    def test_reexports_listed_in_dunder_all(self):
+        """`from ezpz import *` should give every re-export.
+
+        Also protects `dir(ezpz)` discoverability for editors that
+        consume __all__ instead of (or in addition to) walking
+        TYPE_CHECKING blocks.
+        """
+        missing_from_all = [
+            name for name, _ in EXPECTED_STATIC_REEXPORTS
+            if name not in ezpz.__all__
+        ]
+        assert not missing_from_all, (
+            f"Re-exports not in __all__: {missing_from_all}"
+        )
+
+
+class TestPyTypedMarker:
+    """PEP 561 marker that tells type checkers the package is typed."""
+
+    def test_py_typed_file_exists(self):
+        """`src/ezpz/py.typed` must be present.
+
+        Without this empty file, Pyright / Pylance ignore the package's
+        inline annotations and treat everything as `Unknown` — even if
+        the TYPE_CHECKING re-exports are correct. This is the marker
+        PEP 561 specifies.
+        """
+        package_dir = Path(ezpz.__file__).parent
+        marker = package_dir / "py.typed"
+        assert marker.exists(), (
+            f"py.typed marker missing at {marker}. Without it, type "
+            f"checkers treat the package as untyped."
+        )
+
+
+class TestLazyResolutionStillWorks:
+    """The lazy __getattr__ path is unchanged — preserves import speed."""
+
+    def test_submodules_still_resolve_lazily(self):
+        """`ezpz.distributed` is a submodule, not a static re-export.
+
+        The lazy walker should still find it (via _LAZY_MODULES) without
+        the explicit `from .distributed import distributed` (which would
+        be nonsense). Protects against accidentally dropping the lazy
+        path while adding static re-exports.
+        """
+        assert ezpz.distributed is not None
+        # The lazy walker caches on first hit; re-accessing should be
+        # the same module object.
+        assert ezpz.distributed is importlib.import_module("ezpz.distributed")
+
+    def test_top_level_helpers_resolve(self):
+        """Symbols defined directly in `__init__.py` (not re-exports)
+        also remain accessible."""
+        assert callable(ezpz.try_import_wandb)
+        assert callable(ezpz.get_torch_version_tuple)

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -32,39 +32,54 @@ import ezpz
 # submodule it actually lives in (so we can verify both ends).
 EXPECTED_STATIC_REEXPORTS = [
     # -- distributed --
-    ("setup_torch", "ezpz.distributed"),
-    ("get_rank", "ezpz.distributed"),
+    ("all_reduce", "ezpz.distributed"),
+    ("barrier", "ezpz.distributed"),
+    ("broadcast", "ezpz.distributed"),
+    ("cleanup", "ezpz.distributed"),
+    ("get_cpus_per_node", "ezpz.distributed"),
+    ("get_device_properties", "ezpz.distributed"),
+    ("get_dist_info", "ezpz.distributed"),
+    ("get_gpus_per_node", "ezpz.distributed"),
+    ("get_hostname", "ezpz.distributed"),
     ("get_local_rank", "ezpz.distributed"),
-    ("get_world_size", "ezpz.distributed"),
+    ("get_machine", "ezpz.distributed"),
+    ("get_node_index", "ezpz.distributed"),
+    ("get_num_nodes", "ezpz.distributed"),
+    ("get_rank", "ezpz.distributed"),
+    ("get_torch_backend", "ezpz.distributed"),
     ("get_torch_device", "ezpz.distributed"),
     ("get_torch_device_type", "ezpz.distributed"),
-    ("get_torch_backend", "ezpz.distributed"),
+    ("get_world_size", "ezpz.distributed"),
+    ("get_world_size_in_use", "ezpz.distributed"),
+    ("get_world_size_total", "ezpz.distributed"),
+    ("log_dict_as_bulleted_list", "ezpz.distributed"),
+    ("print_dist_setup", "ezpz.distributed"),
+    ("query_environment", "ezpz.distributed"),
+    ("seed_everything", "ezpz.distributed"),
+    ("setup_mlflow", "ezpz.distributed"),
+    ("setup_torch", "ezpz.distributed"),
+    ("setup_wandb", "ezpz.distributed"),
+    ("synchronize", "ezpz.distributed"),
+    ("timeitlogit", "ezpz.distributed"),
+    ("verify_wandb", "ezpz.distributed"),
     ("wrap_model", "ezpz.distributed"),
     ("wrap_model_for_ddp", "ezpz.distributed"),
     ("wrap_model_for_fsdp", "ezpz.distributed"),
     ("wrap_model_for_fsdp2", "ezpz.distributed"),
-    ("synchronize", "ezpz.distributed"),
-    ("barrier", "ezpz.distributed"),
-    ("broadcast", "ezpz.distributed"),
-    ("all_reduce", "ezpz.distributed"),
-    ("cleanup", "ezpz.distributed"),
-    ("timeitlogit", "ezpz.distributed"),
-    ("setup_wandb", "ezpz.distributed"),
-    ("setup_mlflow", "ezpz.distributed"),
-    ("get_hostname", "ezpz.distributed"),
-    ("get_device_properties", "ezpz.distributed"),
-    ("seed_everything", "ezpz.distributed"),
     # -- utils --
-    ("get_timestamp", "ezpz.utils"),
+    ("Color", "ezpz.utils"),
+    ("DistributedPdb", "ezpz.utils"),
+    ("ForkedPdb", "ezpz.utils"),
+    ("NoColor", "ezpz.utils"),
+    ("check_for_tarball", "ezpz.utils"),
     ("format_pair", "ezpz.utils"),
-    ("summarize_dict", "ezpz.utils"),
-    ("model_summary", "ezpz.utils"),
     ("get_max_memory_allocated", "ezpz.utils"),
     ("get_max_memory_reserved", "ezpz.utils"),
-    ("check_for_tarball", "ezpz.utils"),
+    ("get_timestamp", "ezpz.utils"),
+    ("grab_tensor", "ezpz.utils"),
     ("make_tarfile", "ezpz.utils"),
-    ("Color", "ezpz.utils"),
-    ("NoColor", "ezpz.utils"),
+    ("model_summary", "ezpz.utils"),
+    ("summarize_dict", "ezpz.utils"),
     # -- log --
     ("get_logger", "ezpz.log"),
     # -- history --
@@ -93,12 +108,40 @@ class TestStaticReexports:
         hit `AttributeError` at runtime.
         """
         missing = []
-        for name, expected_module in EXPECTED_STATIC_REEXPORTS:
+        for name, _expected_module in EXPECTED_STATIC_REEXPORTS:
             if not hasattr(ezpz, name):
                 missing.append(name)
         assert not missing, (
             f"Statically re-exported but not resolvable at runtime: "
             f"{missing}"
+        )
+
+    def test_expected_list_matches_runtime_static_reexports(self):
+        """Drift guard: EXPECTED_STATIC_REEXPORTS must cover every name
+        in ezpz._STATIC_REEXPORTS.
+
+        Without this, adding a name to _STATIC_REEXPORTS (and the
+        TYPE_CHECKING block) without also updating this test file
+        would silently pass — but a regression where the name doesn't
+        actually resolve at runtime wouldn't be caught for THAT name.
+        Sourcery / Copilot flagged this as the main drift risk in the
+        PR review.
+        """
+        expected_names = {name for name, _ in EXPECTED_STATIC_REEXPORTS}
+        runtime_names = set(ezpz._STATIC_REEXPORTS)
+        missing_from_test = runtime_names - expected_names
+        extra_in_test = expected_names - runtime_names
+        assert not missing_from_test, (
+            f"ezpz._STATIC_REEXPORTS has names not covered by this test "
+            f"file's EXPECTED_STATIC_REEXPORTS: {sorted(missing_from_test)}. "
+            f"Add them to EXPECTED_STATIC_REEXPORTS so the per-symbol "
+            f"resolution test runs against the full set."
+        )
+        assert not extra_in_test, (
+            f"EXPECTED_STATIC_REEXPORTS lists names not in "
+            f"ezpz._STATIC_REEXPORTS: {sorted(extra_in_test)}. "
+            f"Either add them to _STATIC_REEXPORTS or remove from the "
+            f"test file."
         )
 
     def test_every_reexport_comes_from_advertised_submodule(self):
@@ -130,11 +173,54 @@ class TestStaticReexports:
         TYPE_CHECKING blocks.
         """
         missing_from_all = [
-            name for name, _ in EXPECTED_STATIC_REEXPORTS
+            name for name, _expected_module in EXPECTED_STATIC_REEXPORTS
             if name not in ezpz.__all__
         ]
         assert not missing_from_all, (
             f"Re-exports not in __all__: {missing_from_all}"
+        )
+
+    def test_type_checking_block_matches_static_reexports(self):
+        """Drift guard between the TYPE_CHECKING import block and
+        ezpz._STATIC_REEXPORTS.
+
+        Parses ezpz/__init__.py and extracts every name imported
+        inside `if TYPE_CHECKING:`. That set must equal
+        ezpz._STATIC_REEXPORTS — otherwise type checkers and
+        `from ezpz import *` consumers see different surfaces.
+        """
+        import ast
+
+        source = Path(ezpz.__file__).read_text()
+        tree = ast.parse(source)
+
+        # Find the `if TYPE_CHECKING:` block at module scope.
+        type_checking_imports: set[str] = set()
+        for node in tree.body:
+            if isinstance(node, ast.If):
+                # The guard is `if TYPE_CHECKING:` — match by name.
+                test = node.test
+                if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+                    for stmt in node.body:
+                        if isinstance(stmt, ast.ImportFrom):
+                            for alias in stmt.names:
+                                # Use the alias if present, else the name
+                                type_checking_imports.add(
+                                    alias.asname or alias.name
+                                )
+
+        static_reexports = set(ezpz._STATIC_REEXPORTS)
+        only_in_typecheck = type_checking_imports - static_reexports
+        only_in_static = static_reexports - type_checking_imports
+        assert not only_in_typecheck, (
+            f"Imported in TYPE_CHECKING block but missing from "
+            f"_STATIC_REEXPORTS (won't appear in __all__): "
+            f"{sorted(only_in_typecheck)}"
+        )
+        assert not only_in_static, (
+            f"In _STATIC_REEXPORTS but missing from TYPE_CHECKING "
+            f"imports (type checkers won't see them): "
+            f"{sorted(only_in_static)}"
         )
 
 


### PR DESCRIPTION
Closes #133.

## Problem

Pyright / Pylance / LSP-based editors couldn't statically resolve
`ezpz.setup_torch`, `ezpz.get_rank`, `ezpz.History`, etc. — even
though they work at runtime via the lazy `__getattr__` walker in
`ezpz/__init__.py`. Symbols defined directly in `__init__.py` (like
`try_import_wandb`) were discovered correctly, so the inconsistency
was specifically about the lazy re-export pattern.

Root cause: type checkers can't follow `__getattr__` resolution. The
lazy import design (which keeps `import ezpz` fast by deferring heavy
torch/mpi4py imports) is great at runtime but invisible to static
analysis.

## Fix

Hybrid approach — preserves lazy runtime, adds static discoverability.

1. **`if TYPE_CHECKING:` block** at the top of `__init__.py` with
   explicit `from .submodule import name` statements for every
   public top-level API. Type checkers evaluate this branch
   (`TYPE_CHECKING` is `True` at analysis time); runtime skips it.
   The lazy `__getattr__` path below is unchanged.

2. **`_STATIC_REEXPORTS` constant** lists every name; spliced into
   `__all__` so `dir(ezpz)` and `from ezpz import *` work and
   stub-aware tools see the full surface.

3. **`py.typed` marker file** (PEP 561) tells type checkers the
   package is type-aware and they should use its inline annotations
   instead of treating everything as `Unknown`. Hatchling packages
   it automatically (no exclude rule applies).

Standard pattern; same shape pandas/numpy/sqlalchemy use.

## Scope note

Did **not** include the memory-tracking helpers (`get_memory_metrics`,
`format_memory_summary`, `get_current_memory_*`, `reset_peak_memory_stats`,
`is_memory_metric_key`) — those land in #134 and will be added to
this block on that PR's merge. Commented in the source so it's
explicit. Both PRs can land in either order; the second-to-merge just
needs to extend the `TYPE_CHECKING` block + `_STATIC_REEXPORTS` with
its new names.

**71 symbols** now statically discoverable (was 17 — only submodule
keys + `__version__`).

## Test plan

- [x] `pytest tests/test_top_level_exports.py` — 6 new tests pass
- [x] Every `TYPE_CHECKING` re-export resolves at runtime (catches
      drift between static and runtime view)
- [x] Every re-export comes from the advertised submodule
- [x] Every re-export appears in `__all__`
- [x] `py.typed` marker file present at `src/ezpz/py.typed`
- [x] Lazy submodule resolution still works (`ezpz.distributed` via
      `__getattr__` walker)
- [x] Top-level helpers defined directly in `__init__.py` still
      resolve (`try_import_wandb`, `get_torch_version_tuple`)
- [ ] In Neovim/LazyVim w/ Pyright: `ezpz.setup_torch` shows in
      completion + auto-import (the original symptom from #133)

## Summary by Sourcery

Improve static discoverability and typing support for the ezpz top-level API while preserving lazy runtime imports.

Enhancements:
- Add TYPE_CHECKING-based static re-exports in ezpz.__init__ to expose top-level API symbols to type checkers and editor tooling without changing lazy import behavior.
- Extend __all__ with an explicit list of re-exported symbols so star-imports and introspection expose the full public surface.
- Mark the package as typed via a py.typed marker file to enable PEP 561-aware type checkers to use inline annotations.

Tests:
- Add tests ensuring all declared static re-exports resolve at runtime, originate from the expected submodules, are included in __all__, the py.typed marker exists, and lazy submodule resolution and direct __init__ helpers remain functional.