### PR TITLE
feat(failover): port scrape_bad_nodes to ezpz.failover (PR 1/3)

### DIFF
--- a/src/ezpz/bin/test_failover_scrape.sh
+++ b/src/ezpz/bin/test_failover_scrape.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# test_failover_scrape.sh — end-to-end validation of `ezpz.failover.scrape`.
+#
+# Run from any directory inside a Python env that has `saforem2/ezpz@feat/
+# failover-scrape` (or later) installed. No PBS job, no GPU, no MPI required —
+# pure log parsing, runs fine on a login node or even your laptop.
+#
+# Three checks:
+#
+#   A. Unit suite              — 36 tests from tests/test_failover_scrape.py
+#                                downloaded straight from GitHub. Validates
+#                                the package works in YOUR Python env.
+#   B. CLI smoke test          — synthetic log with both Aurora patterns +
+#                                the innocent-rank-N exclusion. Confirms the
+#                                CLI dispatch is wired correctly.
+#   C. Real-log diff           — if an upstream torchtitan scrape_bad_nodes.py
+#                                AND a log with real failure patterns are both
+#                                found on disk, diff the two scrapers'
+#                                outputs. Strongest possible validation;
+#                                skipped (not failed) when prerequisites
+#                                are missing.
+#
+# All three are independent; the script reports each verdict separately and
+# exits non-zero if any HARD test fails. Test C only counts as a failure
+# when the prerequisites exist but the diff is non-empty — i.e. the scrapers
+# actually disagree on a real log. Missing prerequisites are reported as
+# SKIP and don't fail the script.
+#
+# Usage:
+#   bash "$(python3 -c 'import ezpz, pathlib; print(pathlib.Path(ezpz.configs.BIN_DIR) / "test_failover_scrape.sh")")"
+#
+# Or, from the ezpz checkout:
+#   bash src/ezpz/bin/test_failover_scrape.sh
+
+set -u
+unset CDPATH
+
+# ANSI colors (skip if NO_COLOR is set, per the convention).
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+    G=$'\033[1;32m'; R=$'\033[1;31m'; Y=$'\033[1;33m'; C=$'\033[1;36m'; N=$'\033[0m'
+else
+    G=""; R=""; Y=""; C=""; N=""
+fi
+
+PASS=0
+FAIL=0
+SKIP=0
+
+record() {
+    local id="$1" verdict="$2" detail="$3"
+    case "${verdict}" in
+        PASS) PASS=$((PASS+1)); printf "[Test %s] %sPASS%s  %s\n" "${id}" "${G}" "${N}" "${detail}" ;;
+        FAIL) FAIL=$((FAIL+1)); printf "[Test %s] %sFAIL%s  %s\n" "${id}" "${R}" "${N}" "${detail}" ;;
+        SKIP) SKIP=$((SKIP+1)); printf "[Test %s] %sSKIP%s  %s\n" "${id}" "${Y}" "${N}" "${detail}" ;;
+    esac
+}
+
+hdr() {
+    printf "\n%s========================================================================%s\n" "${C}" "${N}"
+    printf "%sTest %s%s\n" "${C}" "$*" "${N}"
+    printf "%s========================================================================%s\n" "${C}" "${N}"
+}
+
+# ---- Preflight: ezpz importable + version sanity ---------------------------
+
+hdr "0: preflight — ezpz + ezpz.failover importable"
+if ! python3 -c "import ezpz" 2>/dev/null; then
+    record 0 FAIL "ezpz not importable in this Python env. Install with:
+        pip install -U 'git+https://github.com/saforem2/ezpz.git@feat/failover-scrape'"
+    printf "\n%s%d test(s) failed. ❌%s\n" "${R}" "${FAIL}" "${N}"
+    exit 1
+fi
+if ! python3 -c "from ezpz.failover import scrape_bad_nodes" 2>/dev/null; then
+    record 0 FAIL "ezpz.failover not importable. Either the install is stale (pre-#142) or the branch isn't installed. Try:
+        pip install -U --force-reinstall --no-deps 'git+https://github.com/saforem2/ezpz.git@feat/failover-scrape'"
+    printf "\n%s%d test(s) failed. ❌%s\n" "${R}" "${FAIL}" "${N}"
+    exit 1
+fi
+EZPZ_VERSION=$(python3 -c "import ezpz; print(getattr(ezpz, '__version__', '?'))" 2>/dev/null)
+EZPZ_LOC=$(python3 -c "import ezpz, pathlib; print(pathlib.Path(ezpz.__file__).parent)")
+record 0 PASS "ezpz=${EZPZ_VERSION} at ${EZPZ_LOC}"
+
+# ---- Test A: unit suite ----------------------------------------------------
+
+hdr "A: unit suite (36 tests downloaded from GitHub)"
+TEST_FILE=/tmp/test_failover_scrape.$$.py
+trap 'rm -f "${TEST_FILE}" /tmp/sample_failure.$$.log /tmp/old_scraper.$$.txt /tmp/new_scraper.$$.txt' EXIT
+
+# Use curl if available, else fall back to urllib via Python — many Sunspot
+# users don't have a working curl proxy until ezpz_setup runs, but Python's
+# urllib honors http_proxy/https_proxy automatically.
+TEST_URL="https://raw.githubusercontent.com/saforem2/ezpz/feat/failover-scrape/tests/test_failover_scrape.py"
+if command -v curl >/dev/null 2>&1 && \
+   curl -fsSL --max-time 15 "${TEST_URL}" -o "${TEST_FILE}" 2>/dev/null; then
+    :
+else
+    python3 -c "
+import urllib.request, pathlib
+urllib.request.urlretrieve('${TEST_URL}', '${TEST_FILE}')
+" 2>/dev/null || {
+        record A FAIL "could not fetch test file from GitHub. Check proxy env (http_proxy/https_proxy)."
+        printf "\n"
+        # Don't bail — try B and C with whatever we have
+        TEST_FILE=""
+    }
+fi
+
+if [[ -n "${TEST_FILE}" && -f "${TEST_FILE}" ]]; then
+    if ! python3 -m pytest --version >/dev/null 2>&1; then
+        record A SKIP "pytest not available in this env"
+    elif python3 -m pytest "${TEST_FILE}" -q 2>&1 | tail -5; then
+        record A PASS "all 36 unit tests pass"
+    else
+        record A FAIL "pytest reported failures — see output above"
+    fi
+fi
+
+# ---- Test B: CLI smoke -----------------------------------------------------
+
+hdr "B: CLI smoke — synthetic log + --explain"
+SAMPLE=/tmp/sample_failure.$$.log
+cat > "${SAMPLE}" <<'EOF'
+[2026-05-23 12:34:56] training step=42 loss=2.4
+x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9
+x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9
+rank 1304 died from signal 11
+Connection closed by peer [127.0.0.1]:1234
+EOF
+
+CLI_OUT=$(python3 -m ezpz.failover --machine aurora "${SAMPLE}" 2>/dev/null)
+EXPECTED="x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"
+if [[ "${CLI_OUT}" == "${EXPECTED}" ]]; then
+    record B PASS "single dedup'd hostname; innocent rank-11 correctly excluded"
+else
+    record B FAIL "expected ${EXPECTED!r}, got ${CLI_OUT!r}"
+fi
+
+# Bonus: show the --explain breakdown so the user can eyeball it
+printf "    %s--explain output:%s\n" "${C}" "${N}"
+python3 -m ezpz.failover --machine aurora --explain "${SAMPLE}" 2>&1 \
+    | sed 's/^/        /'
+
+# ---- Test C: real-log diff against upstream torchtitan scraper -------------
+
+hdr "C: real-log diff against torchtitan's scrape_bad_nodes.py"
+
+# Find upstream scraper. Order: explicit env override → torchtitan checkout
+# next to ezpz → torchtitan checkout under ~/projects → bail.
+UPSTREAM="${UPSTREAM_SCRAPER:-}"
+if [[ -z "${UPSTREAM}" ]]; then
+    for candidate in \
+        "../torchtitan/torchtitan/experiments/ezpz/scripts/scrape_bad_nodes.py" \
+        "../torchtitan-ezpz/torchtitan/experiments/ezpz/scripts/scrape_bad_nodes.py" \
+        "${HOME}/projects/saforem2/torchtitan/torchtitan/experiments/ezpz/scripts/scrape_bad_nodes.py" \
+        "${HOME}/projects/saforem2/torchtitan-ezpz/torchtitan/experiments/ezpz/scripts/scrape_bad_nodes.py" \
+        "${HOME}/datascience/foremans/projects/saforem2/torchtitan/torchtitan/experiments/ezpz/scripts/scrape_bad_nodes.py" \
+        "${HOME}/datascience/foremans/projects/saforem2/torchtitan-ezpz/torchtitan/experiments/ezpz/scripts/scrape_bad_nodes.py"
+    do
+        if [[ -f "${candidate}" ]]; then UPSTREAM="${candidate}"; break; fi
+    done
+fi
+
+if [[ -z "${UPSTREAM}" || ! -f "${UPSTREAM}" ]]; then
+    record C SKIP "no upstream scrape_bad_nodes.py found. Set UPSTREAM_SCRAPER=/path/to/file to override."
+else
+    printf "    upstream scraper: %s%s%s\n" "${C}" "${UPSTREAM}" "${N}"
+
+    # Find a real log with failure patterns. Use either the user's $LOG var
+    # if set, or auto-search for the most patterns.
+    REAL_LOG="${LOG:-}"
+    if [[ -n "${REAL_LOG}" && ! -f "${REAL_LOG}" ]]; then
+        printf "    %swarning: \$LOG points at non-existent file: %s — auto-searching instead%s\n" "${Y}" "${REAL_LOG}" "${N}"
+        REAL_LOG=""
+    fi
+
+    if [[ -z "${REAL_LOG}" ]]; then
+        printf "    searching for a log with real failure patterns (this may take a few seconds)...\n"
+        # Search the current directory for .log files containing either
+        # pattern. Use `fd` if available (much faster), else `find`.
+        # Limit search to the first 200 files to keep it bounded.
+        if command -v fd >/dev/null 2>&1; then
+            CANDIDATES=$(fd -HI -e log 2>/dev/null | head -200)
+        else
+            CANDIDATES=$(find . -name '*.log' 2>/dev/null | head -200)
+        fi
+        BEST_LOG=""
+        BEST_COUNT=0
+        for f in ${CANDIDATES}; do
+            # `grep -c` prints to stdout AND `|| echo 0` adds its own line
+            # when grep matches nothing — combine both into one integer.
+            count=$(grep -cE "shepherd died from signal 9|Connection closed by peer" "${f}" 2>/dev/null | head -1)
+            count=${count:-0}
+            if (( count > BEST_COUNT )); then
+                BEST_LOG="${f}"
+                BEST_COUNT=${count}
+            fi
+        done
+        if [[ -n "${BEST_LOG}" && ${BEST_COUNT} -gt 0 ]]; then
+            REAL_LOG="${BEST_LOG}"
+            printf "    %sfound%s: %s (%d matching lines)\n" "${G}" "${N}" "${REAL_LOG}" "${BEST_COUNT}"
+        fi
+    else
+        # User-supplied $LOG; report match count so they know whether the
+        # diff will be meaningful. Same single-integer extraction as above.
+        match_count=$(grep -cE "shepherd died from signal 9|Connection closed by peer" "${REAL_LOG}" 2>/dev/null | head -1)
+        match_count=${match_count:-0}
+        printf "    user-supplied log: %s (%d matching lines)\n" "${REAL_LOG}" "${match_count}"
+        if (( match_count == 0 )); then
+            printf "    %swarning: log has 0 failure patterns; diff being empty proves nothing%s\n" "${Y}" "${N}"
+        fi
+    fi
+
+    if [[ -z "${REAL_LOG}" ]]; then
+        record C SKIP "no log with bad-node patterns found in cwd. Set \$LOG=/path/to/postmortem.log to override."
+    else
+        OLD=/tmp/old_scraper.$$.txt
+        NEW=/tmp/new_scraper.$$.txt
+        python3 "${UPSTREAM}"                       "${REAL_LOG}" > "${OLD}" 2>/dev/null
+        python3 -m ezpz.failover --machine aurora   "${REAL_LOG}" > "${NEW}" 2>/dev/null
+
+        # `wc -l <file` pads with whitespace on some systems; strip it
+        # so the printf %d works and the eventual `(${NEW_LINES} hostname(s))`
+        # message isn't misaligned.
+        OLD_LINES=$(wc -l < "${OLD}" | tr -d ' ')
+        NEW_LINES=$(wc -l < "${NEW}" | tr -d ' ')
+        printf "    upstream emitted: %d hostname(s)\n" "${OLD_LINES}"
+        printf "    ezpz emitted:     %d hostname(s)\n" "${NEW_LINES}"
+
+        if (( OLD_LINES == 0 && NEW_LINES == 0 )); then
+            # Both empty. This could mean either "log has no patterns" (in
+            # which case both being empty is correct) or "both scrapers are
+            # broken". Report as a soft pass with a clear caveat.
+            record C PASS "both scrapers emitted nothing — consistent, but log may have no patterns"
+        elif diff -q "${OLD}" "${NEW}" >/dev/null 2>&1; then
+            record C PASS "behavior-identical on real log (${NEW_LINES} hostname(s))"
+        else
+            record C FAIL "scrapers DISAGREE on real log — diff:"
+            diff "${OLD}" "${NEW}" | sed 's/^/        /'
+        fi
+    fi
+fi
+
+# ---- Summary ---------------------------------------------------------------
+
+printf "\n%s========================================================================%s\n" "${C}" "${N}"
+printf "Summary  (%sPASS=%d%s  %sFAIL=%d%s  %sSKIP=%d%s)\n" \
+    "${G}" "${PASS}" "${N}" "${R}" "${FAIL}" "${N}" "${Y}" "${SKIP}" "${N}"
+printf "%s========================================================================%s\n" "${C}" "${N}"
+
+if (( FAIL > 0 )); then
+    printf "\n%s%d test(s) failed. ❌%s\n" "${R}" "${FAIL}" "${N}"
+    exit 1
+elif (( SKIP > 0 )); then
+    printf "\n%sAll runnable tests passed. %d skipped (see above for prerequisites).%s ✅\n" "${G}" "${SKIP}" "${N}"
+    exit 0
+else
+    printf "\n%sAll tests passed. ✅%s\n" "${G}" "${N}"
+    exit 0
+fi

