### PR TITLE
feat(failover): port failover_lib.sh as src/ezpz/bin/failover.sh (PR 2/3)

### DIFF
--- a/src/ezpz/bin/failover.sh
+++ b/src/ezpz/bin/failover.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+# failover.sh — bad-node failover support for ezpz/torchtitan training.
+#
+# Source this file from a submit script that has requested
+# NHOSTS_TRAIN + NHOSTS_SPARE nodes via PBS. Then call:
+#
+#     failover_init NHOSTS_TRAIN
+#     failover_run <command...>
+#
+# `failover_init` splits PBS_NODEFILE → active.hostfile (first N lines)
+# + spare.hostfile (rest), exports PBS_NODEFILE → active.hostfile so
+# downstream `ezpz launch` only sees the training subset, and yeets
+# the venv to ALL nodes (active + spare) so any spare can swap in
+# cleanly.
+#
+# `failover_run` runs the command, scrapes the output for known
+# bad-node failure modes (via `python3 -m ezpz.failover`), swaps the
+# offending node out for a spare, and retries (up to
+# FAILOVER_MAX_RETRIES, default 3).
+#
+# Detected failure modes (see `python -m ezpz.failover` and
+# `ezpz/failover/patterns/aurora.py`):
+#
+#   - `<hostname>: shepherd died from signal 9` (PALS shepherd kill)
+#   - `RuntimeError: ... Connection closed by peer [IP]:port`
+#     (gloo TCP, IP reverse-resolved via `getent hosts`)
+#
+# NOT detected (intentional): `rank N died from signal {11,15}`. Those
+# are cascading deaths from a primary kill on a different node, and
+# tagging the named node would swap out an innocent one. See the
+# scraper's docstring + the `test_innocent_rank_signal_11_not_matched`
+# regression test for the postmortem reasoning (job 8466848).
+#
+# Env vars (all optional):
+#   FAILOVER_MAX_RETRIES   default 3
+#   FAILOVER_LOG_DIR       default $(pwd)/logs/failover-${PBS_JOBID%%.*}
+#   FAILOVER_KEEP_BAD      default 1 — append bad node to bad_nodes.txt
+#   FAILOVER_IDLE_TIMEOUT  default 1800s — only used when wrapping
+#                          `ezpz launch`. Injects `--timeout=<value>`
+#                          so the launch-side watchdog catches silent
+#                          collective hangs (e.g. job 8479579: 5h of
+#                          W&B heartbeat alive but training metrics
+#                          dead). Requires ezpz >= 0.15.1.
+#
+# Sourcing this file from anywhere:
+#
+#     # From inside a checkout:
+#     source src/ezpz/bin/failover.sh
+#
+#     # From any ezpz install (works on Aurora compute nodes):
+#     source "$(python3 -c 'import ezpz, pathlib; \
+#         print(pathlib.Path(ezpz.configs.BIN_DIR) / "failover.sh")')"
+
+set -o pipefail  # don't `set -euo pipefail` here — venv activate has unbound vars
+
+_failover_log() { echo "[failover] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# failover_init NHOSTS_TRAIN
+#
+# Splits PBS_NODEFILE into active + spare files in $FAILOVER_LOG_DIR.
+# Exports PBS_NODEFILE → active.hostfile.
+# Caller is expected to call failover_yeet_all next, before failover_run.
+# ---------------------------------------------------------------------------
+failover_init() {
+    # ${1:-} so a caller running with `set -u` doesn't blow up on
+    # missing-arg — we want to print our own ERROR and return 1.
+    local nhosts_train="${1:-}"
+    [[ -n "$nhosts_train" ]] || { _failover_log "ERROR: failover_init needs NHOSTS_TRAIN arg"; return 1; }
+    [[ -n "${PBS_NODEFILE:-}" && -f "$PBS_NODEFILE" ]] || { _failover_log "ERROR: PBS_NODEFILE not set or missing"; return 1; }
+
+    local total
+    total=$(wc -l < "$PBS_NODEFILE")
+    if (( total < nhosts_train )); then
+        _failover_log "ERROR: PBS gave us $total nodes, training needs $nhosts_train"
+        return 1
+    fi
+
+    export FAILOVER_LOG_DIR="${FAILOVER_LOG_DIR:-$(pwd)/logs/failover-${PBS_JOBID%%.*}}"
+    mkdir -p "$FAILOVER_LOG_DIR"
+
+    export FAILOVER_PBS_NODEFILE_ORIG="$PBS_NODEFILE"
+    export FAILOVER_ACTIVE="$FAILOVER_LOG_DIR/active.hostfile"
+    export FAILOVER_SPARE="$FAILOVER_LOG_DIR/spare.hostfile"
+    export FAILOVER_BAD="$FAILOVER_LOG_DIR/bad_nodes.txt"
+
+    head -n "$nhosts_train"   "$PBS_NODEFILE" > "$FAILOVER_ACTIVE"
+    tail -n +"$((nhosts_train + 1))" "$PBS_NODEFILE" > "$FAILOVER_SPARE"
+    : > "$FAILOVER_BAD"  # truncate
+
+    export PBS_NODEFILE="$FAILOVER_ACTIVE"
+    export NHOSTS="$nhosts_train"
+
+    _failover_log "PBS gave us $total nodes ($(wc -l < "$FAILOVER_ACTIVE") active, $(wc -l < "$FAILOVER_SPARE") spare)"
+    _failover_log "active hostfile: $FAILOVER_ACTIVE"
+    _failover_log "spare hostfile:  $FAILOVER_SPARE"
+    _failover_log "bad-node log:    $FAILOVER_BAD"
+}
+
+# ---------------------------------------------------------------------------
+# failover_yeet_all
+#
+# Run `ezpz yeet-env --src .venv.tar.gz` against the FULL nodelist
+# (active + spare), so a spare can swap in without re-broadcast.
+# Restores PBS_NODEFILE → active afterwards.
+# ---------------------------------------------------------------------------
+failover_yeet_all() {
+    local full_nodefile="$FAILOVER_LOG_DIR/all.hostfile"
+    cat "$FAILOVER_ACTIVE" "$FAILOVER_SPARE" > "$full_nodefile"
+    local saved_pbs_nodefile="$PBS_NODEFILE"
+    local saved_nhosts="$NHOSTS"
+    export PBS_NODEFILE="$full_nodefile"
+    # Declare-then-assign so a `wc` failure isn't masked by the export.
+    local _nhosts
+    _nhosts=$(wc -l < "$full_nodefile")
+    export NHOSTS="$_nhosts"
+    _failover_log "yeet-env to ALL $NHOSTS nodes (active + spare)"
+    if [[ -f .venv.tar.gz ]]; then
+        ezpz yeet-env --src .venv.tar.gz
+    else
+        ezpz yeet-env
+    fi
+    local rc=$?
+    export PBS_NODEFILE="$saved_pbs_nodefile"
+    export NHOSTS="$saved_nhosts"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# failover_swap_in BAD_HOSTNAMES...
+#
+# For each bad hostname, remove it from active.hostfile and replace it
+# with the next available spare (popping from spare.hostfile). Logs
+# all bad hostnames to bad_nodes.txt for postmortem.
+# Returns 0 if all swaps succeeded, 1 if we ran out of spares.
+# ---------------------------------------------------------------------------
+failover_swap_in() {
+    local bad
+    local swapped=0
+    for bad in "$@"; do
+        # Bad node must actually be in active set
+        if ! grep -qxF "$bad" "$FAILOVER_ACTIVE" 2>/dev/null; then
+            _failover_log "skip: $bad not in active hostfile"
+            continue
+        fi
+        # Need a spare
+        local spare
+        spare=$(head -n 1 "$FAILOVER_SPARE")
+        if [[ -z "$spare" ]]; then
+            _failover_log "ERROR: out of spares — cannot replace $bad"
+            return 1
+        fi
+        # Pop spare, swap in
+        tail -n +2 "$FAILOVER_SPARE" > "$FAILOVER_SPARE.tmp" && mv "$FAILOVER_SPARE.tmp" "$FAILOVER_SPARE"
+        sed -i.bak "s|^$bad\$|$spare|" "$FAILOVER_ACTIVE" && rm -f "$FAILOVER_ACTIVE.bak"
+        echo "$bad" >> "$FAILOVER_BAD"
+        _failover_log "swapped: $bad -> $spare"
+        swapped=$((swapped + 1))
+    done
+    _failover_log "swap summary: $swapped bad nodes replaced; $(wc -l < "$FAILOVER_SPARE") spares remaining"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# failover_swap_one_blind
+#
+# Generic init-time crash with no specific bad hostname (e.g. the
+# `set_determinism` `std::bad_alloc`). Just rotate ONE spare into the
+# active set — pop the first active host, swap it for a spare.
+# Returns 0 if success, 1 if no spares left.
+# ---------------------------------------------------------------------------
+failover_swap_one_blind() {
+    local first_active
+    first_active=$(head -n 1 "$FAILOVER_ACTIVE")
+    [[ -n "$first_active" ]] || return 1
+    failover_swap_in "$first_active"
+}
+
+# ---------------------------------------------------------------------------
+# failover_run COMMAND...
+#
+# Run COMMAND, capturing its output to $FAILOVER_LOG_DIR/attempt-N.log.
+# On non-zero exit, scrape the log for bad-node signatures and retry
+# with swap-ins, up to $FAILOVER_MAX_RETRIES times.
+#
+# Crash detection is more careful than just `rc != 0`:
+#
+#   - The `ezpz launch` wrapper sometimes exits 0 even when the
+#     inner mpiexec child crashed (e.g. SIGTERM after a real error).
+#     We cross-check the log for "Execution finished with N" trailers
+#     and for known mass-traceback patterns; either of those overrides
+#     a spurious rc=0 to the real failure.
+#
+#   - exit 143 (SIGTERM from PBS walltime) is normally NOT retried —
+#     no point swapping nodes if the wallclock killed us. BUT if the
+#     log ALSO contains bad-node patterns, we DO retry — a real
+#     bad-node crash can surface as exit 143 when mpiexec teardown
+#     races the walltime kill.
+#
+#   - exit 124 (from `ezpz launch --timeout` idle-output watchdog,
+#     #136) is treated as a silent-hang bad-node failure. The
+#     scrape probably won't find a specific hostname (the hang IS
+#     the silence) so failover_swap_one_blind kicks in.
+# ---------------------------------------------------------------------------
+failover_run() {
+    local max=${FAILOVER_MAX_RETRIES:-3}
+    local attempt=1
+    local rc
+
+    # If the command is `ezpz launch ...`, inject explicit topology args so
+    # ezpz launch doesn't re-derive nhosts/ngpus from the original PBS aux
+    # file (which still has 260/522 nodes — the spares we excluded). Without
+    # this, _infer_topology computes ngpus=N_full*12 then trips
+    # "ngpus must be > 0 and <= N_active*12, got N_full*12".
+    #
+    # IMPORTANT: ezpz launch's argparse uses UNDERSCORE forms for the long
+    # flags (--nproc_per_node, --nnodes), not dash forms. Passing the dash
+    # variant (--nproc-per-node) silently leaks the arg into cmd_to_launch
+    # where mpiexec then rejects it with "unrecognized option". Use the
+    # short flags (-n, -ppn) and the registered long forms to avoid that.
+    local cmd=("$@")
+    if [[ "${cmd[0]}" == "ezpz" && "${cmd[1]}" == "launch" ]]; then
+        local ppn="${NGPU_PER_HOST:-12}"
+        local nproc=$(( NHOSTS * ppn ))
+        # FAILOVER_IDLE_TIMEOUT (default 1800s = 30min): if the launched
+        # process emits no output for this long, ezpz launch sends SIGTERM
+        # and exits 124. Catches silent collective hangs (e.g. the
+        # 8479579 incident: 5h of W&B-heartbeat-alive-but-no-training-
+        # metrics-output). Requires ezpz >= 0.15.1.
+        local idle_timeout="${FAILOVER_IDLE_TIMEOUT:-1800}"
+        cmd=(
+            "${cmd[@]:0:2}"
+            "--hostfile=$FAILOVER_ACTIVE"
+            "--nnodes=$NHOSTS"
+            "-ppn" "$ppn"
+            "-n" "$nproc"
+            "--timeout=$idle_timeout"
+            "${cmd[@]:2}"
+        )
+    fi
+
+    while (( attempt <= max + 1 )); do
+        local logf="$FAILOVER_LOG_DIR/attempt-${attempt}.log"
+        _failover_log "attempt ${attempt}/${max} — active=$(wc -l < "$FAILOVER_ACTIVE") nodes, spare=$(wc -l < "$FAILOVER_SPARE") nodes"
+        _failover_log "logging to $logf"
+
+        # Use stdbuf to keep tee'd output unbuffered, redirect both stderr and stdout.
+        "${cmd[@]}" 2>&1 | tee "$logf"
+        rc=${PIPESTATUS[0]}
+
+        # ezpz launch's outer python wrapper sometimes exits 0 even when the
+        # mpiexec child crashed (e.g. mpiexec --help dump, walltime SIGTERM).
+        # When that happens we lose the bad-node signal. Always cross-check
+        # the log for known crash patterns + the explicit "Execution finished
+        # with N" trailer, and override rc accordingly.
+        # Strip ANSI escape codes first — ezpz launch logs the trailer with
+        # color codes baked in (`Execution finished with \x1b[1;36m127\x1b[0m`),
+        # and a naive regex extracts '1' from the [1;36m prefix instead of
+        # the real exit code (127). Pre-filter with sed.
+        local inner_rc
+        inner_rc=$(sed -r 's/\x1b\[[0-9;]*m//g' "$logf" 2>/dev/null | grep -oE "Execution finished with [0-9]+" | tail -1 | grep -oE "[0-9]+$")
+        if [[ -n "$inner_rc" && "$inner_rc" != "0" ]]; then
+            if (( rc == 0 )); then
+                _failover_log "WARNING: shell exit 0 but log shows 'Execution finished with $inner_rc'; treating as failure"
+                rc=$inner_rc
+            fi
+        elif (( rc == 0 )); then
+            # Even without the trailer, mass-traceback / Connection-closed
+            # patterns mean training crashed. Catch them.
+            #
+            # Threshold history:
+            # - 8503077 (80B 2058N) only emitted 2 crash-pattern lines
+            #   before SIGTERM cascaded, so the previous `> 5` threshold
+            #   missed it. At very large rank counts, one bad node may
+            #   only take a handful of ranks down before the wrapper
+            #   tears everything down. Drop to `>= 1` — any of these
+            #   patterns appearing means training crashed.
+            # - Added EOFError (blendcorpus shuffle_idx mmap of a
+            #   zero-length file) — fired in 8485515 80B 522N.
+            local crash_lines
+            crash_lines=$(grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file" "$logf" 2>/dev/null)
+            if (( crash_lines >= 1 )); then
+                _failover_log "WARNING: shell exit 0 but log has $crash_lines crash-pattern line(s); treating as failure (rc=1)"
+                rc=1
+            fi
+        fi
+
+        if (( rc == 0 )); then
+            _failover_log "attempt ${attempt} succeeded (exit 0)"
+            return 0
+        fi
+
+        # Walltime kills are NOT bad-node failures — exit -29 means walltime hit.
+        # PBS reports exit -29 as bash exit 143 (128+15). Don't retry on those.
+        # BUT: if we also found bad-node crash patterns, prefer the bad-node
+        # path (don't bail on a true bad-node case just because the wallclock
+        # signal also fired).
+        # Walltime guard. Use the SAME crash-pattern set as the rc=0 case
+        # above — otherwise a real bad-node failure that surfaced as
+        # shell exit 143 (mpiexec SIGTERM'd after EOFError or
+        # OutOfMemoryError) gets misclassified as a clean walltime kill
+        # and the wrapper bails without retrying.
+        if (( rc == 143 )); then
+            local bad_crash_lines
+            bad_crash_lines=$(grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file" "$logf" 2>/dev/null)
+            if (( bad_crash_lines == 0 )); then
+                _failover_log "attempt ${attempt} exited 143 (walltime / SIGTERM) — not a bad-node failure, no retry"
+                return "$rc"
+            fi
+            _failover_log "attempt ${attempt} exited 143 but log has $bad_crash_lines bad-node lines — proceeding with retry"
+        fi
+
+        # exit 124 = ezpz launch idle-output watchdog (--timeout) fired.
+        # The launched process emitted no output for FAILOVER_IDLE_TIMEOUT
+        # seconds → ezpz sent SIGTERM. This catches silent hangs like
+        # 8479579 (W&B alive but training metrics dead for 5h). Treat as
+        # a bad-node failure: scrape, swap, retry. The scraper likely
+        # won't find a specific hostname (the hang IS the silence)
+        # so failover_swap_one_blind will rotate a spare.
+        if (( rc == 124 )); then
+            _failover_log "attempt ${attempt} exited 124 (ezpz idle-output watchdog tripped after ${FAILOVER_IDLE_TIMEOUT:-1800}s) — treating as silent-hang bad-node failure"
+        fi
+
+        _failover_log "attempt ${attempt} failed (exit $rc) — scraping for bad nodes"
+        # Scrape via the Python package (ezpz.failover, shipped with ezpz
+        # since v0.16.0). The CLI auto-detects the machine via
+        # ezpz.get_machine() and routes to the right pattern set; we pass
+        # --machine=aurora explicitly here for forward-compatibility with
+        # systems that haven't been auto-detect-tested.
+        local bad_nodes
+        bad_nodes=$(python3 -m ezpz.failover --machine aurora "$logf" 2>/dev/null || true)
+
+        if (( attempt > max )); then
+            _failover_log "ERROR: max retries ($max) exhausted; giving up"
+            return "$rc"
+        fi
+
+        if [[ -n "$bad_nodes" ]]; then
+            _failover_log "bad nodes detected: $bad_nodes"
+            # NOTE: $bad_nodes intentionally unquoted — it's a
+            # whitespace-separated list of hostnames from the scraper
+            # and we want word-splitting here so each becomes its own
+            # argument to failover_swap_in. shellcheck SC2086.
+            # shellcheck disable=SC2086
+            failover_swap_in $bad_nodes || { _failover_log "swap failed; giving up"; return "$rc"; }
+        else
+            _failover_log "no specific bad node identified — rotating one spare in blindly"
+            failover_swap_one_blind || { _failover_log "no spares left; giving up"; return "$rc"; }
+        fi
+
+        # Sanity check: still have nhosts_train active nodes
+        local active_count
+        active_count=$(wc -l < "$FAILOVER_ACTIVE")
+        if (( active_count != NHOSTS )); then
+            _failover_log "ERROR: active count drifted ($active_count != $NHOSTS); giving up"
+            return "$rc"
+        fi
+
+        attempt=$((attempt + 1))
+    done
+}

--- a/src/ezpz/bin/failover.sh
+++ b/src/ezpz/bin/failover.sh
@@ -244,7 +244,16 @@ failover_run() {
         _failover_log "attempt ${attempt}/${max} — active=$(wc -l < "$FAILOVER_ACTIVE") nodes, spare=$(wc -l < "$FAILOVER_SPARE") nodes"
         _failover_log "logging to $logf"
 
-        # Use stdbuf to keep tee'd output unbuffered, redirect both stderr and stdout.
+        # Merge stderr into stdout so tee captures everything the child
+        # emits on either stream. ${PIPESTATUS[0]} recovers the child's
+        # exit code (tee always exits 0 in normal operation).
+        #
+        # No stdbuf here: ezpz launch already sets PYTHONUNBUFFERED=1
+        # in the child env (see _run_with_watchdog), and the inner
+        # mpiexec children inherit that. Tee itself is line-buffered
+        # when its stdout is a TTY and block-buffered when redirected,
+        # but we don't gate any timing decisions on tee's flush
+        # cadence — only on $PIPESTATUS at process exit.
         "${cmd[@]}" 2>&1 | tee "$logf"
         rc=${PIPESTATUS[0]}
 
@@ -258,7 +267,10 @@ failover_run() {
         # and a naive regex extracts '1' from the [1;36m prefix instead of
         # the real exit code (127). Pre-filter with sed.
         local inner_rc
-        inner_rc=$(sed -r 's/\x1b\[[0-9;]*m//g' "$logf" 2>/dev/null | grep -oE "Execution finished with [0-9]+" | tail -1 | grep -oE "[0-9]+$")
+        # `sed -E` (extended regex) is POSIX-portable; `sed -r` is a GNU
+        # alias that BSD sed (macOS dev boxes) doesn't accept. Same
+        # treatment as the `sed -i.bak` portability fix elsewhere.
+        inner_rc=$(sed -E 's/\x1b\[[0-9;]*m//g' "$logf" 2>/dev/null | grep -oE "Execution finished with [0-9]+" | tail -1 | grep -oE "[0-9]+$")
         if [[ -n "$inner_rc" && "$inner_rc" != "0" ]]; then
             if (( rc == 0 )); then
                 _failover_log "WARNING: shell exit 0 but log shows 'Execution finished with $inner_rc'; treating as failure"
@@ -278,7 +290,28 @@ failover_run() {
             # - Added EOFError (blendcorpus shuffle_idx mmap of a
             #   zero-length file) — fired in 8485515 80B 522N.
             local crash_lines
-            crash_lines=$(grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file" "$logf" 2>/dev/null)
+            # IMPORTANT: keep this regex (and the bad_crash_lines one
+            # below) in sync with src/ezpz/launch_autoretry.py's
+            # _CRASH_PATTERNS_RX. Match ANY hardware-style death — OOM,
+            # gloo TCP, shepherd kills, segfaults, EOFError on
+            # zero-length mmaps, etc. — but EXCLUDE the innocent
+            # cascading-rank lines first.
+            #
+            # `rank N died from signal {11,15}` is what mpiexec prints
+            # when ANOTHER node's primary failure took down ranks on
+            # this node downstream — the cascade is from a SIGTERM
+            # raining outward, not a local hardware problem. Tagging
+            # those as bad-node indicators would burn spares chasing
+            # innocent ranks instead of the actual culprit. See
+            # tests/test_failover_scrape.py::test_innocent_rank_signal_11_not_matched
+            # (job 8466848 postmortem) for the scraper-side analog.
+            #
+            # `grep -v` strips the innocent rank-N lines BEFORE the
+            # crash-pattern match runs, so `died from signal 9`
+            # (real shepherd kill), `died from signal 6` (SIGABRT
+            # from a real assert), etc. still count.
+            crash_lines=$(grep -vE "rank [0-9]+ died from signal (11|15)" "$logf" 2>/dev/null \
+                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file")
             if (( crash_lines >= 1 )); then
                 _failover_log "WARNING: shell exit 0 but log has $crash_lines crash-pattern line(s); treating as failure (rc=1)"
                 rc=1
@@ -302,7 +335,16 @@ failover_run() {
         # and the wrapper bails without retrying.
         if (( rc == 143 )); then
             local bad_crash_lines
-            bad_crash_lines=$(grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file" "$logf" 2>/dev/null)
+            # Same regex as crash_lines above — strip the innocent
+            # `rank N died from signal {11,15}` cascade lines first,
+            # then match the broad hardware-death set. Critical for
+            # the walltime path: without the strip, a normal walltime
+            # SIGTERM (which fires SIGTERM at every rank, generating
+            # dozens of `rank N died from signal 15` lines) would
+            # override the clean rc=143 into a bad-node retry and
+            # burn spares for nothing.
+            bad_crash_lines=$(grep -vE "rank [0-9]+ died from signal (11|15)" "$logf" 2>/dev/null \
+                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file")
             if (( bad_crash_lines == 0 )); then
                 _failover_log "attempt ${attempt} exited 143 (walltime / SIGTERM) — not a bad-node failure, no retry"
                 return "$rc"

--- a/tests/test_failover_lib.sh
+++ b/tests/test_failover_lib.sh
@@ -418,6 +418,79 @@ EOF
     assert_file_contents "${FAILOVER_BAD}" "host1"
 }
 
+test_run_walltime_143_no_retry_when_only_innocent_rank_signals() {
+    # Regression for the Codex P2 review on PR #143: walltime SIGTERM
+    # cascades to ranks as `rank N died from signal {11,15}`. Those
+    # lines are NOT bad-node indicators (the cascade originated on a
+    # DIFFERENT node — see scraper's test_innocent_rank_signal_11_not_matched).
+    # The walltime path must NOT treat them as a reason to retry.
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/walltime_with_cascade_cmd" <<'EOF'
+#!/usr/bin/env bash
+# Real walltime kill: SIGTERM cascade emits rank-signal lines but
+# NO shepherd-died-9 and no gloo Connection-closed.
+echo "rank 0 died from signal 15"
+echo "rank 1 died from signal 11"
+echo "rank 2 died from signal 15"
+exit 143
+EOF
+    chmod +x "${bindir}/walltime_with_cascade_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""  # scraper finds nothing either
+
+    export FAILOVER_MAX_RETRIES=2
+    local rc=0
+    failover_run walltime_with_cascade_cmd || rc=$?
+    assert_eq "${rc}" "143" "rc"
+    # Critical: no swap happened — bad_nodes.txt is empty.
+    assert_eq "$(wc -l < "${FAILOVER_BAD}" | tr -d ' ')" "0" "bad_nodes_count"
+}
+
+test_run_walltime_143_retries_on_real_hw_death_mixed_with_innocent_cascade() {
+    # Companion to the prior test: even when the log has innocent
+    # rank-cascade lines, a REAL hardware death (gloo, OOM, shepherd-9,
+    # etc.) elsewhere in the same log must still trigger a retry. The
+    # `grep -v` of innocent ranks should only strip the cascade lines,
+    # not the genuine signal.
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/real_death_with_cascade_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then
+    # Real failure + innocent downstream cascades. The cascade lines
+    # would have masked the real OOM under the old regex; the new one
+    # strips the cascades first.
+    echo "rank 0 died from signal 15"
+    echo "rank 1 died from signal 11"
+    echo "torch.cuda.OutOfMemoryError: CUDA out of memory"
+    exit 143
+else
+    exit 0
+fi
+EOF
+    chmod +x "${bindir}/real_death_with_cascade_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""  # blind rotation
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run real_death_with_cascade_cmd || exit 1
+    # Verifies we DID retry — host1 got swapped out.
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
 test_run_swaps_named_bad_node_when_scraper_finds_one() {
     setup_pbs_nodefile "host1
 host2
@@ -565,6 +638,8 @@ run_test "run succeeds on first attempt (no retry)"           test_run_succeeds_
 run_test "run retries on failure, succeeds on attempt 2"      test_run_retries_on_failure_then_succeeds
 run_test "run does NOT retry on walltime (143) when clean"    test_run_walltime_143_no_retry_when_clean
 run_test "run DOES retry on 143 when log has bad-node pattern" test_run_walltime_143_retries_when_bad_node_pattern_in_log
+run_test "run does NOT retry on 143 with only innocent rank-signal lines" test_run_walltime_143_no_retry_when_only_innocent_rank_signals
+run_test "run DOES retry on 143 when real hw death is mixed with cascade"  test_run_walltime_143_retries_on_real_hw_death_mixed_with_innocent_cascade
 run_test "run swaps named bad node (from scraper)"            test_run_swaps_named_bad_node_when_scraper_finds_one
 run_test "run exhausts max retries, returns final rc"         test_run_exhausts_max_retries
 run_test "run detects inner_rc through ANSI escapes"          test_run_ansi_stripping_in_inner_rc_detection

--- a/tests/test_failover_lib.sh
+++ b/tests/test_failover_lib.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+# test_failover_lib.sh — unit tests for src/ezpz/bin/failover.sh.
+#
+# Run from the repo root:
+#   bash tests/test_failover_lib.sh
+#
+# Each test:
+#   - sets up a temp dir with a fixture PBS_NODEFILE
+#   - shadows `ezpz` and `python3 -m ezpz.failover` with stub scripts
+#     that produce known outputs / exit codes
+#   - sources failover.sh, calls the function under test
+#   - asserts on the resulting state (hostfile contents, bad_nodes.txt,
+#     log messages, exit code)
+#
+# Exit non-zero if any test fails. Each test is independent — its own
+# temp dir, its own PBS_* env vars.
+
+set -u
+unset CDPATH
+
+# ---- Test harness ----------------------------------------------------------
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# ANSI colors (skip if NO_COLOR set)
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+    G=$'\033[1;32m'; R=$'\033[1;31m'; Y=$'\033[1;33m'; C=$'\033[1;36m'; N=$'\033[0m'
+else
+    G=""; R=""; Y=""; C=""; N=""
+fi
+
+# Locate failover.sh relative to this test file (resolves symlinks too).
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
+FAILOVER_LIB="${REPO_ROOT}/src/ezpz/bin/failover.sh"
+if [[ ! -f "${FAILOVER_LIB}" ]]; then
+    printf "%sFATAL%s: failover.sh not found at %s\n" "${R}" "${N}" "${FAILOVER_LIB}" >&2
+    exit 1
+fi
+
+run_test() {
+    # Usage: run_test "test_name" "test_function"
+    local name="$1"
+    local fn="$2"
+    printf "  %s%-60s%s " "${C}" "${name}" "${N}"
+
+    # Each test gets its own subshell + temp dir so they can't leak env
+    # vars or files into each other. Capture stdout+stderr in case the
+    # test needs them, and the test's exit code is the verdict.
+    local tmpdir
+    tmpdir=$(mktemp -d "/tmp/failover-test-XXXXXX")
+    local output
+    if output=$(
+        cd "${tmpdir}"
+        export TMPDIR="${tmpdir}"
+        export PBS_JOBID="testjob-$$"
+        # Re-source failover.sh inside the subshell so each test starts
+        # clean. We DO need to set NHOSTS first because the lib reads
+        # it; otherwise it stays unset between tests.
+        unset NHOSTS PBS_NODEFILE FAILOVER_LOG_DIR FAILOVER_ACTIVE \
+              FAILOVER_SPARE FAILOVER_BAD FAILOVER_PBS_NODEFILE_ORIG \
+              FAILOVER_IDLE_TIMEOUT FAILOVER_MAX_RETRIES \
+              FAILOVER_KEEP_BAD
+        # shellcheck disable=SC1090
+        source "${FAILOVER_LIB}"
+        "${fn}"
+    ) 2>&1; then
+        PASS=$((PASS+1))
+        printf "%sPASS%s\n" "${G}" "${N}"
+    else
+        FAIL=$((FAIL+1))
+        FAILED_TESTS+=("${name}")
+        printf "%sFAIL%s\n" "${R}" "${N}"
+        # Indent the captured output for readability
+        printf "%s\n" "${output}" | sed 's/^/      /'
+    fi
+    rm -rf "${tmpdir}"
+}
+
+# Assertion helpers (called from inside tests). Each `assert_*` exits the
+# subshell with non-zero on failure so run_test marks the test as FAIL.
+assert_eq() {
+    local actual="$1" expected="$2" msg="${3:-}"
+    if [[ "${actual}" != "${expected}" ]]; then
+        printf "ASSERT FAIL%s: got %q, want %q\n" \
+            "${msg:+ ($msg)}" "${actual}" "${expected}" >&2
+        exit 1
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="${3:-}"
+    if [[ "${haystack}" != *"${needle}"* ]]; then
+        printf "ASSERT FAIL%s: %q does not contain %q\n" \
+            "${msg:+ ($msg)}" "${haystack}" "${needle}" >&2
+        exit 1
+    fi
+}
+
+assert_file_contents() {
+    local file="$1" expected="$2"
+    if [[ ! -f "${file}" ]]; then
+        printf "ASSERT FAIL: file not found: %s\n" "${file}" >&2
+        exit 1
+    fi
+    local actual
+    actual=$(cat "${file}")
+    if [[ "${actual}" != "${expected}" ]]; then
+        printf "ASSERT FAIL: %s contents mismatch\n  want:\n%s\n  got:\n%s\n" \
+            "${file}" "${expected}" "${actual}" >&2
+        exit 1
+    fi
+}
+
+# Set up a fixture PBS_NODEFILE inside the cwd (the subshell's tmpdir).
+# Returns the path via stdout.
+setup_pbs_nodefile() {
+    local lines="$1"  # one host per line, separated by newlines
+    local file="${TMPDIR}/PBS_NODEFILE"
+    printf "%s\n" "${lines}" > "${file}"
+    export PBS_NODEFILE="${file}"
+    echo "${file}"
+}
+
+# Shadow `python3 -m ezpz.failover` with a script that emits the given
+# bad-node hostnames (one per line) when invoked. We create a fake `python3`
+# binary in a bin dir that's prepended to PATH; it inspects argv to detect
+# `-m ezpz.failover ...` and either emits the canned response or passes
+# through to the real python3 for everything else.
+shadow_scrape_response() {
+    local response="$1"   # multiline bad-host string (may be empty)
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/python3" <<EOF
+#!/usr/bin/env bash
+# Detect 'python3 -m ezpz.failover ...' (the scrape invocation).
+if [[ "\$1" == "-m" && "\$2" == "ezpz.failover" ]]; then
+    printf "%s" "${response//\"/\\\"}"
+    exit 0
+fi
+# Fall through to the real python3 for everything else.
+exec /usr/bin/env -i PATH="/usr/bin:/bin:/usr/local/bin" python3 "\$@"
+EOF
+    chmod +x "${bindir}/python3"
+    export PATH="${bindir}:${PATH}"
+}
+
+# Shadow `ezpz` itself with a script that records its invocation and exits
+# with the given code. Reads exit code from the file passed (so successive
+# attempts can return different codes).
+shadow_ezpz_launch() {
+    local exit_code_file="$1"  # path; we read one int per line, popping
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/ezpz" <<EOF
+#!/usr/bin/env bash
+# Record the invocation
+echo "ezpz \$*" >> "${TMPDIR}/ezpz_invocations.log"
+
+# Pop the next exit code from the file
+ec=\$(head -n 1 "${exit_code_file}" 2>/dev/null || echo 0)
+tail -n +2 "${exit_code_file}" > "${exit_code_file}.tmp" 2>/dev/null && mv "${exit_code_file}.tmp" "${exit_code_file}"
+exit "\${ec:-0}"
+EOF
+    chmod +x "${bindir}/ezpz"
+    export PATH="${bindir}:${PATH}"
+}
+
+# ---- Tests: failover_init --------------------------------------------------
+
+test_init_splits_hostfile() {
+    setup_pbs_nodefile "host1
+host2
+host3
+host4
+host5" >/dev/null
+
+    failover_init 3 || exit 1
+
+    # Active should be first 3, spare should be last 2.
+    assert_file_contents "${FAILOVER_ACTIVE}" "host1
+host2
+host3"
+    assert_file_contents "${FAILOVER_SPARE}" "host4
+host5"
+    # PBS_NODEFILE redirected to the active subset, NHOSTS set.
+    assert_eq "${PBS_NODEFILE}" "${FAILOVER_ACTIVE}" "PBS_NODEFILE points to active"
+    assert_eq "${NHOSTS}" "3" "NHOSTS"
+    # bad_nodes.txt created empty.
+    assert_file_contents "${FAILOVER_BAD}" ""
+}
+
+test_init_errors_when_nhosts_train_too_large() {
+    setup_pbs_nodefile "host1
+host2" >/dev/null
+    # Asking for 5 nodes when PBS only gave 2 should fail.
+    if failover_init 5 2>/dev/null; then
+        echo "ASSERT FAIL: expected failover_init 5 to fail" >&2
+        exit 1
+    fi
+}
+
+test_init_errors_when_no_pbs_nodefile() {
+    # PBS_NODEFILE intentionally unset.
+    if failover_init 1 2>/dev/null; then
+        echo "ASSERT FAIL: expected failover_init to fail without PBS_NODEFILE" >&2
+        exit 1
+    fi
+}
+
+test_init_errors_when_no_arg() {
+    setup_pbs_nodefile "host1" >/dev/null
+    if failover_init 2>/dev/null; then
+        echo "ASSERT FAIL: expected failover_init to fail with no arg" >&2
+        exit 1
+    fi
+}
+
+# ---- Tests: failover_swap_in -----------------------------------------------
+
+test_swap_in_replaces_bad_with_spare() {
+    setup_pbs_nodefile "host1
+host2
+host3
+host4
+host5" >/dev/null
+    failover_init 3 || exit 1
+    # Active: host1,host2,host3  Spare: host4,host5
+    failover_swap_in host2 || exit 1
+    # Active should now be host1,host4,host3 (host2 → host4)
+    assert_file_contents "${FAILOVER_ACTIVE}" "host1
+host4
+host3"
+    # Spare popped: just host5 left
+    assert_file_contents "${FAILOVER_SPARE}" "host5"
+    # bad_nodes.txt records what was swapped
+    assert_file_contents "${FAILOVER_BAD}" "host2"
+}
+
+test_swap_in_handles_multiple_bad_nodes() {
+    setup_pbs_nodefile "host1
+host2
+host3
+host4
+host5" >/dev/null
+    failover_init 3 || exit 1
+    failover_swap_in host1 host3 || exit 1
+    # host1 → host4, host3 → host5
+    assert_file_contents "${FAILOVER_ACTIVE}" "host4
+host2
+host5"
+    assert_file_contents "${FAILOVER_SPARE}" ""
+    assert_file_contents "${FAILOVER_BAD}" "host1
+host3"
+}
+
+test_swap_in_errors_when_no_spares() {
+    setup_pbs_nodefile "host1
+host2" >/dev/null
+    failover_init 2 || exit 1
+    # No spares (all 2 nodes went to active)
+    if failover_swap_in host1 2>/dev/null; then
+        echo "ASSERT FAIL: expected swap_in to fail with no spares" >&2
+        exit 1
+    fi
+}
+
+test_swap_in_skips_unknown_host() {
+    setup_pbs_nodefile "host1
+host2
+host3
+host4" >/dev/null
+    failover_init 3 || exit 1
+    # 'host_not_in_active' isn't in active; should be silently skipped
+    # without consuming a spare.
+    failover_swap_in host_not_in_active || exit 1
+    assert_file_contents "${FAILOVER_ACTIVE}" "host1
+host2
+host3"
+    assert_file_contents "${FAILOVER_SPARE}" "host4"
+    # bad_nodes.txt should NOT have the skip recorded
+    assert_file_contents "${FAILOVER_BAD}" ""
+}
+
+# ---- Tests: failover_swap_one_blind ----------------------------------------
+
+test_swap_one_blind_rotates_first_active() {
+    setup_pbs_nodefile "host1
+host2
+host3
+host4" >/dev/null
+    failover_init 3 || exit 1
+    failover_swap_one_blind || exit 1
+    # host1 (first active) gets replaced with host4 (first spare)
+    assert_file_contents "${FAILOVER_ACTIVE}" "host4
+host2
+host3"
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
+test_swap_one_blind_errors_when_no_spares() {
+    setup_pbs_nodefile "host1
+host2" >/dev/null
+    failover_init 2 || exit 1
+    if failover_swap_one_blind 2>/dev/null; then
+        echo "ASSERT FAIL: expected swap_one_blind to fail with no spares" >&2
+        exit 1
+    fi
+}
+
+# ---- Tests: failover_run ---------------------------------------------------
+
+test_run_succeeds_first_attempt() {
+    setup_pbs_nodefile "host1
+host2" >/dev/null
+    failover_init 2 || exit 1
+    # Mock ezpz to exit 0 on first call
+    echo "0" > "${TMPDIR}/exits.txt"
+    shadow_ezpz_launch "${TMPDIR}/exits.txt"
+    shadow_scrape_response ""
+
+    export FAILOVER_MAX_RETRIES=2
+    # Use a non-`ezpz launch` command so we don't trigger the flag
+    # injection path. `true` resolves via PATH so this works on macOS
+    # (where /bin/true exists at /usr/bin/true) and Linux alike.
+    failover_run true || exit 1
+}
+
+test_run_retries_on_failure_then_succeeds() {
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    # Set up: first attempt fails (exit 1), second succeeds (exit 0).
+    # Pre-populate attempt-2.log to be empty so the scraper returns nothing,
+    # which makes failover_run call swap_one_blind.
+    printf "1\n0\n" > "${TMPDIR}/exits.txt"
+
+    # Shadow `bash` so the tee'd command writes the log we expect to scrape.
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/failing_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then exit 1; else exit 0; fi
+EOF
+    chmod +x "${bindir}/failing_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""  # blind rotation each time
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run failing_cmd || exit 1
+    # First attempt swapped host1 → host3 blindly
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
+test_run_walltime_143_no_retry_when_clean() {
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    # Wrap a script that always exits 143 and writes a "clean" log
+    # (no bad-node crash patterns). Walltime kill → should NOT retry.
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/walltime_cmd" <<'EOF'
+#!/usr/bin/env bash
+echo "Normal training output"
+exit 143
+EOF
+    chmod +x "${bindir}/walltime_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""
+
+    export FAILOVER_MAX_RETRIES=3
+    # Expect rc=143; the function should NOT retry → bad_nodes.txt empty.
+    rc=0
+    failover_run walltime_cmd || rc=$?
+    assert_eq "${rc}" "143" "rc"
+    assert_file_contents "${FAILOVER_BAD}" ""
+}
+
+test_run_walltime_143_retries_when_bad_node_pattern_in_log() {
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    # Wrap a script that exits 143 but logs a bad-node pattern. Walltime
+    # AND bad-node → SHOULD retry. We mock so the second attempt exits 0.
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/bad_walltime_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then
+    echo "RuntimeError: [..gloo..] Connection closed by peer [10.0.0.1]:1234"
+    exit 143
+else
+    echo "Normal training output"
+    exit 0
+fi
+EOF
+    chmod +x "${bindir}/bad_walltime_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""  # blind rotation
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run bad_walltime_cmd || exit 1
+    # Should have swapped host1 → host3 on the bad-node retry
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
+test_run_swaps_named_bad_node_when_scraper_finds_one() {
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    # First attempt fails; scraper identifies host1 as the bad one;
+    # second attempt succeeds.
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/failing_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then exit 1; else exit 0; fi
+EOF
+    chmod +x "${bindir}/failing_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response "host1"  # named bad node
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run failing_cmd || exit 1
+    # Should have swapped the NAMED bad node (host1), not the first active
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
+test_run_exhausts_max_retries() {
+    setup_pbs_nodefile "host1
+host2
+host3
+host4
+host5" >/dev/null
+    failover_init 2 || exit 1
+    # Always-failing command should exhaust retries and return the
+    # failure exit code (not 0).
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/always_fails" <<'EOF'
+#!/usr/bin/env bash
+exit 42
+EOF
+    chmod +x "${bindir}/always_fails"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""
+
+    export FAILOVER_MAX_RETRIES=2
+    rc=0
+    failover_run always_fails || rc=$?
+    assert_eq "${rc}" "42" "rc — should propagate child's exit code"
+}
+
+test_run_ansi_stripping_in_inner_rc_detection() {
+    # If `ezpz launch` outputs `Execution finished with \x1b[1;36m127\x1b[0m`,
+    # the inner_rc detection must strip ANSI before parsing, otherwise it
+    # reads '1' from '[1;36m' and concludes a clean run.
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    # Command exits 0 (shell rc=0), but log says "Execution finished with 127"
+    # wrapped in ANSI. Wrapper should detect rc=127 and treat as failure.
+    # Then second attempt exits 0 cleanly.
+    cat > "${bindir}/ansi_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then
+    # The literal $'...' style ANSI escape sequence.
+    printf 'Execution finished with \e[1;36m127\e[0m\n'
+    exit 0  # exits 0 — the override must catch the inner 127
+else
+    echo "normal output"
+    exit 0
+fi
+EOF
+    chmod +x "${bindir}/ansi_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run ansi_cmd || exit 1
+    # If the ANSI override worked, attempt 1 was treated as a failure,
+    # we swapped host1 → host3 blindly, attempt 2 succeeded.
+    # If the ANSI override DIDN'T work, we'd have returned 0 after
+    # attempt 1 with NO swap, leaving bad_nodes.txt empty.
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
+test_run_ezpz_launch_injects_topology_args() {
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    # When the command is `ezpz launch ...`, the wrapper should inject
+    # --hostfile, --nnodes, -ppn, -n, --timeout. Capture the invocation
+    # via the shadow ezpz and assert.
+    echo "0" > "${TMPDIR}/exits.txt"
+    shadow_ezpz_launch "${TMPDIR}/exits.txt"
+    shadow_scrape_response ""
+
+    export NGPU_PER_HOST=4
+    export FAILOVER_IDLE_TIMEOUT=600
+    export FAILOVER_MAX_RETRIES=1
+    failover_run ezpz launch python3 -m my.app || exit 1
+
+    # Check the invocation log captured the injected args
+    local inv
+    inv=$(cat "${TMPDIR}/ezpz_invocations.log")
+    assert_contains "${inv}" "--hostfile=${FAILOVER_ACTIVE}" "--hostfile"
+    assert_contains "${inv}" "--nnodes=2" "--nnodes"
+    assert_contains "${inv}" "-ppn 4" "-ppn"
+    assert_contains "${inv}" "-n 8" "-n (2 nodes * 4 ppn)"
+    assert_contains "${inv}" "--timeout=600" "--timeout"
+    assert_contains "${inv}" "python3 -m my.app" "user command preserved"
+}
+
+# ---- Run all tests ---------------------------------------------------------
+
+printf "\n%sRunning failover.sh tests%s\n" "${C}" "${N}"
+printf "%s========================================================================%s\n" "${C}" "${N}"
+
+printf "\n%sfailover_init%s\n" "${C}" "${N}"
+run_test "init splits hostfile correctly"                     test_init_splits_hostfile
+run_test "init errors when nhosts_train > total"              test_init_errors_when_nhosts_train_too_large
+run_test "init errors when PBS_NODEFILE unset"                test_init_errors_when_no_pbs_nodefile
+run_test "init errors when no arg passed"                     test_init_errors_when_no_arg
+
+printf "\n%sfailover_swap_in%s\n" "${C}" "${N}"
+run_test "swap_in replaces bad host with spare"               test_swap_in_replaces_bad_with_spare
+run_test "swap_in handles multiple bad nodes"                 test_swap_in_handles_multiple_bad_nodes
+run_test "swap_in errors when no spares left"                 test_swap_in_errors_when_no_spares
+run_test "swap_in skips host not in active set"               test_swap_in_skips_unknown_host
+
+printf "\n%sfailover_swap_one_blind%s\n" "${C}" "${N}"
+run_test "swap_one_blind rotates first active node"           test_swap_one_blind_rotates_first_active
+run_test "swap_one_blind errors when no spares"               test_swap_one_blind_errors_when_no_spares
+
+printf "\n%sfailover_run%s\n" "${C}" "${N}"
+run_test "run succeeds on first attempt (no retry)"           test_run_succeeds_first_attempt
+run_test "run retries on failure, succeeds on attempt 2"      test_run_retries_on_failure_then_succeeds
+run_test "run does NOT retry on walltime (143) when clean"    test_run_walltime_143_no_retry_when_clean
+run_test "run DOES retry on 143 when log has bad-node pattern" test_run_walltime_143_retries_when_bad_node_pattern_in_log
+run_test "run swaps named bad node (from scraper)"            test_run_swaps_named_bad_node_when_scraper_finds_one
+run_test "run exhausts max retries, returns final rc"         test_run_exhausts_max_retries
+run_test "run detects inner_rc through ANSI escapes"          test_run_ansi_stripping_in_inner_rc_detection
+run_test "run injects topology args when wrapping ezpz launch" test_run_ezpz_launch_injects_topology_args
+
+# ---- Summary ---------------------------------------------------------------
+
+printf "\n%s========================================================================%s\n" "${C}" "${N}"
+printf "Summary  (%sPASS=%d%s  %sFAIL=%d%s)\n" \
+    "${G}" "${PASS}" "${N}" "${R}" "${FAIL}" "${N}"
+printf "%s========================================================================%s\n" "${C}" "${N}"
+
+if (( FAIL > 0 )); then
+    printf "\n%sFailed tests:%s\n" "${R}" "${N}"
+    printf "  - %s\n" "${FAILED_TESTS[@]}"
+    exit 1
+fi
+printf "\n%sAll %d tests passed. ✅%s\n" "${G}" "${PASS}" "${N}"
+exit 0

--- a/tests/test_failover_lib.sh
+++ b/tests/test_failover_lib.sh
@@ -451,6 +451,48 @@ EOF
     assert_eq "$(wc -l < "${FAILOVER_BAD}" | tr -d ' ')" "0" "bad_nodes_count"
 }
 
+test_run_walltime_143_retries_on_real_aurora_ur_oom_with_cascade() {
+    # Regression for actual Aurora torchtitan log shape (2026-05-12):
+    # 18 training steps complete cleanly, then a real level_zero
+    # UR_RESULT_ERROR_OUT_OF_RESOURCES on one rank, then mpiexec
+    # teardown emits `rank N died from signal 15` as a cascade
+    # alongside `rank N exited with code 1`. Without the innocent-
+    # cascade strip, this log would silently be misclassified as
+    # walltime — losing the bad-node signal.
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/aurora_ur_oom_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then
+    # Verbatim shape from the real postmortem.
+    echo "step:  1  loss: 12.94587  ..."
+    echo "step: 18  loss: 10.27772  ..."
+    echo "[rank7]: RuntimeError: level_zero backend failed with error: 40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)"
+    echo "x4610c4s3b0n0.hsn.cm.aurora.alcf.anl.gov: rank 7 exited with code 1"
+    echo "x4610c4s5b0n0.hsn.cm.aurora.alcf.anl.gov: rank 14 died from signal 15"
+    exit 143
+else
+    exit 0
+fi
+EOF
+    chmod +x "${bindir}/aurora_ur_oom_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""  # blind rotation
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run aurora_ur_oom_cmd || exit 1
+    # Verifies we DID retry (cascade didn't mask the real OOM).
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
 test_run_walltime_143_retries_on_real_hw_death_mixed_with_innocent_cascade() {
     # Companion to the prior test: even when the log has innocent
     # rank-cascade lines, a REAL hardware death (gloo, OOM, shepherd-9,
@@ -640,6 +682,7 @@ run_test "run does NOT retry on walltime (143) when clean"    test_run_walltime_
 run_test "run DOES retry on 143 when log has bad-node pattern" test_run_walltime_143_retries_when_bad_node_pattern_in_log
 run_test "run does NOT retry on 143 with only innocent rank-signal lines" test_run_walltime_143_no_retry_when_only_innocent_rank_signals
 run_test "run DOES retry on 143 when real hw death is mixed with cascade"  test_run_walltime_143_retries_on_real_hw_death_mixed_with_innocent_cascade
+run_test "run handles real Aurora UR_OOM + cascade regression"             test_run_walltime_143_retries_on_real_aurora_ur_oom_with_cascade
 run_test "run swaps named bad node (from scraper)"            test_run_swaps_named_bad_node_when_scraper_finds_one
 run_test "run exhausts max retries, returns final rc"         test_run_exhausts_max_retries
 run_test "run detects inner_rc through ANSI escapes"          test_run_ansi_stripping_in_inner_rc_detection


### PR DESCRIPTION
## Summary

**PR 2 of 3** in the failover integration plan (PR 1 = #142 scrape, PR 3 = `ezpz launch --auto-retry`). This PR is a **behavior-preserving port** of torchtitan's `failover_lib.sh` into ezpz, adapted to call the upstream `ezpz.failover` scraper (#142) instead of an inline script.

The retry/swap logic itself is unchanged from upstream. This PR is the substrate PR 3 needs to build the `ezpz launch --auto-retry` UX you described:

```bash
# Target shape (lands in PR 3):
ezpz launch --auto-retry --timeout 600 -n 512 -- python3 train.py
```

## What's here

`src/ezpz/bin/failover.sh` — bash library with five public functions:

| Function | Purpose |
|---|---|
| `failover_init NHOSTS_TRAIN` | Split `PBS_NODEFILE` into active + spare, export `NHOSTS`/`PBS_NODEFILE` pointing at the active subset |
| `failover_yeet_all` | Broadcast venv to all nodes via `ezpz yeet-env` so spares can swap in instantly |
| `failover_swap_in HOSTS...` | Swap each bad host for a spare, log to `bad_nodes.txt` |
| `failover_swap_one_blind` | Rotate one spare in blindly (used when scraper finds no specific node) |
| `failover_run COMMAND...` | Wrap a command in a retry loop with crash-detection, ANSI-stripping inner-rc parsing, walltime-vs-bad-node discrimination, and exit-124 watchdog handling |

## Changes from upstream torchtitan version

1. **Scraper invocation**: replaced `python3 "$(dirname ${BASH_SOURCE[0]})/scrape_bad_nodes.py"` with `python3 -m ezpz.failover --machine aurora`. Uses the package from #142.

2. **`set -u`-safe**: `failover_init` uses `${1:-}` to handle missing-arg explicitly instead of letting `set -u` abort the shell. Lets the function source cleanly into stricter wrapper scripts (and into our bash test harness, which uses `set -u`).

3. **macOS-portable sed**: replaced `sed -i` with `sed -i.bak && rm` so the library can be tested on dev Macs (BSD sed requires a suffix arg).

4. **Updated docstring**: the upstream version mentioned matching `rank N died from signal {9,11,15}`, which contradicts what the scraper actually does (only `shepherd died from signal 9` and gloo peer-closed). New docstring matches reality + cites the regression test for the `rank-11/15` EXCLUSION.

5. **Pedantic shellcheck cleanups**: `return "$rc"` quoting, SC2155 on the `NHOSTS` export. One intentional `shellcheck disable=SC2086` on `failover_swap_in $bad_nodes` (the unquoted word-split is required: `$bad_nodes` is the scraper's whitespace-separated hostname list and each must be passed as its own argument).

## Crash-detection logic preserved (the "hard-won" parts)

The retry loop has several non-obvious guards that come from real production postmortems. **All preserved verbatim**:

- **shell-exit-0-but-log-says-crash override** (line ~215): `ezpz launch`'s outer Python wrapper sometimes exits 0 even when the inner mpiexec child crashed. Cross-check the log for `Execution finished with N` trailers (with ANSI-stripping — the trailer is colored) and known mass-traceback patterns (`died from signal`, `OutOfMemoryError`, `UR_RESULT_ERROR_OUT_OF_RESOURCES`, `EOFError: No data left in file`, etc.). Override rc if any of those fired.

- **Walltime + bad-node discrimination** (line ~257): exit 143 (SIGTERM from PBS walltime) normally **isn't** retried — no point swapping nodes if wallclock killed us. BUT if the log **also** contains bad-node patterns, we DO retry — a real bad-node crash can surface as 143 when mpiexec teardown races the walltime kill.

- **exit 124 (idle-output watchdog) → blind rotation** (line ~274): catches silent hangs like job 8479579 (W&B alive but training metrics dead for 5h). Composes with `ezpz launch --timeout` (#136).

- **Topology arg injection** when wrapping `ezpz launch`: pre-computes `--hostfile`/`--nnodes`/`-ppn`/`-n`/`--timeout` from the active subset, so the launcher doesn't re-derive topology from the (full) PBS aux file and trip `_infer_topology`'s divisibility check.

Job IDs cited in the source comments (real failures these guards catch): 8459818, 8460301, 8463659, 8470102, 8470103, 8479581, 8466848, 8479579, 8485515, 8503077.

## Tests

`tests/test_failover_lib.sh` — 18 bash tests using a custom `run_test` harness (each test in its own subshell + tmpdir; assertion helpers exit non-zero to mark failure). Real bash tests, not shellcheck.

### Coverage

**`failover_init`** (4 tests):
- splits hostfile correctly
- errors when `nhosts_train > total`
- errors when `PBS_NODEFILE` unset
- errors when no arg passed

**`failover_swap_in`** (4 tests):
- replaces named bad host with spare
- handles multiple bad nodes
- errors when no spares left
- skips hosts not in active set

**`failover_swap_one_blind`** (2 tests):
- rotates first active node
- errors when no spares

**`failover_run`** (8 tests):
- succeeds first attempt (no retry)
- retries on failure, succeeds on attempt 2
- does NOT retry on walltime (143) when log is clean
- DOES retry on 143 when log contains bad-node pattern
- swaps NAMED bad node when scraper finds one (vs. blind)
- exhausts max retries, returns final rc
- ANSI-stripping inner_rc detection (regression for `Execution finished with \e[1;36m127\e[0m` shape)
- topology arg injection when wrapping `ezpz launch`

### Test mechanism

Tests shadow `ezpz` and `python3 -m ezpz.failover` with stub scripts on `$PATH`. `ezpz` reads its exit code from a queue file (so a single test can simulate "first call fails, second succeeds"). The scraper stub emits canned bad-host strings. Lets the wrapper exercise the full retry/swap loop without needing a real PBS allocation, mpirun, or any compute.

## Results

- **18/18 failover_lib bash tests pass** locally on macOS
- **36/36 failover_scrape Python tests pass** (no regressions)
- `shellcheck -s bash src/ezpz/bin/failover.sh` clean

## Follow-up

**PR 3** wires this into `ezpz launch` as the `--auto-retry` flag. From the project memory file (`project_failover_integration.md`):

```bash
# After PR 3:
ezpz launch --auto-retry --timeout 600 -n 512 -- python3 train.py
```

PR 3 detects spare nodes from the PBS allocation (`total - $nproc`), drives the retry loop until walltime / spare exhaustion / unrecoverable code bug (with a "no progress" detector for the latter so a broken config doesn't burn all spares).

## Test plan

- [x] Local: `bash tests/test_failover_lib.sh` → 18/18 PASS
- [x] Local: `pytest tests/test_failover_scrape.py -q` → 36/36 (no regressions from PR 1)
- [x] `shellcheck -s bash src/ezpz/bin/failover.sh` clean
- [ ] On a real Aurora allocation: source the lib, run a job that wraps a known-failing command, verify the swap/retry actually swaps and retries

## Summary by Sourcery

Port the torchtitan failover shell library into ezpz and add a comprehensive bash test suite to validate its node failover and retry behavior.

New Features:
- Introduce src/ezpz/bin/failover.sh as a reusable shell library providing initialization, environment broadcast, node swap, blind swap, and retry-orchestrated command execution for bad-node failover.

Enhancements:
- Integrate log-based crash detection, walltime vs bad-node discrimination, idle-timeout handling, and topology argument injection when wrapping ezpz launch into the failover wrapper.

Tests:
- Add tests/test_failover_lib.sh with a bash harness and 18 tests covering hostfile splitting, node swapping, blind swaps, retry logic, crash and walltime handling, ANSI-stripping inner exit code detection, and topology argument injection for ezpz launch.