### PR TITLE
fix(history): promote distributed std to fp64 to avoid fp32 cancellation

### DIFF
--- a/src/ezpz/history.py
+++ b/src/ezpz/history.py
@@ -1378,8 +1378,19 @@ class History:
             dtype=dtype,
             device=metric_device,
         )
-        sum_vals = values.clone()
-        sq_vals = values.square()
+        # Promote to fp64 *before* squaring so the variance arithmetic
+        # `E[X^2] - E[X]^2` doesn't lose its signal to fp32 cancellation.
+        # For typical training metrics (`tokens_per_sec ≈ 1e5`,
+        # `tflops ≈ 40`, etc.) the squared values are 8-10 orders of
+        # magnitude larger than the across-rank variance, and the
+        # subtraction collapses to exactly 0.0 in fp32 — `tflops/std=0.0`
+        # is then indistinguishable from "all ranks identical" and the
+        # console summary drops the `(±std)` parenthetical entirely.
+        # fp64 has ~16 sig digits of headroom which covers any realistic
+        # training metric. Cost: one extra cast + ~2x bandwidth on the
+        # squared-sum all-reduce, negligible vs. the metric collection.
+        sum_vals = values.to(torch.float64)
+        sq_vals = sum_vals.square()
         max_vals = values.clone()
         min_vals = values.clone()
         # world_size = ezpz.distributed.get_world_size()

--- a/src/ezpz/history.py
+++ b/src/ezpz/history.py
@@ -1387,10 +1387,34 @@ class History:
         # is then indistinguishable from "all ranks identical" and the
         # console summary drops the `(±std)` parenthetical entirely.
         # fp64 has ~16 sig digits of headroom which covers any realistic
-        # training metric. Cost: one extra cast + ~2x bandwidth on the
-        # squared-sum all-reduce, negligible vs. the metric collection.
-        sum_vals = values.to(torch.float64)
-        sq_vals = sum_vals.square()
+        # training metric. Cost: two casts + ~2x bandwidth on both the
+        # sum and squared-sum all-reduces (max/min stay in the original
+        # dtype since they don't suffer cancellation). Negligible vs.
+        # the metric collection itself.
+        #
+        # Some accelerator backends (notably some Intel XPU devices)
+        # don't support fp64 natively. We probe the cast + a trivial
+        # fp64 op BEFORE starting any collectives — if it fails, we
+        # commit to the original dtype for the whole reduce so we
+        # don't leave half the ranks in fp64 and half in fp32 (which
+        # would deadlock the all_reduce). `copy=True` on the cast
+        # also defends against aliasing when `values` is already fp64
+        # (otherwise the in-place all_reduce below would mutate it).
+        try:
+            sum_vals = values.to(torch.float64, copy=True)
+            _ = sum_vals.square().sum().item()  # probe fp64 arithmetic
+            sq_vals = sum_vals.square()
+        except RuntimeError as exc:
+            logger.warning(
+                "fp64 promotion failed on %s (%s); falling back to "
+                "%s for distributed std. `/std` for large-magnitude "
+                "metrics may collapse to 0.0 due to fp32 cancellation.",
+                metric_device,
+                exc,
+                dtype,
+            )
+            sum_vals = values.clone()
+            sq_vals = values.square()
         max_vals = values.clone()
         min_vals = values.clone()
         # world_size = ezpz.distributed.get_world_size()

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -189,6 +189,110 @@ class TestHistory:
         warmed = hist.to_DataArray([1, 2, 3], warmup=1.0)
         assert warmed.shape == (0,)
 