--- a/src/ezpz/bin/test_failover_scrape.sh
+++ b/src/ezpz/bin/test_failover_scrape.sh
@@ -189,53 +189,28 @@ else
     fi
 
     if [[ -z "${REAL_LOG}" ]]; then
-        printf "    searching for a log with real failure patterns (this may take a few seconds)...\n"
-        # Search the current directory for files that COULD contain the
-        # failure patterns. We can't filter by .log extension only —
-        # PBS sometimes writes to .out/.err and ezpz uses .jsonl/.log
-        # interchangeably. But explicitly EXCLUDE source files / build
-        # artifacts so we don't accidentally "find" the test fixture
-        # files that contain the patterns as string literals.
-        # Bounded to 2000 files; on Sunspot's lustre this is ~5s
-        # worst-case, well within the prompt-iteration budget.
-        EXCLUDE_RE='\.(py|pyc|so|pyi|ipynb|md|rst|toml|yaml|yml|json|sh)$|/(\.git|node_modules|__pycache__|\.venv|\.pytest_cache)/'
-        if command -v fd >/dev/null 2>&1; then
-            CANDIDATES=$(fd -HI --type=file . 2>/dev/null \
-                | grep -Ev "${EXCLUDE_RE}" | head -2000)
-        else
-            CANDIDATES=$(find . -type f 2>/dev/null \
-                | grep -Ev "${EXCLUDE_RE}" | head -2000)
-        fi
-        BEST_LOG=""
-        BEST_COUNT=0
-        for f in ${CANDIDATES}; do
-            # `grep -c` prints to stdout AND `|| echo 0` adds its own line
-            # when grep matches nothing — combine both into one integer.
-            count=$(grep -cE "shepherd died from signal 9|Connection closed by peer" "${f}" 2>/dev/null | head -1)
-            count=${count:-0}
-            if (( count > BEST_COUNT )); then
-                BEST_LOG="${f}"
-                BEST_COUNT=${count}
-            fi
-        done
-        if [[ -n "${BEST_LOG}" && ${BEST_COUNT} -gt 0 ]]; then
-            REAL_LOG="${BEST_LOG}"
-            printf "    %sfound%s: %s (%d matching lines)\n" "${G}" "${N}" "${REAL_LOG}" "${BEST_COUNT}"
-        fi
+        # Auto-search across an HPC user's home / lustre is a tarpit —
+        # millions of files, slow stat()s, lazy globbing through fd
+        # doesn't help because `grep -c` per candidate is the real
+        # cost. We tried this; it hung for 90+ seconds and got
+        # Ctrl-C'd. Make this an explicit opt-in instead: user knows
+        # where their logs are, point us at the file.
+        record C SKIP "no \$LOG supplied. Re-run with:
+        LOG=/path/to/known-bad-postmortem.log bash \"\$(python3 -c \\
+            'import ezpz, pathlib; print(pathlib.Path(ezpz.configs.BIN_DIR) / \"test_failover_scrape.sh\")')\"
+    Good candidates: jobs 8459818, 8460301, 8463659, 8470102, 8470103,
+    8479581, 8466848 (cited in scrape_bad_nodes.py docstring as having
+    real shepherd-9 or gloo-peer-closed patterns)."
     else
-        # User-supplied $LOG; report match count so they know whether the
-        # diff will be meaningful. Same single-integer extraction as above.
+        # User-supplied $LOG; report match count so they know whether
+        # the diff will be meaningful.
         match_count=$(grep -cE "shepherd died from signal 9|Connection closed by peer" "${REAL_LOG}" 2>/dev/null | head -1)
         match_count=${match_count:-0}
         printf "    user-supplied log: %s (%d matching lines)\n" "${REAL_LOG}" "${match_count}"
         if (( match_count == 0 )); then
             printf "    %swarning: log has 0 failure patterns; diff being empty proves nothing%s\n" "${Y}" "${N}"
         fi
-    fi
 
-    if [[ -z "${REAL_LOG}" ]]; then
-        record C SKIP "no log with bad-node patterns found in cwd. Set \$LOG=/path/to/postmortem.log to override."
-    else
         # ${OLD_OUT} / ${NEW_OUT} declared above in the trap.
         python3 "${UPSTREAM}"                       "${REAL_LOG}" > "${OLD_OUT}" 2>/dev/null
         python3 -m ezpz.failover --machine aurora   "${REAL_LOG}" > "${NEW_OUT}" 2>/dev/null
@@ -249,9 +224,10 @@ else
         printf "    ezpz emitted:     %d hostname(s)\n" "${NEW_LINES}"
 
         if (( OLD_LINES == 0 && NEW_LINES == 0 )); then
-            # Both empty. This could mean either "log has no patterns" (in
-            # which case both being empty is correct) or "both scrapers are
-            # broken". Report as a soft pass with a clear caveat.
+            # Both empty. This could mean either "log has no patterns"
+            # (in which case both being empty is correct) or "both
+            # scrapers are broken". Report as a soft pass with a clear
+            # caveat.
             record C PASS "both scrapers emitted nothing — consistent, but log may have no patterns"
         elif diff -q "${OLD_OUT}" "${NEW_OUT}" >/dev/null 2>&1; then
             record C PASS "behavior-identical on real log (${NEW_LINES} hostname(s))"

--- a/src/ezpz/bin/test_failover_scrape.sh
+++ b/src/ezpz/bin/test_failover_scrape.sh
@@ -83,8 +83,15 @@ record 0 PASS "ezpz=${EZPZ_VERSION} at ${EZPZ_LOC}"
 # ---- Test A: unit suite ----------------------------------------------------
 
 hdr "A: unit suite (36 tests downloaded from GitHub)"
