### PR TITLE
fix(history): emit memory token for prefixed metrics + close inference.py gap

### DIFF
--- a/src/ezpz/examples/inference.py
+++ b/src/ezpz/examples/inference.py
@@ -637,6 +637,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 )
 
             if not is_warmup:
+                # Merge in per-step device memory (mem_alloc/peak/reserved/
+                # peak_reserved) so console + JSONL + tracker backends all
+                # see GPU memory alongside the throughput metrics. Returns
+                # {} on CPU/MPS or when EZPZ_TRACK_MEMORY=0, so this is a
+                # safe no-op on unsupported devices.
+                metrics |= ezpz.get_memory_metrics()
                 history.update(metrics)
 
             if pred_file is not None:

--- a/src/ezpz/history.py
+++ b/src/ezpz/history.py
@@ -1546,7 +1546,16 @@ class History:
             # Build the compact memory string from the RAW metrics dict
             # (which still has the 4 keys even after the filter above).
             # Empty string when no memory keys, e.g. on CPU/MPS.
-            memory_str = format_memory_summary(metrics, prefix=prefix or "")
+            #
+            # `prefix` here came from `_split_prefix(metrics)` and is the
+            # bare namespace WITHOUT a trailing slash (e.g. "train").
+            # `format_memory_summary` expects either a full prefix WITH
+            # slash ("train/") or None for auto-detection. Passing
+            # "train" directly would make the lookup miss
+            # ("trainmem_alloc" — no key matches) and silently drop the
+            # memory= token from the line. Use None and let the helper
+            # infer the prefix from the *mem_alloc keys it scans.
+            memory_str = format_memory_summary(metrics, prefix=None)
             parts = [p for p in (base, f"memory={memory_str}" if memory_str else "") if p]
             return " ".join(parts)
         return ""

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -707,3 +707,62 @@ class TestLogMetricsCondensation:
             include_summary=False,
         )
         assert "memory=" not in records[0]
+
+
+@pytest.mark.skipif(not HISTORY_AVAILABLE, reason="ezpz.history not available")
+class TestUpdateSummaryMemoryToken:
+    """`History.update` must emit the `memory=…GiB` token in its summary
+    string regardless of whether metric keys use a namespace prefix."""
+
+    def test_memory_token_present_with_prefix(self):
+        """Regression: when metrics are namespaced (``train/loss``,
+        ``train/mem_alloc``, etc.), the summary string returned by
+        ``History.update`` must still contain the collapsed
+        ``memory=…GiB`` token.
+
+        Pre-fix, ``History.update`` passed ``prefix="train"`` (no
+        trailing slash) to ``format_memory_summary``, which then looked
+        up ``trainmem_alloc`` and never found the key, so the memory
+        token was silently dropped from the line. Every example with a
+        ``"train/"`` prefix (vit, fsdp_tp, diffusion, hf) lost its
+        memory readout in the console summary as a result.
+
+        Fix: pass ``prefix=None`` and let the helper auto-detect from
+        the keys it scans.
+        """
+        hist = history.History(backends=[])
+        hist._rank = 0
+        metrics = {
+            "train/loss": 2.94,
+            "train/mem_alloc": 1.5,
+            "train/mem_peak_alloc": 2.0,
+            "train/mem_reserved": 3.0,
+            "train/mem_peak_reserved": 4.0,
+        }
+        summary = hist.update(metrics)
+        # The point of the regression: `memory=` MUST appear in the
+        # summary string.
+        assert "memory=" in summary, (
+            f"memory=...GiB token dropped from summary for prefixed metrics — "
+            f"got: {summary!r}"
+        )
+        # And the values should be the actual alloc/peak (1.5/2.0),
+        # not zeros — proves the prefix-aware lookup found the keys.
+        assert "1.50/2.00GiB" in summary
+
+    def test_memory_token_present_without_prefix(self):
+        """Bare (no-prefix) metrics also produce the ``memory=`` token —
+        verifies the fix didn't regress the non-prefixed case that was
+        accidentally working before."""
+        hist = history.History(backends=[])
+        hist._rank = 0
+        metrics = {
+            "loss": 2.94,
+            "mem_alloc": 1.5,
+            "mem_peak_alloc": 2.0,
+            "mem_reserved": 3.0,
+            "mem_peak_reserved": 4.0,
+        }
+        summary = hist.update(metrics)
+        assert "memory=" in summary
+        assert "1.50/2.00GiB" in summary


### PR DESCRIPTION
## Summary

Two related fixes to memory tracking in the examples:

