### PR TITLE
fix(utils): ezpz_setup_job propagates return codes

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -2646,10 +2646,17 @@ ezpz_setup_job() {
 	log_message INFO "  - Hostname: ${YELLOW}${hn}${RESET}"
 	if [[ "${scheduler_type}" == "pbs" ]]; then
 		ezpz_setup_job_alcf "$@"
+		return $?
 	elif [[ "${scheduler_type}" == "slurm" ]]; then
 		ezpz_setup_job_slurm "$@"
+		return $?
 	else
+		# Was previously silent (function returned the exit of `log_message`
+		# itself, almost always 0), which let callers like `ezpz_setup_env`
+		# and the new `ezpz_setup` proceed past a real configuration error.
+		# Now return 1 so the wrapper chain can short-circuit cleanly.
 		log_message ERROR "Unknown scheduler: ${scheduler_type} on ${mn}"
+		return 1
 	fi
 }
 


### PR DESCRIPTION
## Summary

`ezpz_setup_job` was silently succeeding in two failure cases:

1. **Unknown scheduler**: logged `ERROR "Unknown scheduler"` but returned 0 because \`log_message\` is the last statement and almost always succeeds.
2. **Inner setup failure**: \`ezpz_setup_job_alcf\` and \`ezpz_setup_job_slurm\` had their exit codes dropped because they weren't the last statement of their respective branches.

Either case let callers like \`ezpz_setup_env\` and the new \`ezpz_setup\` (added in #138) proceed past a real configuration error, producing confusing secondary errors instead of failing fast at the root cause.

## Reproducer (before fix)

On macOS (no PBS/SLURM):

\`\`\`
$ ezpz_setup .venv
[INFO]  - Detected unknown scheduler
[ERROR] Unknown scheduler: unknown on sams-macbook-pro-3.local
# falls through to ezpz_load_modules, which errors there:
[ERROR] ezpz_load_modules: no loader for machine='sams-macbook-pro-3.local'.
[ERROR]   - Module load failed. Aborting.
\`\`\`

## After fix

\`\`\`
$ ezpz_setup .venv
[INFO]  - Detected unknown scheduler
[ERROR] Unknown scheduler: unknown on sams-macbook-pro-3.local
[ERROR]   - Job setup failed. Aborting.
# Short-circuits at the root cause.
\`\`\`

## Diff

\`\`\`diff
 if [[ "\${scheduler_type}" == "pbs" ]]; then
     ezpz_setup_job_alcf "\$@"
+    return \$?
 elif [[ "\${scheduler_type}" == "slurm" ]]; then
     ezpz_setup_job_slurm "\$@"
+    return \$?
 else
     log_message ERROR "Unknown scheduler: \${scheduler_type} on \${mn}"
+    return 1
 fi
\`\`\`

## Context

Discovered while smoke-testing PR #138 (\`ezpz_setup\` wrapper). Flagged as "Out of scope" in that PR's description with a note to fix on its own branch — this is that fix.

## Test plan

- [x] \`bash -n src/ezpz/bin/utils.sh\` (syntax)
- [x] On macOS: \`ezpz_setup_job\` now exits 1 (was 0)
- [x] On macOS: \`ezpz_setup .venv\` now short-circuits at "Job setup failed" instead of falling through to module loading
- [ ] On Aurora / Polaris: existing pbs/slurm paths still succeed (the fix only adds explicit \`return \$?\` — same as the implicit behavior when the call is the last statement, but now also handles the case where the call returns non-zero)

## Summary by Sourcery

Ensure ezpz_setup_job propagates scheduler setup failures to its callers instead of silently succeeding.

Bug Fixes:
- Propagate non-zero exit codes from PBS and SLURM setup helpers so job setup failures are correctly surfaced.
- Return a failure status when the scheduler type is unknown so higher-level setup commands short-circuit on configuration errors.