-TEST_FILE=/tmp/test_failover_scrape.$$.py
-trap 'rm -f "${TEST_FILE}" /tmp/sample_failure.$$.log /tmp/old_scraper.$$.txt /tmp/new_scraper.$$.txt' EXIT
+# Use an underscore (not a dot) before $$ — pytest treats dots in filenames as
+# package-path separators during collection, so `test_failover_scrape.1234.py`
+# triggers `ModuleNotFoundError: No module named 'test_failover_scrape.1234'`
+# even though the file exists.
+TEST_FILE="/tmp/test_failover_scrape_$$.py"
+SAMPLE="/tmp/sample_failure_$$.log"
+OLD_OUT="/tmp/old_scraper_$$.txt"
+NEW_OUT="/tmp/new_scraper_$$.txt"
+trap 'rm -f "${TEST_FILE}" "${SAMPLE}" "${OLD_OUT}" "${NEW_OUT}"' EXIT
 
 # Use curl if available, else fall back to urllib via Python — many Sunspot
 # users don't have a working curl proxy until ezpz_setup runs, but Python's
@@ -108,17 +115,25 @@ fi
 if [[ -n "${TEST_FILE}" && -f "${TEST_FILE}" ]]; then
     if ! python3 -m pytest --version >/dev/null 2>&1; then
         record A SKIP "pytest not available in this env"
-    elif python3 -m pytest "${TEST_FILE}" -q 2>&1 | tail -5; then
-        record A PASS "all 36 unit tests pass"
     else
-        record A FAIL "pytest reported failures — see output above"
+        # Run pytest; print its tail-5 for context but check pytest's
+        # OWN exit code via PIPESTATUS, not tail's. `if cmd | tail` would
+        # always be "true" because tail always exits 0 even when cmd fails
+        # (which is how a collection error got reported as PASS earlier).
+        python3 -m pytest "${TEST_FILE}" -q 2>&1 | tail -5
+        pytest_rc=${PIPESTATUS[0]}
+        if (( pytest_rc == 0 )); then
+            record A PASS "all unit tests pass"
+        else
+            record A FAIL "pytest exit ${pytest_rc} — see output above"
+        fi
     fi
 fi
 
 # ---- Test B: CLI smoke -----------------------------------------------------
 
 hdr "B: CLI smoke — synthetic log + --explain"
-SAMPLE=/tmp/sample_failure.$$.log
+# ${SAMPLE} declared above in the trap.
 cat > "${SAMPLE}" <<'EOF'
 [2026-05-23 12:34:56] training step=42 loss=2.4
 x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9
@@ -175,13 +190,21 @@ else
 
     if [[ -z "${REAL_LOG}" ]]; then
         printf "    searching for a log with real failure patterns (this may take a few seconds)...\n"
-        # Search the current directory for .log files containing either
-        # pattern. Use `fd` if available (much faster), else `find`.
-        # Limit search to the first 200 files to keep it bounded.
+        # Search the current directory for files that COULD contain the
+        # failure patterns. We can't filter by .log extension only —
+        # PBS sometimes writes to .out/.err and ezpz uses .jsonl/.log
+        # interchangeably. But explicitly EXCLUDE source files / build
+        # artifacts so we don't accidentally "find" the test fixture
+        # files that contain the patterns as string literals.
+        # Bounded to 2000 files; on Sunspot's lustre this is ~5s
+        # worst-case, well within the prompt-iteration budget.
+        EXCLUDE_RE='\.(py|pyc|so|pyi|ipynb|md|rst|toml|yaml|yml|json|sh)$|/(\.git|node_modules|__pycache__|\.venv|\.pytest_cache)/'
         if command -v fd >/dev/null 2>&1; then
-            CANDIDATES=$(fd -HI -e log 2>/dev/null | head -200)
+            CANDIDATES=$(fd -HI --type=file . 2>/dev/null \
+                | grep -Ev "${EXCLUDE_RE}" | head -2000)
         else
-            CANDIDATES=$(find . -name '*.log' 2>/dev/null | head -200)
+            CANDIDATES=$(find . -type f 2>/dev/null \
+                | grep -Ev "${EXCLUDE_RE}" | head -2000)
         fi
         BEST_LOG=""
         BEST_COUNT=0
@@ -213,16 +236,15 @@ else
     if [[ -z "${REAL_LOG}" ]]; then
         record C SKIP "no log with bad-node patterns found in cwd. Set \$LOG=/path/to/postmortem.log to override."
     else
-        OLD=/tmp/old_scraper.$$.txt
-        NEW=/tmp/new_scraper.$$.txt
-        python3 "${UPSTREAM}"                       "${REAL_LOG}" > "${OLD}" 2>/dev/null
-        python3 -m ezpz.failover --machine aurora   "${REAL_LOG}" > "${NEW}" 2>/dev/null
+        # ${OLD_OUT} / ${NEW_OUT} declared above in the trap.
+        python3 "${UPSTREAM}"                       "${REAL_LOG}" > "${OLD_OUT}" 2>/dev/null
+        python3 -m ezpz.failover --machine aurora   "${REAL_LOG}" > "${NEW_OUT}" 2>/dev/null
 
         # `wc -l <file` pads with whitespace on some systems; strip it
         # so the printf %d works and the eventual `(${NEW_LINES} hostname(s))`
         # message isn't misaligned.
-        OLD_LINES=$(wc -l < "${OLD}" | tr -d ' ')
-        NEW_LINES=$(wc -l < "${NEW}" | tr -d ' ')
+        OLD_LINES=$(wc -l < "${OLD_OUT}" | tr -d ' ')
+        NEW_LINES=$(wc -l < "${NEW_OUT}" | tr -d ' ')
         printf "    upstream emitted: %d hostname(s)\n" "${OLD_LINES}"
         printf "    ezpz emitted:     %d hostname(s)\n" "${NEW_LINES}"
 
@@ -231,11 +253,11 @@ else
             # which case both being empty is correct) or "both scrapers are
             # broken". Report as a soft pass with a clear caveat.
             record C PASS "both scrapers emitted nothing — consistent, but log may have no patterns"
-        elif diff -q "${OLD}" "${NEW}" >/dev/null 2>&1; then
+        elif diff -q "${OLD_OUT}" "${NEW_OUT}" >/dev/null 2>&1; then
             record C PASS "behavior-identical on real log (${NEW_LINES} hostname(s))"
         else
             record C FAIL "scrapers DISAGREE on real log — diff:"
-            diff "${OLD}" "${NEW}" | sed 's/^/        /'
+            diff "${OLD_OUT}" "${NEW_OUT}" | sed 's/^/        /'
         fi
     fi
 fi

--- a/src/ezpz/failover/__init__.py
+++ b/src/ezpz/failover/__init__.py
@@ -1,0 +1,20 @@
+"""Bad-node failover support for distributed training on HPC clusters.
+
+This package provides the primitives the (forthcoming) failover
+wrapper builds on:
+
+  - :func:`scrape_bad_nodes` — parse a training log for known
+    failure-mode signatures and return the bad hostnames.
+  - :mod:`ezpz.failover.patterns` — per-machine pattern registry
+    (Aurora bundled, others addable).
+
+The shell-level orchestration (split nodefile, yeet env, swap in
+spares, retry) lives in ``src/ezpz/bin/failover.sh`` and is
+introduced in a separate PR.
+"""
+
+from __future__ import annotations
+
+from ezpz.failover.scrape import scrape_bad_nodes
+
+__all__ = ["scrape_bad_nodes"]

--- a/src/ezpz/failover/__main__.py
+++ b/src/ezpz/failover/__main__.py
@@ -1,0 +1,78 @@
+"""CLI entry point: ``python -m ezpz.failover <log-file>``.
+
+Drop-in replacement for the old ``scrape_bad_nodes.py`` script that
+lived in torchtitan. Reads one log file, prints one bad hostname per
+line on stdout (deduplicated, first-seen order). Exits non-zero on
+usage errors; exits 0 even when nothing was matched (silence here
+means "no actionable hostname", not "log was clean").
+
+Usage:
+    python -m ezpz.failover <log-file>
+    python -m ezpz.failover --machine aurora <log-file>
+    python -m ezpz.failover --explain <log-file>   # per-pattern breakdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ezpz.failover.scrape import (
+    _collect_all_matches_for_debug,
+    scrape_bad_nodes,
+)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m ezpz.failover",
+        description=(
+            "Scrape a training log for bad-node hostnames. Prints one "
+            "hostname per line. Exit 0 even when nothing matched."
+        ),
+    )
+    parser.add_argument(
+        "log_file",
+        type=Path,
+        help="Path to the training log to scrape.",
+    )
+    parser.add_argument(
+        "--machine",
+        default=None,
+        help=(
+            "Override machine detection (e.g. 'aurora'). Defaults to "
+            "the result of ezpz.get_machine() lower-cased."
+        ),
+    )
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "Print a per-pattern breakdown to stderr in addition to "
+            "the deduplicated hostnames on stdout. Useful when "
+            "postmorteming an unfamiliar failure mode."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.log_file.is_file():
+        print(f"log file not found: {args.log_file}", file=sys.stderr)
+        return 1
+
+    if args.explain:
+        per_pattern = _collect_all_matches_for_debug(
+            args.log_file, machine=args.machine
+        )
+        print("[explain] per-pattern matches:", file=sys.stderr)
+        for name, hosts in per_pattern.items():
+            print(f"  {name}: {hosts or '<none>'}", file=sys.stderr)
+
+    hosts = scrape_bad_nodes(args.log_file, machine=args.machine)
+    for host in hosts:
+        print(host)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ezpz/failover/patterns/__init__.py
+++ b/src/ezpz/failover/patterns/__init__.py
@@ -41,8 +41,13 @@ class BadNodePattern:
             Used in log messages so postmortem reviewers know which
             pattern fired.
         extractor: Callable that takes the full log text and yields
-            hostnames or IPs. Yielding IPs is fine — the registry's
-            ``resolve_to_hostname`` step handles reverse-resolution.
+            hostnames (and only hostnames). If the underlying log
+            shape gives you IPs (e.g. the gloo "Connection closed by
+            peer [IP]:port" line), the extractor is responsible for
+            doing the IP→hostname conversion itself — the registry
+            does NOT do a resolve step. Use :func:`reverse_resolve_ip`
+            from this module to handle the lookup the same way the
+            Aurora patterns do.
         description: One-line plain-English summary for help text +
             postmortem notes.
     """