1. **Bug fix**: \`History.update\` was silently dropping the \`memory=…GiB\` summary token for metrics with a namespace prefix (e.g. \`train/loss\`, \`train/mem_alloc\`). This affected **every example with prefixed metrics** — \`vit\`, \`fsdp_tp\`, \`diffusion\`, \`hf\` — covering most realistic training workloads.

2. **Coverage gap**: \`inference.py\` was the only example with a \`History.update\` loop that wasn't merging in \`ezpz.get_memory_metrics()\`. One-line fix.

## Bug discovery

Sam pasted a real \`hf.py\` log line:

\`\`\`
[train] step=27 epoch=0 loss=2.94(± 0.28) ... tflops=42.98(± 0.04) mfu=14.41(± 0.01)
\`\`\`

…and asked why there was no \`memory=…GiB\` token at the end, despite \`hf.py\` clearly calling \`ezpz.get_memory_metrics(prefix=\"train/\")\`. Reproducer:

\`\`\`python
>>> from ezpz.utils import format_memory_summary
>>> m = {'train/loss': 2.94, 'train/mem_alloc': 1.5, 'train/mem_peak_alloc': 2.0}

>>> # What History.update does today:
>>> format_memory_summary(m, prefix='train')
''

>>> # What it should do:
>>> format_memory_summary(m, prefix='train/')
'1.50/2.00GiB'
>>> format_memory_summary(m, prefix=None)  # auto-detect
'1.50/2.00GiB'
\`\`\`

## Root cause

\`_split_prefix(metrics)\` returns the namespace WITHOUT a trailing slash (e.g. \`\"train\"\`). The summary path in \`History.update\` did:

\`\`\`python
memory_str = format_memory_summary(metrics, prefix=prefix or \"\")
\`\`\`

…passing \`\"train\"\` (no slash). \`format_memory_summary\` then did \`metrics.get(f\"{prefix}mem_alloc\")\` = \`metrics.get(\"trainmem_alloc\")\` → \`None\` → empty memory string → token dropped from line.

The bare-prefix path worked accidentally because \`prefix=\"\"\` made the lookup \`\"mem_alloc\"\` which matches.

## Fix

\`\`\`diff
- memory_str = format_memory_summary(metrics, prefix=prefix or \"\")
+ memory_str = format_memory_summary(metrics, prefix=None)
\`\`\`

\`prefix=None\` triggers the helper's existing auto-detection branch (already used correctly by the \`log_metrics\` call site at \`history.py:1721\`), which scans the metrics dict for \`*mem_alloc\` keys and infers the prefix from those. No more passing partial-slash strings around.

## Test

New test class \`TestUpdateSummaryMemoryToken\` in \`tests/test_history.py\`:

- \`test_memory_token_present_with_prefix\` — the regression test (prefixed keys)
- \`test_memory_token_present_without_prefix\` — proves the fix didn't regress the accidentally-working case

**Verified the regression test catches the bug**: applied only the test against pre-fix \`history.py\`, observed the exact failure:

\`\`\`
AssertionError: memory=...GiB token dropped from summary for prefixed metrics — got: 'train/loss=2.940000'
\`\`\`

Applied the source fix → both tests pass.

## inference.py change

Audit of \`src/ezpz/examples/*.py\` against \`History.update\` callers + \`get_memory_metrics\`:

| File | History? | Memory? |
|---|---|---|
| test, vit, fsdp, fsdp_tp, diffusion, hf, minimal | ✓ | ✓ |
| hf_trainer | ✓ (Callback) | ✓ |
| **inference** | **✓** | **✗** |
| hf_trainer_alt | ✗ (uses HF Trainer) | n/a |
| cria, generate*, report, run_all | ✗ | n/a |

\`inference.py\` was the only gap. Added \`metrics |= ezpz.get_memory_metrics()\` right before the \`history.update(metrics)\` call. Safe no-op on CPU/MPS / when \`EZPZ_TRACK_MEMORY=0\`.

## Test plan

- [x] \`pytest tests/test_history.py tests/test_memory_metrics.py\` — 93 pass (was 91)
- [x] Pre-fix regression test fails with expected message; post-fix passes
- [x] Bare (no-prefix) path still works
- [ ] On a real training run with prefixed metrics (vit/hf/etc.): \`memory=X.XX/Y.YYGiB (Z%)\` appears in the console summary
- [ ] \`inference.py\` console line now includes \`memory=…GiB\` on CUDA/XPU

## Summary by Sourcery

Ensure History.update always emits a memory summary token and extend memory tracking to the inference example.

Bug Fixes:
- Fix omission of the memory=…GiB token in History.update summaries when metrics use a namespace prefix.
- Preserve correct memory summary emission for non-prefixed metrics after the History.update change.

Enhancements:
- Add device memory metrics to inference.py so its History.update loop reports memory usage alongside other metrics.

Tests:
- Add regression tests verifying that History.update summaries include the memory=…GiB token for both prefixed and non-prefixed metric keys.