+    def test_distributed_std_survives_fp32_cancellation(
+        self, monkeypatch
+    ):
+        """Distributed std for large-magnitude metrics survives the
+        ``E[X^2] - E[X]^2`` variance formula.
+
+        Regression: when per-rank values are ~1e5 (e.g. ``tokens_per_sec``)
+        and their across-rank variance is small (~hundreds), the
+        variance subtraction loses its entire signal to fp32
+        catastrophic cancellation — the squared values are ~1e10 and
+        the variance is 8 orders of magnitude smaller than mantissa
+        precision allows. Pre-fix, ``std`` came back as exactly 0.0
+        and the console summary dropped the ``(±std)`` parenthetical
+        entirely, making it look like every rank measured the same
+        value.
+
+        Fix: promote to fp64 before squaring (commit message has the
+        full numerical analysis).
+        """
+        # Per-rank values mirroring a real training-log signature:
+        # tokens_per_sec ≈ 124k across 6 ranks with ~20 std.
+        per_rank_values = [
+            123880.0, 123920.0, 123870.0, 123890.0, 123900.0, 123860.0,
+        ]
+        world_size = len(per_rank_values)
+
+        # `History.__init__` short-circuits `distributed_history` to
+        # False unless `get_world_size() > 1`. Patch BEFORE constructing
+        # so the flag survives, and again later for the actual call.
+        monkeypatch.setattr(
+            "ezpz.distributed.get_world_size", lambda: world_size
+        )
+        monkeypatch.setattr(
+            torch.distributed,
+            "is_initialized",
+            lambda: True,
+            raising=False,
+        )
+        # Also patch is_available — checked inside _compute_distributed_metrics.
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True, raising=False
+        )
+
+        hist = history.History(distributed_history=True)
+        hist._rank = 0
+        # Force _select_metric_device to return CPU so we don't try to
+        # allocate on a GPU that doesn't exist in CI.
+        monkeypatch.setattr(
+            hist, "_select_metric_device", lambda: torch.device("cpu")
+        )
+        # Each rank only sees its own value; the all-reduce here
+        # simulates the global SUM/MAX/MIN by replacing the local
+        # tensor's contents in-place with the across-rank aggregate.
+        def _fake_all_reduce(tensor, op=None, **_kw):
+            ops = torch.distributed.ReduceOp
+            arr = torch.tensor(
+                per_rank_values, dtype=tensor.dtype, device=tensor.device
+            )
+            if op == ops.SUM:
+                # Local tensor is rank 0's contribution; we want the
+                # sum of all rank contributions. The first time we
+                # see SUM the tensor is the rank-0 value; for the
+                # squared sum it's the rank-0 squared value. Re-derive
+                # from `arr` to keep this test agnostic of which call.
+                if torch.allclose(tensor.squeeze(), arr[0:1].to(tensor.dtype)):
+                    tensor.copy_(arr.sum().to(tensor.dtype).view_as(tensor))
+                else:
+                    tensor.copy_(
+                        arr.square().sum().to(tensor.dtype).view_as(tensor)
+                    )
+            elif op == ops.MAX:
+                tensor.copy_(arr.max().to(tensor.dtype).view_as(tensor))
+            elif op == ops.MIN:
+                tensor.copy_(arr.min().to(tensor.dtype).view_as(tensor))
+
+        monkeypatch.setattr(
+            torch.distributed, "all_reduce", _fake_all_reduce
+        )
+
+        # The History helper enters with this rank's local value.
+        stats = hist._compute_distributed_metrics(
+            {"tokens_per_sec": per_rank_values[0]}
+        )
+
+        # Sanity: mean is approximately correct. With fp64 promotion
+        # we get full precision; pre-fix the fp32 mean also worked but
+        # only to ~7 sig digits for ~1e5 values. The bug is in std,
+        # not mean.
+        true_mean = sum(per_rank_values) / world_size
+        assert stats["tokens_per_sec/mean"] == pytest.approx(true_mean, abs=0.01)
+        # The point of the regression: std MUST be non-zero. Pre-fix
+        # this was exactly 0.0 due to fp32 cancellation.
+        assert stats["tokens_per_sec/std"] > 0.0, (
+            "Distributed std collapsed to 0.0 — fp32 cancellation regressed "
+            "(see history.py:_compute_distributed_metrics)"
+        )
+        # Verify the std is close to the actual population std (~20)
+        # — not just non-zero by accident.
+        import statistics
+        expected_std = statistics.pstdev(per_rank_values)
+        assert stats["tokens_per_sec/std"] == pytest.approx(
+            expected_std, rel=1e-3
+        )
+
     def test_history_finalize_report_contains_environment(self, tmp_path):
         """Finalized report lives alongside outputs with environment context."""
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -242,18 +242,22 @@ class TestHistory:
         # Each rank only sees its own value; the all-reduce here
         # simulates the global SUM/MAX/MIN by replacing the local
         # tensor's contents in-place with the across-rank aggregate.
+        # Dispatch by call order, not tensor contents — the source
+        # always issues reduces in the same order (SUM sum, SUM sq,
+        # MAX, MIN), and content-comparison would break for inputs
+        # where x ≈ x² (e.g. small floats or values near 0 or 1).
+        sum_call_count = [0]  # nonlocal-effective via list
+
         def _fake_all_reduce(tensor, op=None, **_kw):
             ops = torch.distributed.ReduceOp
             arr = torch.tensor(
                 per_rank_values, dtype=tensor.dtype, device=tensor.device
             )
             if op == ops.SUM:
-                # Local tensor is rank 0's contribution; we want the
-                # sum of all rank contributions. The first time we
-                # see SUM the tensor is the rank-0 value; for the
-                # squared sum it's the rank-0 squared value. Re-derive
-                # from `arr` to keep this test agnostic of which call.
-                if torch.allclose(tensor.squeeze(), arr[0:1].to(tensor.dtype)):
+                sum_call_count[0] += 1
+                # First SUM is for `sum_vals` (Σx), second is for
+                # `sq_vals` (Σx²). Source code never reorders these.
+                if sum_call_count[0] == 1:
                     tensor.copy_(arr.sum().to(tensor.dtype).view_as(tensor))
                 else:
                     tensor.copy_(
@@ -292,6 +296,92 @@ class TestHistory:
         assert stats["tokens_per_sec/std"] == pytest.approx(
             expected_std, rel=1e-3
         )
+
+    def test_distributed_std_falls_back_when_fp64_unsupported(
+        self, monkeypatch, caplog
+    ):
+        """If the fp64 promotion or probe raises (e.g. some Intel XPU
+        devices don't support fp64), the helper should fall back to
+        fp32 with a logged warning rather than crashing the run.
+
+        Losing precision on ``/std`` for large-magnitude metrics is
+        bad, but losing the entire training run because metric
+        collection threw is much worse.
+        """
+        # Smaller-magnitude values so fp32 cancellation isn't an
+        # issue here — this test is about the fallback path firing,
+        # not about std accuracy on the fallback.
+        per_rank_values = [0.5, 0.6, 0.4, 0.55, 0.45, 0.5]
+        world_size = len(per_rank_values)
+
+        monkeypatch.setattr(
+            "ezpz.distributed.get_world_size", lambda: world_size
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True, raising=False
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True, raising=False
+        )
+
+        hist = history.History(distributed_history=True)
+        hist._rank = 0
+        monkeypatch.setattr(
+            hist, "_select_metric_device", lambda: torch.device("cpu")
+        )
+
+        # Patch the Tensor.to method so any fp64 promotion raises.
+        # Simulates an XPU device that doesn't support fp64.
+        orig_to = torch.Tensor.to
+
+        def _no_fp64(self, *args, **kwargs):
+            dtype = kwargs.get("dtype")
+            if not dtype and args and isinstance(args[0], torch.dtype):
+                dtype = args[0]
+            if dtype == torch.float64:
+                raise RuntimeError(
+                    "Simulated: device does not support fp64"
+                )
+            return orig_to(self, *args, **kwargs)
+
+        monkeypatch.setattr(torch.Tensor, "to", _no_fp64)
+
+        sum_call_count = [0]
+
+        def _fake_all_reduce(tensor, op=None, **_kw):
+            ops = torch.distributed.ReduceOp
+            arr = torch.tensor(
+                per_rank_values, dtype=tensor.dtype, device=tensor.device
+            )
+            if op == ops.SUM:
+                sum_call_count[0] += 1
+                if sum_call_count[0] == 1:
+                    tensor.copy_(arr.sum().to(tensor.dtype).view_as(tensor))
+                else:
+                    tensor.copy_(
+                        arr.square().sum().to(tensor.dtype).view_as(tensor)
+                    )
+            elif op == ops.MAX:
+                tensor.copy_(arr.max().to(tensor.dtype).view_as(tensor))
+            elif op == ops.MIN:
+                tensor.copy_(arr.min().to(tensor.dtype).view_as(tensor))
+
+        monkeypatch.setattr(
+            torch.distributed, "all_reduce", _fake_all_reduce
+        )
+
+        # Should not raise — the source's try/except catches the
+        # fp64 RuntimeError and falls back to fp32.
+        stats = hist._compute_distributed_metrics(
+            {"loss": per_rank_values[0]}
+        )
+
+        # Stats should still be computed (in fp32). Mean is exact for
+        # these small values; std is non-zero because the magnitudes
+        # are small enough that fp32 cancellation doesn't bite.
+        true_mean = sum(per_rank_values) / world_size
+        assert stats["loss/mean"] == pytest.approx(true_mean, abs=1e-5)
+        assert stats["loss/std"] > 0.0
 
     def test_history_finalize_report_contains_environment(self, tmp_path):
         """Finalized report lives alongside outputs with environment context."""


### PR DESCRIPTION
## Summary

`_compute_distributed_metrics` in `history.py` was computing
across-rank variance using the numerically unstable
`E[X²] - E[X]²` formula in **fp32**. For typical training metrics
(`tokens_per_sec ≈ 1e5`, `tflops ≈ 40`, `tokens_per_sec_per_gpu ≈ 1e4`)
the squared values are ~1e10 while the across-rank variance is
hundreds — that's 8+ orders of magnitude smaller than fp32 mantissa
precision allows, so the subtraction collapses to **exactly 0.0**.

## The symptom

Training logs where some metrics had `(±std)` and others were bare,
depending on whether the metric magnitude happened to fit inside
fp32's precision window:

```
[train] step=1 loss=2.467(± 0.17) ... tokens_per_sec=50982(± 111) tflops=15.75(± 0.035)
[train] step=2 loss=2.881(± 0.23) ... tokens_per_sec=122821(± 32) tflops=37.94          
[train] step=3 loss=2.584(± 0.14) ... tokens_per_sec=123881(± 45) tflops=38.27          
[train] step=4 loss=2.606(± 0.12) ... tokens_per_sec=124562(± 32) tflops=38.48(±5.5e-3)
```

Notice step 2-4 dropping `(±std)` on `tflops` despite per-rank
spread *guaranteed* to exist (every rank measured a slightly
different FLOPs throughput). Looked like ranks had identical values
when they were actually just losing the signal to fp32 precision.

## Numerical demo

```python
per_rank = [123880, 123920, 123870, 123890, 123900, 123860]
# OLD (fp32 E[X²] - E[X]²):     std=0.000000
# NEW (fp64 promotion):          std=19.720266
# torch.std(unbiased=False):     std=19.720266  ← matches exactly
```

## Fix

Promote `sum_vals` and `sq_vals` to fp64 before the all-reduce and
variance arithmetic. The max/min reductions stay in the original
dtype — they don't suffer cancellation.

```diff
- sum_vals = values.clone()
- sq_vals = values.square()
+ sum_vals = values.to(torch.float64)
+ sq_vals = sum_vals.square()
```

fp64 has ~16 sig digits of headroom which covers any realistic
training metric (even at 1e9 scale the variance arithmetic stays
stable). Cost is one extra cast + ~2x bandwidth on the squared-sum
all-reduce — negligible vs. the metric collection itself.

## Test

`tests/test_history.py::TestHistory::test_distributed_std_survives_fp32_cancellation`

Uses mocked `torch.distributed.all_reduce` to simulate a 6-rank
aggregation of the realistic `tokens_per_sec ≈ 1.24e5` values from
the failing log. Asserts `std > 0.0` with a regression message
pointing at the source file. Also verifies the std matches
`statistics.pstdev` to within 1e-3 relative tolerance — not just
"non-zero by accident".

**Verified the test catches the regression**: applied only the test
against the pre-fix source, observed the exact assertion failure:
> AssertionError: Distributed std collapsed to 0.0 — fp32 cancellation regressed

Applied the source fix, test passes.

## Test plan

- [x] `pytest tests/test_history.py` — 34/34 pass (was 33)
- [x] `pytest tests/test_history.py::TestHistory::test_distributed_std_survives_fp32_cancellation` against pre-fix source FAILS with expected message
- [x] Numerical demo: `std=19.72` matches `torch.std(unbiased=False)` exactly
- [ ] On a real multi-rank training run: `tflops(±X.XXX)` consistently has a non-zero std across steps

## Notes

- Bug is pre-existing — unrelated to PR #134 or #136. Caught while looking at training logs from the launch-flag work.
- The `clamp_min_(0.0)` on the variance line was the smoking gun — the original author knew about negative-variance edge cases and just clamped, treating it as "rounding error" when it was actually "lost the entire signal to fp32 cancellation".

## Summary by Sourcery

Ensure distributed metric standard deviation remains accurate for large-magnitude training metrics by improving numerical stability in the history aggregation logic.

Bug Fixes:
- Prevent distributed standard deviation for large-magnitude metrics from collapsing to zero due to fp32 catastrophic cancellation in variance computation.

Tests:
- Add a regression test that simulates multi-rank aggregation of large-magnitude metrics to verify distributed std is non-zero and matches the true population standard deviation.