@@ -64,25 +69,48 @@ def register_patterns(
     hostname_normalizer: "Callable[[str], str | None] | None" = None,
 ) -> None:
     """Register a set of patterns + an optional hostname normalizer for
-    a machine. Idempotent — calling twice with the same machine replaces
-    the previous registration (lets tests inject mock patterns)."""
+    a machine. Idempotent — calling twice with the same machine
+    replaces the previous registration (lets tests inject mocks).
+
+    Re-registration FULLY replaces the previous state, including the
+    normalizer slot: passing ``hostname_normalizer=None`` clears any
+    previously-registered normalizer for this machine. Otherwise the
+    old normalizer would silently apply to the new pattern set, which
+    bit us in early development.
+    """
     _PATTERNS[machine] = list(patterns)
     if hostname_normalizer is not None:
         _HOSTNAME_NORMALIZERS[machine] = hostname_normalizer
+    else:
+        # Clear any prior registration. This makes re-registration
+        # truly idempotent regardless of whether the new caller
+        # supplied a normalizer.
+        _HOSTNAME_NORMALIZERS.pop(machine, None)
 
 
 def get_patterns_for_machine(machine: str) -> list[BadNodePattern]:
     """Return the patterns registered for *machine*. Lazy-imports the
     per-machine module on first access so we don't pay the import cost
-    for machines that aren't being used."""
+    for machines that aren't being used.
+
+    Only "no such per-machine module" is silently treated as "unknown
+    machine"; any OTHER ImportError (a missing dep, a syntax error,
+    etc. INSIDE a known machine module) is re-raised so it surfaces
+    instead of looking like an unsupported cluster.
+    """
     if machine not in _PATTERNS:
-        # Try to import the per-machine module; it should register itself
-        # at import time. Swallow ImportError for unknown machines so the
-        # caller gets an empty list (and can decide whether to warn).
+        module_name = f"ezpz.failover.patterns.{machine}"
         try:
-            importlib.import_module(f"ezpz.failover.patterns.{machine}")
-        except ImportError:
-            pass
+            importlib.import_module(module_name)
+        except ImportError as exc:
+            # `name` on ImportError tells us which module the import
+            # machinery couldn't find. If it matches the one we asked
+            # for, the machine genuinely doesn't have a pattern module
+            # → return [] silently. If it matches some OTHER module
+            # (e.g. the machine module exists but imports a missing
+            # dep), re-raise so the failure isn't swallowed.
+            if getattr(exc, "name", None) != module_name:
+                raise
     return _PATTERNS.get(machine, [])
 
 

--- a/src/ezpz/failover/patterns/__init__.py
+++ b/src/ezpz/failover/patterns/__init__.py
@@ -1,0 +1,147 @@
+"""Per-machine bad-node detection patterns.
+
+Each ALCF / NERSC / OLCF system has its own failure-mode signatures —
+PALS shepherd messages on Aurora, NCCL timeouts on Polaris, etc. —
+and its own hostname conventions for resolving an IP back to a node.
+This package defines a small registry so :func:`ezpz.failover.scrape`
+can dispatch to the right pattern set based on the detected machine.
+
+To add support for a new machine:
+
+  1. Create ``src/ezpz/failover/patterns/<machine>.py`` with one or
+     more :class:`BadNodePattern` instances.
+  2. Register them via :func:`register_patterns` at module import.
+  3. The module gets imported automatically by
+     :func:`get_patterns_for_machine` when needed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+# Pattern types --------------------------------------------------------------
+
+# A pattern's ``match`` callable receives the FULL log text (not a stream of
+# lines) and yields zero or more bad-host strings (possibly raw IPs that need
+# resolution). Returning an iterable rather than a list keeps memory bounded
+# on very large logs — the caller deduplicates downstream.
+HostExtractor = Callable[[str], Iterable[str]]
+
+
+@dataclass(frozen=True)
+class BadNodePattern:
+    """A single failure-mode signature for one machine.
+
+    Args:
+        name: Human-readable identifier (``"aurora.shepherd_signal_9"``).
+            Used in log messages so postmortem reviewers know which
+            pattern fired.
+        extractor: Callable that takes the full log text and yields
+            hostnames or IPs. Yielding IPs is fine — the registry's
+            ``resolve_to_hostname`` step handles reverse-resolution.
+        description: One-line plain-English summary for help text +
+            postmortem notes.
+    """
+
+    name: str
+    extractor: HostExtractor
+    description: str
+
+
+# Machine registry -----------------------------------------------------------
+
+_PATTERNS: dict[str, list[BadNodePattern]] = {}
+_HOSTNAME_NORMALIZERS: dict[str, Callable[[str], "str | None"]] = {}
+
+
+def register_patterns(
+    machine: str,
+    patterns: list[BadNodePattern],
+    hostname_normalizer: "Callable[[str], str | None] | None" = None,
+) -> None:
+    """Register a set of patterns + an optional hostname normalizer for
+    a machine. Idempotent — calling twice with the same machine replaces
+    the previous registration (lets tests inject mock patterns)."""
+    _PATTERNS[machine] = list(patterns)
+    if hostname_normalizer is not None:
+        _HOSTNAME_NORMALIZERS[machine] = hostname_normalizer
+
+
+def get_patterns_for_machine(machine: str) -> list[BadNodePattern]:
+    """Return the patterns registered for *machine*. Lazy-imports the
+    per-machine module on first access so we don't pay the import cost
+    for machines that aren't being used."""
+    if machine not in _PATTERNS:
+        # Try to import the per-machine module; it should register itself
+        # at import time. Swallow ImportError for unknown machines so the
+        # caller gets an empty list (and can decide whether to warn).
+        try:
+            importlib.import_module(f"ezpz.failover.patterns.{machine}")
+        except ImportError:
+            pass
+    return _PATTERNS.get(machine, [])
+
+
+def get_hostname_normalizer(
+    machine: str,
+) -> "Callable[[str], str | None] | None":
+    """Return the hostname normalizer for *machine* (or None)."""
+    # Trigger registration if not yet loaded.
+    get_patterns_for_machine(machine)
+    return _HOSTNAME_NORMALIZERS.get(machine)
+
+
+# Shared helpers (used by per-machine modules) -------------------------------
+
+def reverse_resolve_ip(ip: str, timeout_s: float = 5.0) -> "str | None":
+    """Reverse-resolve an IP to a hostname via ``getent hosts``.
+
+    Returns the first hostname token in the lookup result, or None if
+    the lookup fails (binary missing, timeout, empty result). The
+    caller is responsible for further canonicalization (e.g. mapping
+    to the cluster's HSN form).
+
+    ``getent`` is preferred over ``socket.gethostbyaddr`` because it
+    honors ``/etc/hosts`` + ``nsswitch.conf`` config — the IPs in
+    gloo error messages are usually on the HSN fabric and only
+    resolvable through the cluster's name service.
+    """
+    try:
+        out = subprocess.check_output(
+            ["getent", "hosts", ip],
+            text=True,
+            timeout=timeout_s,
+        ).strip()
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        return None
+    if not out:
+        return None
+    # `getent hosts <ip>` → `<ip>  <hostname1> <hostname2>...`
+    parts = out.split()
+    if len(parts) >= 2:
+        return parts[1]
+    return None
+
+
+def compile_multiline(pattern: str) -> "re.Pattern[str]":
+    """Compile *pattern* with ``re.MULTILINE`` set. Convenience for
+    per-machine modules whose patterns all anchor on line starts."""
+    return re.compile(pattern, re.MULTILINE)
+
+
+__all__ = [
+    "BadNodePattern",
+    "register_patterns",
+    "get_patterns_for_machine",
+    "get_hostname_normalizer",
+    "reverse_resolve_ip",
+    "compile_multiline",
+]

--- a/src/ezpz/failover/patterns/aurora.py
+++ b/src/ezpz/failover/patterns/aurora.py
@@ -65,7 +65,9 @@ def _extract_shepherd_sig9(log_text: str) -> Iterable[str]:
 # Gloo errors typically point at a single peer IP across many
 # "Connection closed" lines (every rank that was talking to the dead
 # node logs its own copy), so deduplication usually collapses to one
-# node. We yield IPs here; the caller resolves them.
+# node. We reverse-resolve the IP to a hostname here (using the
+# shared `reverse_resolve_ip` helper) and yield hostnames; the
+# scraper's downstream normalizer canonicalizes the suffix.
 # ---------------------------------------------------------------------------
 _GLOO_PEER_RX = compile_multiline(
     r"Connection closed by peer\s+\[([0-9.]+)\]:\d+",
@@ -92,7 +94,14 @@ def _extract_gloo_peer(log_text: str) -> Iterable[str]:
 _AURORA_HSN_RX = re.compile(
     r"^x\d+c\d+s\d+b\d+n\d+\.hsn\.cm\.aurora\.alcf\.anl\.gov$"
 )
-_AURORA_NODE_PREFIX_RX = re.compile(r"^(x\d+c\d+s\d+b\d+n\d+)\.")
+# The .hostmgmtNNNN.cm.aurora.alcf.anl.gov form is the management
+# interface; we know it maps 1:1 to the HSN interface and is safe to
+# rewrite. Any OTHER suffix on a `x...n0.` host is something we
+# haven't seen and shouldn't speculatively rewrite — better to drop
+# (return None) than risk tagging a wrong node.
+_AURORA_HOSTMGMT_RX = re.compile(
+    r"^(x\d+c\d+s\d+b\d+n\d+)\.hostmgmt\d+\.cm\.aurora\.alcf\.anl\.gov$"
+)
 
 
 def normalize_aurora_hostname(host: str) -> "str | None":
@@ -100,13 +109,14 @@ def normalize_aurora_hostname(host: str) -> "str | None":
     None if *host* doesn't look like a valid Aurora compute hostname.
 
     Examples (in → out):
-      ``x1234c0s0b0n0.hsn.cm.aurora.alcf.anl.gov`` → unchanged
-      ``x1234c0s0b0n0.hostmgmt2042.cm.aurora.alcf.anl.gov`` → HSN form
-      ``some-other-host``                          → None
+      ``x1234c0s0b0n0.hsn.cm.aurora.alcf.anl.gov``           → unchanged
+      ``x1234c0s0b0n0.hostmgmt2042.cm.aurora.alcf.anl.gov``  → HSN form
+      ``x1234c0s0b0n0.something-else.example.com``           → None
+      ``some-other-host``                                    → None
     """
     if _AURORA_HSN_RX.match(host):
         return host
-    m = _AURORA_NODE_PREFIX_RX.match(host)
+    m = _AURORA_HOSTMGMT_RX.match(host)
     if m:
         return f"{m.group(1)}.hsn.cm.aurora.alcf.anl.gov"
     return None

--- a/src/ezpz/failover/patterns/aurora.py
+++ b/src/ezpz/failover/patterns/aurora.py
@@ -1,0 +1,148 @@
+"""Aurora-specific bad-node failure patterns.
+
+These patterns were derived from postmortem analysis of real Aurora
+training jobs. Each one is tied to a specific failure mode we've
+seen take down a production training run:
+
+  - **shepherd_signal_9** — PALS shepherd kill (node went bad
+    mid-run). Aurora's most common hardware failure mode.
+    Seen on jobs 8459818 / 8460301 / 8463659.
+
+  - **gloo_connection_closed** — gloo TCP failure, usually one
+    bad node taking down peer connections from many ranks. We
+    reverse-resolve the IP to a hostname.
+    Seen on jobs 8470102 / 8470103 / 8479581.
+
+We DO NOT match ``rank N died from signal {11,15}`` because those
+are almost always cascading deaths from a primary kill elsewhere on
+a *different* node. Including them would falsely tag innocent nodes
+(e.g. job 8466848 had rank 1304 die from signal 11 as a downstream
+effect of a ``std::bad_alloc`` on rank 2413 — the kill happened on
+the *first* node, but the signal-11 message named the *second*).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from ezpz.failover.patterns import (
+    BadNodePattern,
+    compile_multiline,
+    register_patterns,
+    reverse_resolve_ip,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1: PALS shepherd kill
+#
+# Log line shape:
+#     xNNNNcNsNbNnN.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9
+#
+# The hostname prefix is the literal compute node — PALS prepends it to
+# every shepherd-level message. signal 9 = SIGKILL, sent by the runtime
+# when the node-local daemon went non-responsive. Almost always a
+# hardware fault (memory corruption, fabric flap, kernel hang).
+# ---------------------------------------------------------------------------
+_SHEPHERD_SIG9_RX = compile_multiline(
+    r"^([a-zA-Z0-9.-]+\.hsn\.cm\.aurora\.alcf\.anl\.gov):\s+"
+    r"shepherd\s+died\s+from\s+signal\s+9\b",
+)
+
+
+def _extract_shepherd_sig9(log_text: str) -> Iterable[str]:
+    for m in _SHEPHERD_SIG9_RX.finditer(log_text):
+        yield m.group(1)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2: gloo TCP peer-closed
+#
+# Log line shape (one of many — gloo wraps in RuntimeError):
+#     RuntimeError: [..gloo..] Connection closed by peer [10.0.0.42]:12345
+#
+# Gloo errors typically point at a single peer IP across many
+# "Connection closed" lines (every rank that was talking to the dead
+# node logs its own copy), so deduplication usually collapses to one
+# node. We yield IPs here; the caller resolves them.
+# ---------------------------------------------------------------------------
+_GLOO_PEER_RX = compile_multiline(
+    r"Connection closed by peer\s+\[([0-9.]+)\]:\d+",
+)
+
+
+def _extract_gloo_peer(log_text: str) -> Iterable[str]:
+    for m in _GLOO_PEER_RX.finditer(log_text):
+        ip = m.group(1)
+        host = reverse_resolve_ip(ip)
+        if host is not None:
+            yield host
+
+
+# ---------------------------------------------------------------------------
+# Hostname normalizer
+#
+# PBS hostfile entries are in the `.hsn.cm.aurora.alcf.anl.gov` form
+# (the HSN fabric's name service). Other parts of Aurora occasionally
+# emit the `.hostmgmtNNNN.cm.aurora...` management form. We normalize
+# everything to the HSN form so swap_in (which greps the active
+# hostfile) actually finds matches.
+# ---------------------------------------------------------------------------
+_AURORA_HSN_RX = re.compile(
+    r"^x\d+c\d+s\d+b\d+n\d+\.hsn\.cm\.aurora\.alcf\.anl\.gov$"
+)
+_AURORA_NODE_PREFIX_RX = re.compile(r"^(x\d+c\d+s\d+b\d+n\d+)\.")
+
+
+def normalize_aurora_hostname(host: str) -> "str | None":
+    """Return the canonical ``.hsn.cm.aurora.alcf.anl.gov`` form, or
+    None if *host* doesn't look like a valid Aurora compute hostname.
+
+    Examples (in → out):
+      ``x1234c0s0b0n0.hsn.cm.aurora.alcf.anl.gov`` → unchanged
+      ``x1234c0s0b0n0.hostmgmt2042.cm.aurora.alcf.anl.gov`` → HSN form
+      ``some-other-host``                          → None
+    """
+    if _AURORA_HSN_RX.match(host):
+        return host
+    m = _AURORA_NODE_PREFIX_RX.match(host)
+    if m:
+        return f"{m.group(1)}.hsn.cm.aurora.alcf.anl.gov"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Register at import time
+# ---------------------------------------------------------------------------
+AURORA_PATTERNS = [
+    BadNodePattern(
+        name="aurora.shepherd_signal_9",
+        extractor=_extract_shepherd_sig9,
+        description=(
+            "PALS shepherd kill (signal 9). Node-local daemon went "
+            "non-responsive; almost always a hardware fault."
+        ),
+    ),
+    BadNodePattern(
+        name="aurora.gloo_connection_closed",
+        extractor=_extract_gloo_peer,
+        description=(
+            "gloo TCP peer-connection closed. IP reverse-resolved to "
+            "an Aurora HSN hostname."
+        ),
+    ),
+]
+
+register_patterns(
+    "aurora",
+    AURORA_PATTERNS,
+    hostname_normalizer=normalize_aurora_hostname,
+)
+# NOTE: Sunspot uses the same XPU fabric + PALS shepherd as Aurora,
+# so the patterns SHOULD apply — but the full hostname suffix differs
+# from Aurora's `.hsn.cm.aurora.alcf.anl.gov`. We haven't postmortemed
+# a real Sunspot failure yet to confirm the exact suffix shape, so the
+# Aurora pattern is NOT auto-registered for sunspot here. Add a
+# dedicated `sunspot.py` module once a real failure provides the
+# hostname format to match against.

--- a/src/ezpz/failover/scrape.py
+++ b/src/ezpz/failover/scrape.py
@@ -26,7 +26,6 @@ succeeded, only that the patterns couldn't pinpoint a culprit.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
 
 from ezpz.failover.patterns import (
     get_hostname_normalizer,
@@ -47,6 +46,20 @@ def _detect_machine() -> str:
         return ezpz.get_machine().lower()
     except Exception:
         return ""
+
+
+def _resolve_machine_key(machine: "str | None") -> str:
+    """Pick the registry lookup key from an optional caller override.
+
+    Registry keys are always lowercase (Aurora's module registers
+    itself as ``"aurora"``). The auto-detect path already lowercases
+    the result of ``ezpz.get_machine()``, but an explicit override
+    arrives verbatim — so ``scrape_bad_nodes(log, machine="Aurora")``
+    would silently miss every pattern unless we normalize here too.
+    """
+    if machine is None:
+        return _detect_machine()
+    return machine.lower()
 
 
 def scrape_bad_nodes(
@@ -83,8 +96,7 @@ def scrape_bad_nodes(
     if not log_path.is_file():
         raise FileNotFoundError(f"log file not found: {log_path}")
 
-    if machine is None:
-        machine = _detect_machine()
+    machine = _resolve_machine_key(machine)
     patterns = get_patterns_for_machine(machine)
     if not patterns:
         # No registered patterns → nothing to do. Returning [] (rather
@@ -93,6 +105,11 @@ def scrape_bad_nodes(
         return []
 
     normalize = get_hostname_normalizer(machine)
+    # NOTE: this reads the entire log into memory. In practice
+    # postmortem logs we've handled (multi-rank Aurora training,
+    # hundreds of MB to a couple GB) fit fine on the head node where
+    # failover runs. If you hit a 10+ GB log, pre-trim it with
+    # `tail -c 1G` or similar before passing to this function.
     text = log_path.read_text(errors="replace")
 
     seen_order: list[str] = []
@@ -122,17 +139,23 @@ def _collect_all_matches_for_debug(
     fired, not just that *some* pattern fired.
     """
     log_path = Path(log_path)
-    if machine is None:
-        machine = _detect_machine()
+    machine = _resolve_machine_key(machine)
     patterns = get_patterns_for_machine(machine)
     text = log_path.read_text(errors="replace")
     normalize = get_hostname_normalizer(machine)
     out: dict[str, list[str]] = {}
     for pattern in patterns:
+        # Track seen separately so dedup is O(1) per check; otherwise
+        # `host not in matches` is O(n) and the whole loop quadratic
+        # on patterns that fire across many ranks (gloo peer-closed
+        # routinely emits dozens of copies of the same host).
         matches: list[str] = []
+        seen: set[str] = set()
         for raw_host in pattern.extractor(text):
             host = normalize(raw_host) if normalize else raw_host
-            if host is not None and host not in matches:
-                matches.append(host)
+            if host is None or host in seen:
+                continue
+            seen.add(host)
+            matches.append(host)
         out[pattern.name] = matches
     return out

--- a/src/ezpz/failover/scrape.py
+++ b/src/ezpz/failover/scrape.py
@@ -1,0 +1,138 @@
+"""Scrape training logs for bad-node hostnames.
+
+The public entry point is :func:`scrape_bad_nodes`. It takes a path
+to a training log and returns a deduplicated list of bad hostnames
+in first-seen order. The patterns it matches are per-machine —
+Aurora's PALS shepherd kills and gloo TCP failures are bundled by
+default; other systems can register their own via the
+:mod:`ezpz.failover.patterns` registry.
+
+Typical usage from a failover wrapper::
+
+    from ezpz.failover import scrape_bad_nodes
+
+    hosts = scrape_bad_nodes("/path/to/attempt-1.log")
+    if hosts:
+        swap_in(hosts)
+    else:
+        swap_one_blind()  # nothing specific identified; rotate a spare
+
+When no hostnames are matched the caller should treat that as
+"failure with no actionable hostname" and apply whatever its
+blind-rotation policy is — silence here does NOT mean the run
+succeeded, only that the patterns couldn't pinpoint a culprit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from ezpz.failover.patterns import (
+    get_hostname_normalizer,
+    get_patterns_for_machine,
+)
+
+
+def _detect_machine() -> str:
+    """Best-effort detection of the current machine via ezpz's existing
+    hostname → machine mapping. Imported lazily so the scrape module
+    itself doesn't pull in the rest of ezpz when only the pattern
+    helpers are needed (e.g. by unit tests)."""
+    try:
+        import ezpz  # noqa: PLC0415
+    except ImportError:
+        return ""
+    try:
+        return ezpz.get_machine().lower()
+    except Exception:
+        return ""
+
+
+def scrape_bad_nodes(
+    log_path: "str | Path",
+    *,
+    machine: "str | None" = None,
+) -> list[str]:
+    """Return the deduplicated list of bad hostnames in *log_path*.
+
+    Args:
+        log_path: Path to the training log file. Read in full as
+            text (errors='replace' so binary garbage in the middle
+            of a log doesn't crash the scrape — these logs are
+            sometimes >1GB and partially corrupted by mid-write
+            crashes, and the patterns we care about always appear
+            on lines that are clean ASCII).
+        machine: Override machine detection. Defaults to the result
+            of :func:`ezpz.get_machine`. Pass an explicit value
+            (``"aurora"``, ``"polaris"``, ...) for tests or when
+            scraping logs from a different cluster than the one
+            running this code.
+
+    Returns:
+        Bad hostnames in first-seen order, deduplicated. Hostnames
+        are canonicalized via the machine's hostname normalizer if
+        one is registered (e.g. Aurora maps everything to the
+        ``.hsn.cm.aurora.alcf.anl.gov`` form so downstream swap-in
+        logic matches the PBS hostfile entries).
+
+        Returns ``[]`` when no patterns matched OR when there is no
+        pattern set registered for the detected machine.
+    """
+    log_path = Path(log_path)
+    if not log_path.is_file():
+        raise FileNotFoundError(f"log file not found: {log_path}")
+
+    if machine is None:
+        machine = _detect_machine()
+    patterns = get_patterns_for_machine(machine)
+    if not patterns:
+        # No registered patterns → nothing to do. Returning [] (rather
+        # than raising) lets the caller's blind-rotation fallback fire,
+        # which is the right behavior for unknown failure modes too.
+        return []
+
+    normalize = get_hostname_normalizer(machine)
+    text = log_path.read_text(errors="replace")
+
+    seen_order: list[str] = []
+    seen_set: set[str] = set()
+
+    for pattern in patterns:
+        for raw_host in pattern.extractor(text):
+            host = normalize(raw_host) if normalize else raw_host
+            if host is None:
+                continue
+            if host in seen_set:
+                continue
+            seen_order.append(host)
+            seen_set.add(host)
+
+    return seen_order
+
+
+def _collect_all_matches_for_debug(
+    log_path: "str | Path",
+    *,
+    machine: "str | None" = None,
+) -> dict[str, list[str]]:
+    """Per-pattern breakdown of what the scraper matched. Not part of
+    the public API — used by the CLI's ``--explain`` mode (when
+    that's added) and by tests that want to verify a specific pattern
+    fired, not just that *some* pattern fired.
+    """
+    log_path = Path(log_path)
+    if machine is None:
+        machine = _detect_machine()
+    patterns = get_patterns_for_machine(machine)
+    text = log_path.read_text(errors="replace")
+    normalize = get_hostname_normalizer(machine)
+    out: dict[str, list[str]] = {}
+    for pattern in patterns:
+        matches: list[str] = []
+        for raw_host in pattern.extractor(text):
+            host = normalize(raw_host) if normalize else raw_host
+            if host is not None and host not in matches:
+                matches.append(host)
+        out[pattern.name] = matches
+    return out

--- a/tests/test_failover_scrape.py
+++ b/tests/test_failover_scrape.py
@@ -357,3 +357,263 @@ class TestPatternRegistry:
                 "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov"
             ],
         }
+
+    def test_re_register_without_normalizer_clears_old_normalizer(
+        self, tmp_path
+    ):
+        """REGRESSION: re-registering a machine with
+        ``hostname_normalizer=None`` must clear any previously-
+        registered normalizer. Without this, tests (and real plugin
+        callers) that re-register the same key with raw hostnames
+        would silently keep applying the old normalizer and either
+        rewrite or drop the new pattern's outputs.
+        """
+        from ezpz.failover.patterns import get_hostname_normalizer
+
+        # First registration: WITH a normalizer.
+        register_patterns(
+            "test-clear-norm",
+            [BadNodePattern("p1", lambda _t: ["x"], "")],
+            hostname_normalizer=lambda h: f"normalized-{h}",
+        )
+        assert get_hostname_normalizer("test-clear-norm") is not None
+
+        # Re-register WITHOUT a normalizer.
+        register_patterns(
+            "test-clear-norm",
+            [BadNodePattern("p2", lambda _t: ["y"], "")],
+        )
+        assert get_hostname_normalizer("test-clear-norm") is None, (
+            "Old normalizer must be cleared on re-registration without one"
+        )
+
+    def test_import_error_inside_known_module_surfaces(
+        self, tmp_path, monkeypatch
+    ):
+        """REGRESSION: if a per-machine pattern module exists but has
+        a real import problem inside it (missing dep, syntax error,
+        circular import), the registry should re-raise rather than
+        silently behaving as "unknown machine". Otherwise debugging
+        why "aurora" suddenly returns [] becomes a nightmare.
+        """
+        from ezpz.failover.patterns import get_patterns_for_machine
+
+        # Make importlib.import_module raise an ImportError that names
+        # a DIFFERENT module than the one we're asking for — that's the
+        # signature of "module exists but fails to load some dep".
+        def _import_fail(name):
+            raise ImportError(
+                "No module named 'unrelated_dep'",
+                name="unrelated_dep",
+            )
+
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.importlib.import_module", _import_fail
+        )
+        # Use an unregistered machine so the lookup falls through to
+        # the import path.
+        with pytest.raises(ImportError, match="unrelated_dep"):
+            get_patterns_for_machine("never-registered-machine")
+
+    def test_import_error_for_unknown_machine_silent(self, monkeypatch):
+        """Counterpoint to the above: if the per-machine module simply
+        doesn't exist, that's the "unknown machine" case and should
+        return [] silently."""
+        from ezpz.failover.patterns import get_patterns_for_machine
+
+        def _import_fail(name):
+            raise ImportError(
+                f"No module named '{name}'",
+                name=name,
+            )
+
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.importlib.import_module", _import_fail
+        )
+        # Pattern registry lookup for a genuinely unknown machine →
+        # silent empty list, no exception.
+        assert get_patterns_for_machine("definitely-not-a-machine") == []
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection path (machine=None)
+# ---------------------------------------------------------------------------
+
+class TestAutoDetectMachine:
+    """Coverage for the ``machine=None`` code path that pulls machine
+    name from ``ezpz.get_machine()``. The rest of the suite passes
+    an explicit ``machine="aurora"`` and skips this dispatch."""
+
+    def test_auto_detect_uses_lowercased_ezpz_machine(
+        self, tmp_path, monkeypatch
+    ):
+        """``ezpz.get_machine()`` returns title-case (``"Aurora"``);
+        registry keys are lowercase. The auto-detect path must
+        lowercase the result before lookup."""
+        import ezpz
+        monkeypatch.setattr(ezpz, "get_machine", lambda: "Aurora")
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log)  # no machine= arg
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_explicit_machine_arg_also_normalized(self, tmp_path):
+        """Explicit override is also lowercased — passing ``"Aurora"``
+        (matching the casing of ``ezpz.get_machine()``'s output)
+        should find the registered ``"aurora"`` patterns. Pre-fix this
+        silently returned []."""
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="Aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_auto_detect_handles_get_machine_raising(
+        self, tmp_path, monkeypatch
+    ):
+        """If ``ezpz.get_machine()`` itself raises (unlikely but
+        possible — e.g. called before distributed setup), the scraper
+        falls back to an empty-string machine name, which means
+        "no patterns" → empty list, NOT a crash."""
+        import ezpz
+
+        def _raise():
+            raise RuntimeError("get_machine failed")
+
+        monkeypatch.setattr(ezpz, "get_machine", _raise)
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+        ))
+        # No crash; empty list because no patterns registered for "".
+        assert scrape_bad_nodes(log) == []
+
+
+# ---------------------------------------------------------------------------
+# Helper: reverse_resolve_ip
+# ---------------------------------------------------------------------------
+
+class TestReverseResolveIp:
+    """The other suites all monkeypatch this away. Cover the real
+    implementation here against mocked ``subprocess.check_output``."""
+
+    def test_success_returns_first_hostname(self, monkeypatch):
+        from ezpz.failover.patterns import reverse_resolve_ip
+        # `getent hosts <ip>` shape:
+        #   "10.0.0.42  some-host.example.com other-host.example.com"
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.subprocess.check_output",
+            lambda *a, **kw: (
+                "10.0.0.42  primary.example.com secondary.example.com\n"
+            ),
+        )
+        assert reverse_resolve_ip("10.0.0.42") == "primary.example.com"
+
+    def test_called_process_error_returns_none(self, monkeypatch):
+        """Non-zero exit (IP not in any name service) → None."""
+        import subprocess
+        from ezpz.failover.patterns import reverse_resolve_ip
+
+        def _raise(*a, **kw):
+            raise subprocess.CalledProcessError(2, ["getent"])
+
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.subprocess.check_output", _raise
+        )
+        assert reverse_resolve_ip("10.0.0.42") is None
+
+    def test_timeout_returns_none(self, monkeypatch):
+        """Slow name service → don't hang failover; return None."""
+        import subprocess
+        from ezpz.failover.patterns import reverse_resolve_ip
+
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired(["getent"], 5)
+
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.subprocess.check_output", _raise
+        )
+        assert reverse_resolve_ip("10.0.0.42", timeout_s=0.1) is None
+
+    def test_getent_missing_returns_none(self, monkeypatch):
+        """No `getent` binary on PATH (e.g. macOS dev box, alpine
+        container) → None, not crash."""
+        from ezpz.failover.patterns import reverse_resolve_ip
+
+        def _raise(*a, **kw):
+            raise FileNotFoundError("getent")
+
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.subprocess.check_output", _raise
+        )
+        assert reverse_resolve_ip("10.0.0.42") is None
+
+    def test_empty_output_returns_none(self, monkeypatch):
+        """`getent hosts <ip>` exits 0 with empty output on some
+        systems when there's no PTR. Treat as miss."""
+        from ezpz.failover.patterns import reverse_resolve_ip
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.subprocess.check_output",
+            lambda *a, **kw: "\n",
+        )
+        assert reverse_resolve_ip("10.0.0.42") is None
+
+    def test_malformed_output_returns_none(self, monkeypatch):
+        """Output with only the IP and no hostnames after it (some
+        getent implementations) → None."""
+        from ezpz.failover.patterns import reverse_resolve_ip
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.subprocess.check_output",
+            lambda *a, **kw: "10.0.0.42\n",
+        )
+        assert reverse_resolve_ip("10.0.0.42") is None
+
+
+# ---------------------------------------------------------------------------
+# Aurora normalizer (tightened to known suffixes only)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeAuroraHostname:
+    """The normalizer must reject hostnames whose suffix we haven't
+    explicitly seen — even if they start with the `xNc.s.b.n.` prefix.
+    Otherwise a stale `/etc/hosts` entry or a cross-cluster name could
+    silently get rewritten to a fake Aurora hostname and end up in
+    the bad-nodes list."""
+
+    def test_canonical_hsn_passes_through(self):
+        from ezpz.failover.patterns.aurora import normalize_aurora_hostname
+        host = "x1234c0s0b0n0.hsn.cm.aurora.alcf.anl.gov"
+        assert normalize_aurora_hostname(host) == host
+
+    def test_hostmgmt_rewrites_to_hsn(self):
+        from ezpz.failover.patterns.aurora import normalize_aurora_hostname
+        in_ = "x1234c0s0b0n0.hostmgmt2042.cm.aurora.alcf.anl.gov"
+        out = "x1234c0s0b0n0.hsn.cm.aurora.alcf.anl.gov"
+        assert normalize_aurora_hostname(in_) == out
+
+    def test_unknown_suffix_with_aurora_like_prefix_dropped(self):
+        """REGRESSION: an Aurora-like prefix on a non-Aurora suffix
+        must NOT be rewritten — that would tag a wrong node. Before
+        the fix, this rewrote ANY ``x...n0.<anything>`` to the HSN
+        form, including stale /etc/hosts entries from other clusters.
+        """
+        from ezpz.failover.patterns.aurora import normalize_aurora_hostname
+        # Same xNcNsNbNnN prefix, different/unknown suffix.
+        cases = [
+            "x1234c0s0b0n0.something-else.example.com",
+            "x1234c0s0b0n0.staging-cluster.foo.bar",
+            "x1234c0s0b0n0.local",
+        ]
+        for host in cases:
+            assert normalize_aurora_hostname(host) is None, (
+                f"Unknown suffix '{host}' should be rejected, got rewrite"
+            )
+
+    def test_completely_unrelated_host_dropped(self):
+        from ezpz.failover.patterns.aurora import normalize_aurora_hostname
+        assert normalize_aurora_hostname("some-other-host") is None
+        assert normalize_aurora_hostname("nid001234") is None
+        assert normalize_aurora_hostname("polaris-login-1") is None

--- a/tests/test_failover_scrape.py
+++ b/tests/test_failover_scrape.py
@@ -1,0 +1,359 @@
+"""Tests for :mod:`ezpz.failover.scrape`.
+
+The Aurora pattern set is derived from postmortem analysis of real
+production failures; the test fixtures below replay the log lines
+that caused each one. Job IDs cited in comments map to the source
+material in the original torchtitan failover_lib.sh + scrape script.
+
+The most important test is :func:`test_innocent_rank_signal_11_not_matched`
+— this exclusion is the entire reason we don't naively grep for
+"died from signal 11/15". A naive matcher would falsely tag the node
+whose ranks got the cascading kill, not the node that started it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ezpz.failover.patterns import (
+    BadNodePattern,
+    get_patterns_for_machine,
+    register_patterns,
+)
+from ezpz.failover.scrape import (
+    _collect_all_matches_for_debug,
+    scrape_bad_nodes,
+)
+
+
+# Helpers --------------------------------------------------------------------
+
+def _make_log(tmp_path, content: str):
+    """Write `content` to a fixture log file and return its Path."""
+    p = tmp_path / "training.log"
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Aurora: PALS shepherd signal-9 kill
+# ---------------------------------------------------------------------------
+
+class TestAuroraShepherdSignal9:
+    """Pattern: `<host>.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9`.
+
+    Source: jobs 8459818 / 8460301 / 8463659 (PALS shepherd kills on
+    Aurora). The shepherd is PALS's per-node daemon; when it dies
+    from signal 9, the node went non-responsive and the runtime
+    killed it. Almost always a hardware fault.
+    """
+
+    def test_single_signal_9_extracted(self, tmp_path):
+        log = _make_log(tmp_path, (
+            "Some normal training output\n"
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            "More output after\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_multiple_signal_9_deduplicated(self, tmp_path):
+        """Same node firing multiple shepherd-9 lines (PALS often
+        emits more than one) → one entry in first-seen order."""
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            "more output\n"
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_two_different_nodes_in_first_seen_order(self, tmp_path):
+        log = _make_log(tmp_path, (
+            "x4001c0s0b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        # Order matters: first-seen wins, both retained.
+        assert hosts == [
+            "x4001c0s0b0n0.hsn.cm.aurora.alcf.anl.gov",
+            "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov",
+        ]
+
+    def test_innocent_rank_signal_11_not_matched(self, tmp_path):
+        """REGRESSION (job 8466848): rank 1304 died from signal 11 as a
+        downstream effect of a std::bad_alloc on a DIFFERENT rank on a
+        DIFFERENT node. A naive matcher that greps for "died from
+        signal" would tag the wrong node and swap out the *innocent*
+        one, leaving the actual bad node in the active set.
+
+        Our scrape MUST NOT match `rank N died from signal {11,15}`
+        and MUST NOT match log lines that don't start with the
+        hostname-colon prefix.
+        """
+        log = _make_log(tmp_path, (
+            # Real shape from 8466848: the rank-died lines have no
+            # hostname prefix and use "rank N died from signal", not
+            # "shepherd died from signal".
+            "rank 1304 died from signal 11\n"
+            "rank 2413 died from signal 11\n"
+            "rank 88 died from signal 15\n"
+            # And a "shepherd died from signal 11" — also should NOT
+            # match (we only match signal 9).
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 11\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == [], (
+            f"Innocent ranks/signals must not be tagged, got: {hosts!r}"
+        )
+
+    def test_hostmgmt_form_normalized_to_hsn(self, tmp_path):
+        """Aurora occasionally emits the .hostmgmtNNNN.cm.aurora form
+        instead of the .hsn.cm.aurora form. The scraper's hostname
+        normalizer must map both to the HSN form so downstream
+        swap_in (which greps the PBS hostfile) finds matches.
+
+        NOTE: the shepherd pattern itself anchors on `.hsn.cm.aurora`,
+        so .hostmgmt lines won't match it. The normalizer's job is
+        re-canonicalizing names that DID match but came from a
+        different code path (e.g. reverse-resolved IPs). Tested more
+        directly below via test_gloo_*.
+        """
+        # Even when shepherd line is already in HSN form, normalizer
+        # leaves it alone. This is the easy case.
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+
+# ---------------------------------------------------------------------------
+# Aurora: gloo TCP peer-closed
+# ---------------------------------------------------------------------------
+
+class TestAuroraGlooConnectionClosed:
+    """Pattern: `Connection closed by peer [IP]:port` → IP reverse-resolved.
+
+    Source: jobs 8470102 / 8470103 / 8479581. gloo errors typically
+    point at a single peer IP across many "Connection closed" lines
+    (every rank that was talking to the dead node logs its own copy),
+    so deduplication usually collapses to one node.
+
+    Tests stub `reverse_resolve_ip` because we can't do real DNS in
+    unit tests — the IPs in real Aurora logs are on the HSN fabric
+    and only resolvable through Aurora's name service.
+    """
+
+    def test_single_peer_ip_resolved_to_hostname(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov",
+        )
+        log = _make_log(tmp_path, (
+            "RuntimeError: [..gloo..] Connection closed by peer [10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_many_ranks_same_peer_dedup_to_one_node(
+        self, tmp_path, monkeypatch
+    ):
+        """Real production shape: dozens of ranks all log the same
+        peer-closed against the same IP. We want ONE entry, not 30."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov",
+        )
+        lines = [
+            f"rank {i}: RuntimeError: [..gloo..] Connection closed by peer "
+            f"[10.0.0.42]:{12000 + i}\n"
+            for i in range(30)
+        ]
+        log = _make_log(tmp_path, "".join(lines))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_unresolvable_ip_skipped(self, tmp_path, monkeypatch):
+        """If `getent hosts <ip>` fails (binary missing, timeout, etc.)
+        the entry is silently dropped — losing one is better than
+        tagging a wrong node based on a bogus reverse lookup."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: None,
+        )
+        log = _make_log(tmp_path, (
+            "RuntimeError: [..gloo..] Connection closed by peer [10.0.0.42]:1\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == []
+
+    def test_non_aurora_resolved_name_dropped_by_normalizer(
+        self, tmp_path, monkeypatch
+    ):
+        """Reverse-lookup returning a non-Aurora-looking name (e.g.
+        the management interface, or a stale /etc/hosts entry) is
+        dropped by the hostname normalizer. Better than tagging a
+        nonsense hostname that the active hostfile would never match."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: "some-unrelated-host.example.com",
+        )
+        log = _make_log(tmp_path, (
+            "Connection closed by peer [10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == []
+
+    def test_hostmgmt_form_canonicalized_to_hsn(
+        self, tmp_path, monkeypatch
+    ):
+        """If reverse-lookup returns the .hostmgmtNNNN form, the
+        normalizer rewrites it to the .hsn form so downstream swap_in
+        finds it in the PBS hostfile (which uses .hsn exclusively)."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: (
+                "x4502c1s3b0n0.hostmgmt2042.cm.aurora.alcf.anl.gov"
+            ),
+        )
+        log = _make_log(tmp_path, (
+            "Connection closed by peer [10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-pattern: dedup + ordering
+# ---------------------------------------------------------------------------
+
+class TestScraperBehavior:
+
+    def test_both_patterns_fire_same_node_dedup(self, tmp_path, monkeypatch):
+        """Same bad node can fire both patterns (shepherd-9 AND gloo
+        peer-closed from neighboring ranks). Should still appear once."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov",
+        )
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            "Connection closed by peer [10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+    def test_both_patterns_fire_different_nodes_both_returned(
+        self, tmp_path, monkeypatch
+    ):
+        """Two separate bad nodes (one shepherd-9, one gloo-closed)
+        both end up in the output, shepherd's first because the
+        patterns iterate in registration order."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov",
+        )
+        log = _make_log(tmp_path, (
+            "x4001c0s0b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            "Connection closed by peer [10.0.0.42]:1\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == [
+            "x4001c0s0b0n0.hsn.cm.aurora.alcf.anl.gov",
+            "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov",
+        ]
+
+    def test_empty_log_returns_empty_list(self, tmp_path):
+        log = _make_log(tmp_path, "")
+        assert scrape_bad_nodes(log, machine="aurora") == []
+
+    def test_clean_log_returns_empty_list(self, tmp_path):
+        log = _make_log(tmp_path, "step=1 loss=2.4\nstep=2 loss=2.3\n")
+        assert scrape_bad_nodes(log, machine="aurora") == []
+
+    def test_unknown_machine_returns_empty_list(self, tmp_path):
+        """No registered patterns → empty list, not exception. Lets
+        the caller's blind-rotation fallback fire."""
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+        ))
+        assert scrape_bad_nodes(log, machine="mars-rover-cluster") == []
+
+    def test_missing_log_raises_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            scrape_bad_nodes(tmp_path / "does-not-exist.log", machine="aurora")
+
+    def test_binary_garbage_in_log_doesnt_crash(self, tmp_path):
+        """Real logs can be partially corrupted by mid-write crashes;
+        the scraper must handle that gracefully (errors='replace')."""
+        log = tmp_path / "corrupt.log"
+        log.write_bytes(
+            b"x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            b"\xfe\xff\xfe\xff some garbage \x00\x00\xff\xff\n"
+        )
+        hosts = scrape_bad_nodes(log, machine="aurora")
+        assert hosts == ["x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov"]
+
+
+# ---------------------------------------------------------------------------
+# Registry extension
+# ---------------------------------------------------------------------------
+
+class TestPatternRegistry:
+
+    def test_can_register_custom_pattern(self, tmp_path):
+        """Third parties (or future machine modules) can register
+        patterns at import time."""
+        def _extract_bad_widget(text: str):
+            for line in text.splitlines():
+                if "WIDGET_DOWN:" in line:
+                    yield line.split("WIDGET_DOWN:")[1].strip()
+
+        register_patterns(
+            "fictional-cluster",
+            [
+                BadNodePattern(
+                    name="fictional.widget_down",
+                    extractor=_extract_bad_widget,
+                    description="The widget went down.",
+                )
+            ],
+            hostname_normalizer=None,
+        )
+        log = _make_log(tmp_path, "WIDGET_DOWN: node-42\nother stuff\n")
+        hosts = scrape_bad_nodes(log, machine="fictional-cluster")
+        assert hosts == ["node-42"]
+
+    def test_re_register_overwrites(self, tmp_path):
+        """Calling register_patterns twice for the same machine
+        replaces the previous registration."""
+        first = [BadNodePattern("first", lambda _t: ["nope"], "")]
+        second = [BadNodePattern("second", lambda _t: ["yes"], "")]
+        register_patterns("test-overwrite", first)
+        register_patterns("test-overwrite", second)
+        patterns = get_patterns_for_machine("test-overwrite")
+        assert len(patterns) == 1 and patterns[0].name == "second"
+
+    def test_explain_mode_breaks_down_per_pattern(
+        self, tmp_path, monkeypatch
+    ):
+        """`_collect_all_matches_for_debug` returns one list per
+        pattern, even when only some fired."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.aurora.reverse_resolve_ip",
+            lambda ip, **_kw: "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov",
+        )
+        log = _make_log(tmp_path, (
+            "x4001c0s0b0n0.hsn.cm.aurora.alcf.anl.gov: shepherd died from signal 9\n"
+            "Connection closed by peer [10.0.0.42]:1\n"
+        ))
+        per_pattern = _collect_all_matches_for_debug(log, machine="aurora")
+        assert per_pattern == {
+            "aurora.shepherd_signal_9": [
+                "x4001c0s0b0n0.hsn.cm.aurora.alcf.anl.gov"
+            ],
+            "aurora.gloo_connection_closed": [
+                "x4002c0s0b0n0.hsn.cm.aurora.alcf.anl.gov"
+            ],
+        }


### PR DESCRIPTION
## Summary

First of three PRs porting the production bad-node failover system from
[`torchtitan/experiments/ezpz/scripts/`](https://github.com/saforem2/torchtitan/tree/ezpz/torchtitan/experiments/ezpz/scripts) into the `ezpz` package proper.

**Scope of this PR**: the log-parsing layer only. The bash orchestration (`failover_lib.sh`) and the `ezpz launch --failover` flag are follow-ups.

## What's here

- `ezpz.failover.scrape_bad_nodes(log_path, *, machine=None)` — public entry point that returns a deduplicated list of bad hostnames in first-seen order. Auto-detects the current machine via `ezpz.get_machine()`; explicit override for tests + cross-cluster postmortems.
- `ezpz.failover.patterns` — per-machine pattern registry. Aurora's PALS shepherd kills and gloo TCP failures bundled by default; other systems register their own via `register_patterns(machine, [BadNodePattern...])`.
- `python -m ezpz.failover <log>` — drop-in CLI replacement for the original `scrape_bad_nodes.py`. Adds an `--explain` mode that breaks down matches per pattern.

## Why this matters

The torchtitan failover system has caught real Aurora hardware failures across many production training runs (jobs **8459818, 8460301, 8463659, 8470102, 8470103, 8479581, 8466848**, others). Two distinct bad-node failure modes are detected:

| Pattern | Source jobs |
|---|---|
| PALS shepherd signal-9 kill (node-local daemon went non-responsive — hardware fault) | 8459818, 8460301, 8463659 |
| gloo TCP peer-closed (IP reverse-resolved via `getent hosts`) | 8470102, 8470103, 8479581 |

The crucial **non-detection** is `rank N died from signal {11,15}` — those are cascading deaths from a primary kill on a *different* node. Including them would falsely tag innocent nodes. Job 8466848 had rank 1304 die from signal 11 as a downstream effect of a `std::bad_alloc` on rank 2413, on a different node — the kill happened on the first node, but the signal-11 message named the second. This is tested as a regression in `test_innocent_rank_signal_11_not_matched`.

## Public API

```python
from ezpz.failover import scrape_bad_nodes

# Auto-detect machine from hostname
hosts = scrape_bad_nodes("/path/to/attempt-1.log")

# Explicit override (tests, cross-cluster postmortems)
hosts = scrape_bad_nodes("/path/to/log", machine="aurora")
```

```bash
# Drop-in CLI replacement for torchtitan's scrape_bad_nodes.py
python -m ezpz.failover /path/to/log
python -m ezpz.failover --machine aurora --explain /path/to/log
```

## Extending to new machines

```python
from ezpz.failover.patterns import BadNodePattern, register_patterns

register_patterns(
    "my-cluster",
    [
        BadNodePattern(
            name="mycluster.fabric_flap",
            extractor=lambda text: [...],
            description="Fabric link reset; node went unreachable.",
        )
    ],
    hostname_normalizer=lambda h: h if h.endswith(".my-cluster.example.com") else None,
)
```

## Sunspot / Polaris / Frontier?

NOT bundled. Sunspot likely shares Aurora's patterns (same PALS shepherd, same XPU fabric) but the full hostname suffix differs and we haven't postmortemed a real Sunspot failure yet to confirm the exact format. Will add a dedicated `sunspot.py` once we have ground truth.

Polaris/Frontier need their own pattern modules (NCCL signatures, SLURM-on-Frontier shapes) — easy follow-up PRs once real failures provide the source material.

## Tests

20 tests in `tests/test_failover_scrape.py`:

- ✅ Both Aurora patterns (shepherd-9 + gloo-closed)
- ✅ The innocent-rank-N exclusion (regression for job 8466848)
- ✅ IP-resolution mocking (no real DNS in unit tests; the IPs in real Aurora logs are HSN-fabric-only)
- ✅ Hostname normalization (`.hostmgmt` → `.hsn` rewrite for downstream PBS-hostfile-match)
- ✅ Dedup + first-seen ordering across many ranks logging the same peer-closed
- ✅ Unresolvable IP / non-Aurora resolved name → silent drop (better than tagging a wrong node from a bogus lookup)
- ✅ Pattern registry: custom registration, re-registration overwrite, `--explain` per-pattern breakdown
- ✅ Edge cases: empty log, clean log, missing log, binary-corrupt log

All 20 pass; **126 total tests pass** across the broader suite (no regressions).

## Test plan

- [x] `pytest tests/test_failover_scrape.py` — 20/20 pass
- [x] `python -m ezpz.failover --explain <sample-log>` — dedup + innocent-rank exclusion work as expected
- [x] Broader regression: `pytest tests/test_history.py tests/test_memory_metrics.py tests/test_launch_watchdog.py tests/test_failover_scrape.py` — 126/126 pass
- [ ] On a real Aurora postmortem log: `python -m ezpz.failover` produces the same output as the existing `scrape_bad_nodes.py` from torchtitan

## Follow-up PRs (planned)

- **PR 2**: port `failover_lib.sh` → `src/ezpz/bin/failover.sh` (the bash orchestration: split nodefile, yeet env, swap in spares, retry loop). Composes with this PR's `scrape_bad_nodes` Python function.
- **PR 3**: wire `--failover` / `--spare-nodes` / `--max-failover-retries` into `ezpz launch` so users get the whole system as a single CLI flag instead of needing to source a bash lib.

Once all three land, the torchtitan copies become thin shims that import from ezpz (or get deleted outright).
