### PR TITLE
feat(launch): add --auto-retry for unbounded bad-node failover (PR 3/3)

### DIFF
--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -216,6 +216,13 @@ post-mortem `grep` is reliable.
 | 8 | bad-node verdict but no spares left                    | **EXHAUSTED** → return rc |
 | 9 | SIGINT (Ctrl-C)                                        | **INTERRUPTED** → return 130 |
 
+**Empty-`swap_in` fallback.** Row 5's `swap_in` skips any host that
+isn't currently in the active set (the named host was already
+replaced on a prior attempt, the scraper picked up stale lines from
+an older log, etc.). If `swap_in` ends up swapping zero hosts, the
+loop falls through to row 6's `swap_one_blind` so it still makes
+forward progress instead of looping on the same bad set.
+
 The `step=` marker guard (#7) replaces a numeric "max consecutive
 blind rotations" cap. The intent is to catch broken configs / missing
 datasets / pre-training-loop bugs before they burn the entire spare
@@ -248,6 +255,15 @@ Per-job, in `$(pwd)/logs/failover-<jobid>/`:
 - `bad_nodes.txt` — every host that's been swapped out (named
   swap_in *and* blind rotations). Append-only.
 - `attempt-N.log` — combined stdout+stderr of attempt N.
+
+> **Note on `active.hostfile` mutation.** The file is rewritten in
+> place between attempts. If you `cat` it from a second shell
+> mid-run, you'll see the *current* active set, not the original
+> PBS allocation. The launcher reads it fresh at each attempt — no
+> re-launch of `ezpz launch` itself is needed for the new contents
+> to take effect, since the launcher subprocess re-resolves the
+> hostfile path's contents per spawn. To inspect the *original*
+> PBS allocation, look at `$PBS_NODEFILE` (unmodified) instead.
 
 ### Relationship to `src/ezpz/bin/failover.sh`
 

--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -85,6 +85,15 @@ allocated to your job.
         --timeout IDLE_TIMEOUT_S
                                 Idle-output watchdog timeout in seconds. Off by default.
         --retries RETRIES     Re-execute on non-zero exit, up to N times. Default: 0.
+        --auto-retry          Unbounded bad-node failover loop. Mutually
+                                exclusive with --retries. Requires explicit --nproc.
+        --spare-nodes SPARE_NODES
+                                Spare-node pool for --auto-retry. "auto" (default)
+                                derives from total_pbs_nodes - $nproc; pass an int
+                                for an explicit cap.
+        --max-failover-retries MAX_FAILOVER_RETRIES
+                                Optional upper bound on --auto-retry attempts.
+                                Default: unbounded (see termination matrix).
         ```
 
 ## Idle-output watchdog (`--timeout`)
@@ -140,6 +149,115 @@ A clean exit on any attempt short-circuits the loop and returns 0.
 If every attempt fails, the final attempt's exit code is returned.
 Combine with `--timeout` to convert silent hangs into retryable
 failures.
+
+## Auto-retry on bad-node failure (`--auto-retry`)
+
+`--auto-retry` engages the failover loop. On every non-zero exit,
+ezpz scrapes the log for known bad-node signatures (Aurora PALS
+shepherd-9, gloo TCP peer-closed), swaps each named host out for a
+spare from the rest of the PBS allocation, and re-runs the command.
+Unlike `--retries N`, the loop is *unbounded* by default — it
+continues until one of the conditions in the **termination matrix**
+below fires.
+
+```bash
+# 522 nodes allocated by PBS; use 512 for training, reserve 10 as
+# spares. Loop until success / walltime / spare exhaustion.
+ezpz launch --auto-retry --np 512 -- python3 -m ezpz.examples.test
+```
+
+`--auto-retry` is **mutually exclusive** with `--retries`. They model
+different things: `--retries N` is a bounded *process-level* retry
+that re-launches the same command on the same nodes. `--auto-retry`
+is an unbounded *node-level* failover that swaps bad hosts out
+between attempts.
+
+### Required: explicit `--nproc`
+
+`--auto-retry` needs to know how many ranks are training so it can
+split the PBS allocation into active + spare. We **do not guess**
+the active-host count — pass `--nproc N` (or `-n N` / `--np N`)
+explicitly. The CLI errors out at parse time otherwise:
+
+```text
+$ ezpz launch --auto-retry -- python3 train.py
+--auto-retry requires --nproc (-n/--np) to be set explicitly. ...
+```
+
+### Spare-node policy (`--spare-nodes`)
+
+By default (`--spare-nodes auto`), the spare pool is
+`total_pbs_nodes - $nproc/$ppn`. So if PBS gave you 522 nodes and
+you ask for 512 training ranks on 12-GPU nodes, the spare pool is
+`522 - 43 = 479` — though you'll usually want to reserve fewer in
+practice (a node typically isn't worth using if 50 others failed
+on it first).
+
+Pass `--spare-nodes N` to cap the pool explicitly:
+
+```bash
+ezpz launch --auto-retry --np 512 --spare-nodes 10 -- ...
+```
+
+### Termination matrix
+
+Every termination logs a single `FAILOVER STOP: <reason>` line so
+post-mortem `grep` is reliable.
+
+| # | Condition                                              | Result                |
+|---|--------------------------------------------------------|-----------------------|
+| 1 | exit 0 (clean inner trailer, no crash patterns)        | **SUCCESS** → return 0|
+| 2 | exit 143 (walltime SIGTERM), no crash patterns         | **WALLTIME** → return rc|
+| 3 | exit 143 *with* crash patterns in log                  | bad-node retry (real failure raced the walltime kill) |
+| 4 | exit 124 (idle-output watchdog tripped)                | bad-node retry (silent hang → blind rotation) |
+| 5 | any other non-zero, scraper found named host(s)        | **swap_in** named → retry |
+| 6 | any other non-zero, scraper found nothing              | **swap_one_blind** → retry |
+| 7 | two consecutive attempts with zero `step=` markers     | **STUCK_PRE_TRAINING** → return rc |
+| 8 | bad-node verdict but no spares left                    | **EXHAUSTED** → return rc |
+| 9 | SIGINT (Ctrl-C)                                        | **INTERRUPTED** → return 130 |
+
+The `step=` marker guard (#7) replaces a numeric "max consecutive
+blind rotations" cap. The intent is to catch broken configs / missing
+datasets / pre-training-loop bugs before they burn the entire spare
+pool — if two attempts in a row die before `History.update` prints
+its first `step=N` line, no amount of node-swapping will help.
+
+### Default idle-output watchdog
+
+When `--auto-retry` is set, `--timeout` defaults to **1800 seconds**
+(30 minutes) instead of being off. This matches the
+`FAILOVER_IDLE_TIMEOUT` default in `src/ezpz/bin/failover.sh` and
+prevents silent xccl hangs from burning the full PBS walltime
+before the loop can intervene. Pass `--timeout 0` to disable, or
+`--timeout N` to override.
+
+### Optional cap (`--max-failover-retries`)
+
+`--max-failover-retries N` is an additional belt-and-suspenders
+cap. Default is unbounded — terminate only via the matrix above.
+Useful for short jobs where you'd rather give up than retry 100
+times.
+
+### Files written
+
+Per-job, in `$(pwd)/logs/failover-<jobid>/`:
+
+- `active.hostfile` — the *current* active node set, mutated in
+  place as nodes are swapped. Always reflects what the next attempt
+  will run on.
+- `bad_nodes.txt` — every host that's been swapped out (named
+  swap_in *and* blind rotations). Append-only.
+- `attempt-N.log` — combined stdout+stderr of attempt N.
+
+### Relationship to `src/ezpz/bin/failover.sh`
+
+`failover.sh` is the bash equivalent for users who can't put
+`ezpz launch` at the top of their job script — for example,
+`qsub`'ing a wrapper that already invokes `python` directly. The
+scrape source is identical (`ezpz.failover.scrape_bad_nodes`); the
+retry/swap mechanics are independent re-implementations because the
+classifier is much easier to test in Python. Prefer `--auto-retry`
+when you can, fall back to sourcing the bash lib when you can't.
 
 ## Python interpreter resolution
 

--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -192,14 +192,17 @@ flowchart TD
     CheckStuck -->|no| CheckSpares{"spares left?"}
     CheckSpares -->|no| Exhausted(["FAILOVER STOP:<br/>exhausted<br/>return rc"])
     CheckSpares -->|yes| CheckScraper{"scraper found<br/>named host(s)?"}
-    CheckScraper -->|yes| SwapIn["swap_in<br/>named hosts"]
-    CheckScraper -->|no| SwapBlind["swap_one_blind"]
-    SwapIn --> CheckSwapped{"actually swapped<br/>any host?"}
-    CheckSwapped -->|"no<br/>(all already<br/>replaced)"| SwapBlind
-    CheckSwapped -->|yes| Backoff
-    SwapBlind --> Backoff["Backoff sleep:<br/>5/10/20/40/60s"]
+    CheckScraper -->|yes| Swap["Swap bad host(s)<br/>for spare(s),<br/>rewrite active.hostfile"]
+    CheckScraper -->|no| Swap
+    Swap --> Backoff["Backoff sleep:<br/>5/10/20/40/60s"]
     Backoff --> Attempt
 ```
+
+The single `Swap` node above is `swap_in` when the scraper named
+hosts and `swap_one_blind` when it didn't — see the
+[empty-`swap_in` fallback](#termination-matrix) note for the
+edge case where `swap_in` finds no live hosts to replace and
+falls through to a blind rotation.
 
 ### Required: explicit `--nproc`
 

--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -172,6 +172,35 @@ that re-launches the same command on the same nodes. `--auto-retry`
 is an unbounded *node-level* failover that swaps bad hosts out
 between attempts.
 
+### Decision flow at a glance
+
+```mermaid
+flowchart TD
+    Start(["ezpz launch --auto-retry --np N"]) --> Validate{"nproc set<br/>explicitly?"}
+    Validate -->|no| ErrParse["SystemExit at parse:<br/>requires --nproc"]
+    Validate -->|yes| Split["Split PBS nodelist<br/>into active + spare,<br/>write active.hostfile"]
+    Split --> Attempt["Run attempt i<br/>tee to attempt-i.log,<br/>watchdog armed<br/>(default 1800s)"]
+    Attempt -->|"SIGINT<br/>(Ctrl-C)"| Interrupted(["FAILOVER STOP:<br/>interrupted<br/>return 130"])
+    Attempt --> GotRC["rc = child exit<br/>124 if watchdog fired"]
+    GotRC --> Strip["Strip ANSI codes,<br/>strip innocent<br/>rank-cascade lines"]
+    Strip --> CheckSuccess{"rc==0 AND<br/>no crash patterns<br/>AND inner_rc==0?"}
+    CheckSuccess -->|yes| Success(["FAILOVER STOP:<br/>success<br/>return 0"])
+    CheckSuccess -->|no| CheckWalltime{"rc==143 AND<br/>no crash patterns?"}
+    CheckWalltime -->|yes| Walltime(["FAILOVER STOP:<br/>walltime<br/>return 143"])
+    CheckWalltime -->|no| CheckStuck{"prior AND current<br/>attempt both have<br/>0 step= markers?"}
+    CheckStuck -->|yes| Stuck(["FAILOVER STOP:<br/>stuck_pre_training<br/>return rc"])
+    CheckStuck -->|no| CheckSpares{"spares left?"}
+    CheckSpares -->|no| Exhausted(["FAILOVER STOP:<br/>exhausted<br/>return rc"])
+    CheckSpares -->|yes| CheckScraper{"scraper found<br/>named host(s)?"}
+    CheckScraper -->|yes| SwapIn["swap_in<br/>named hosts"]
+    CheckScraper -->|no| SwapBlind["swap_one_blind"]
+    SwapIn --> CheckSwapped{"actually swapped<br/>any host?"}
+    CheckSwapped -->|"no<br/>(all already<br/>replaced)"| SwapBlind
+    CheckSwapped -->|yes| Backoff
+    SwapBlind --> Backoff["Backoff sleep:<br/>5/10/20/40/60s"]
+    Backoff --> Attempt
+```
+
 ### Required: explicit `--nproc`
 
 `--auto-retry` needs to know how many ranks are training so it can
@@ -228,6 +257,84 @@ blind rotations" cap. The intent is to catch broken configs / missing
 datasets / pre-training-loop bugs before they burn the entire spare
 pool — if two attempts in a row die before `History.update` prints
 its first `step=N` line, no amount of node-swapping will help.
+
+### Worked example — real Aurora `UR_RESULT_ERROR_OUT_OF_RESOURCES`
+
+Here's an excerpt from a real Aurora torchtitan job that the
+classifier handles correctly. The relevant signals from
+`attempt-1.log`:
+
+```
+[2026-05-12 08:04:23][I][components/metrics:526:log] step:  1  loss: 12.94587  ...
+[2026-05-12 08:04:30][I][components/metrics:526:log] step:  2  loss: 12.90856  ...
+... (16 more clean training steps) ...
+[2026-05-12 08:06:24][I][components/metrics:526:log] step: 18  loss: 10.27772  ...
+[rank7]: RuntimeError: level_zero backend failed with error: 40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)
+x4610c4s3b0n0.hsn.cm.aurora.alcf.anl.gov: rank 7 exited with code 1
+x4610c4s5b0n0.hsn.cm.aurora.alcf.anl.gov: rank 14 died from signal 15
+[ezpz/launch] Execution finished with 143.
+```
+
+What the classifier does step by step:
+
+1. `rc=143` from the shell (mpiexec teardown after the GPU OOM).
+2. Strip ANSI codes from the log.
+3. Strip innocent rank-cascade lines: `rank 14 died from signal 15`
+   is a **downstream cascade** from the primary kill on
+   `x4610c4s3b0n0`, not a bad-node indicator on `x4610c4s5b0n0`.
+   This line is excluded *before* the crash-pattern match runs
+   (job 8466848 postmortem — tagging cascade victims as bad nodes
+   burns spares for nothing).
+4. Run the crash-pattern grep on the stripped text:
+   `UR_RESULT_ERROR_OUT_OF_RESOURCES` matches → there IS a real
+   hardware failure in the log.
+5. `rc==143 AND crash_patterns` → **bad-node retry path**, not
+   `WALLTIME`. Without the strip we'd still get to bad-node retry
+   (the cascade lines also contain `died from signal`), but we'd
+   reach it via the *wrong* condition — and we'd be at risk of
+   tagging `x4610c4s5b0n0` as a bad node when only
+   `x4610c4s3b0n0` is the actual culprit.
+6. Scraper picks up the hostname from the
+   `x4610c4s3b0n0.hsn...: rank 7 exited with code 1` line (or, if
+   the scraper missed it because it's not in the explicit pattern
+   set, falls through to `swap_one_blind`).
+7. `bad_nodes.txt` gets `x4610c4s3b0n0.hsn.cm.aurora.alcf.anl.gov`.
+   `active.hostfile` is rewritten with that host replaced by the
+   next spare.
+8. Backoff 5 seconds, run `attempt-2.log`. The retry uses the
+   updated active set; the bad GPU is no longer in the training
+   pool.
+
+This exact log shape is pinned as a regression test in both code
+paths:
+[`test_crash_patterns_real_ur_oom_with_cascade_regression`](https://github.com/saforem2/ezpz/blob/main/tests/test_launch_autoretry.py)
+(Python) and
+[`test_run_walltime_143_retries_on_real_aurora_ur_oom_with_cascade`](https://github.com/saforem2/ezpz/blob/main/tests/test_failover_lib.sh)
+(bash).
+
+### Reading the postmortem log
+
+After a run finishes (success, walltime, or exhausted), the
+`logs/failover-<jobid>/` directory is the postmortem entry point.
+A few one-liners:
+
+```bash
+# What was the final verdict?
+grep "FAILOVER STOP" logs/failover-*/attempt-*.log
+
+# Which nodes were swapped out across all attempts?
+cat logs/failover-*/bad_nodes.txt
+
+# Which step did each attempt reach before dying?
+for f in logs/failover-*/attempt-*.log; do
+  echo "=== $f ==="
+  grep -oE "step:[[:space:]]+[0-9]+" "$f" | tail -1
+done
+
+# Was the failure a real hardware death or just a walltime hit?
+grep -E "OutOfMemoryError|UR_RESULT_ERROR|gloo.*Connection closed|shepherd died" \
+  logs/failover-*/attempt-*.log
+```
 
 ### Default idle-output watchdog
 

--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -89,8 +89,8 @@ allocated to your job.
                                 exclusive with --retries. Requires explicit --nproc.
         --spare-nodes SPARE_NODES
                                 Spare-node pool for --auto-retry. "auto" (default)
-                                derives from total_pbs_nodes - $nproc; pass an int
-                                for an explicit cap.
+                                derives from total_pbs_nodes - ceil($nproc / $ppn);
+                                pass an int for an explicit cap.
         --max-failover-retries MAX_FAILOVER_RETRIES
                                 Optional upper bound on --auto-retry attempts.
                                 Default: unbounded (see termination matrix).
@@ -161,8 +161,10 @@ continues until one of the conditions in the **termination matrix**
 below fires.
 
 ```bash
-# 522 nodes allocated by PBS; use 512 for training, reserve 10 as
-# spares. Loop until success / walltime / spare exhaustion.
+# 50 nodes allocated by PBS on Aurora (12 ranks/node = 600 GPUs).
+# Train on 512 ranks (= ceil(512/12) = 43 hosts), reserve the
+# remaining 7 hosts as spares. Loop until success / walltime /
+# spare exhaustion.
 ezpz launch --auto-retry --np 512 -- python3 -m ezpz.examples.test
 ```
 
@@ -219,16 +221,21 @@ $ ezpz launch --auto-retry -- python3 train.py
 ### Spare-node policy (`--spare-nodes`)
 
 By default (`--spare-nodes auto`), the spare pool is
-`total_pbs_nodes - $nproc/$ppn`. So if PBS gave you 522 nodes and
-you ask for 512 training ranks on 12-GPU nodes, the spare pool is
-`522 - 43 = 479` — though you'll usually want to reserve fewer in
-practice (a node typically isn't worth using if 50 others failed
-on it first).
+`total_pbs_nodes - ceil($nproc / $ppn)`. The `--nproc` (or `-n`,
+`--np`) flag counts *ranks*, not nodes; we ceiling-divide by the
+ranks-per-node (`--ppn` or the cluster's `get_gpus_per_node()`) to
+get the number of *hosts* actually needed for training. Any
+allocated nodes beyond that go into the spare pool.
 
-Pass `--spare-nodes N` to cap the pool explicitly:
+So if PBS gave you 50 nodes on Aurora (12 GPUs/node) and you ask
+for 512 training ranks, the active set is `ceil(512/12) = 43`
+hosts and the spare pool is `50 - 43 = 7`. Pass `--spare-nodes N`
+to cap the pool explicitly (useful when you'd rather not use the
+full leftover slice):
 
 ```bash
-ezpz launch --auto-retry --np 512 --spare-nodes 10 -- ...
+# Cap the spare pool at 5, regardless of how many nodes PBS gave us.
+ezpz launch --auto-retry --np 512 --spare-nodes 5 -- ...
 ```
 
 ### Termination matrix

--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -388,9 +388,12 @@ def build_launch_parser(
             "SIGKILL after a 10s grace period) and exit with code 124. "
             "NOT a total walltime — the process can run indefinitely "
             "as long as it keeps emitting output on either stream. "
-            "Off by default; pass 0 explicitly to disable. Useful for "
-            "catching collective hangs (e.g. xccl silent deadlock on "
-            "XPU) that would otherwise consume the full PBS walltime."
+            "Off by default, BUT defaults to 1800 (30 min) when "
+            "--auto-retry is set (matches FAILOVER_IDLE_TIMEOUT in "
+            "src/ezpz/bin/failover.sh — silent xccl hangs otherwise "
+            "burn the full PBS walltime). Pass 0 explicitly to disable "
+            "even under --auto-retry. Useful for catching collective "
+            "hangs (e.g. xccl silent deadlock on XPU)."
         ),
     )
     parser.add_argument(

--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -33,6 +33,20 @@ def _non_negative_int(value: str) -> int:
     return as_int
 
 
+def _spare_nodes_value(value: str) -> "int | str":
+    """argparse type for ``--spare-nodes``.
+
+    Accepts either the literal string ``"auto"`` (derive from
+    ``total_pbs_nodes - $nproc``) or a non-negative integer. Returning
+    a union here keeps the auto/explicit distinction visible to the
+    downstream resolver — `launch.py` checks for the string before
+    treating the value as a count.
+    """
+    if value == "auto":
+        return "auto"
+    return _non_negative_int(value)
+
+
 def build_test_parser(*, prog: str | None = None) -> argparse.ArgumentParser:
     """Build the CLI argument parser for ``ezpz test`` (ezpz.examples.test)."""
     parser = argparse.ArgumentParser(
@@ -389,6 +403,48 @@ def build_launch_parser(
             "exit (including a watchdog kill, exit 124). Applies "
             "exponential backoff between attempts (5s, 10s, 20s, ..., "
             "capped at 60s). Default: 0 (no retry)."
+        ),
+    )
+    parser.add_argument(
+        "--auto-retry",
+        action="store_true",
+        dest="auto_retry",
+        help=(
+            "Run with automatic bad-node failover. On every non-zero "
+            "exit (including watchdog kill, exit 124, and walltime-"
+            "racing crashes that surface as 143), scrape the log for "
+            "known bad-node signatures (Aurora PALS shepherd-9, gloo "
+            "peer-closed) and either swap the named hosts for spares "
+            "or rotate one spare blindly. Loops until success, a real "
+            "walltime hit, spare exhaustion, two consecutive attempts "
+            "with zero training progress, or SIGINT. "
+            "Requires --nproc to be set explicitly. "
+            "Mutually exclusive with --retries."
+        ),
+    )
+    parser.add_argument(
+        "--spare-nodes",
+        type=_spare_nodes_value,
+        default=None,
+        dest="spare_nodes",
+        help=(
+            "Number of spare nodes to reserve for --auto-retry "
+            "swap-ins. Pass 'auto' (the default when --auto-retry is "
+            "set) to derive from total_pbs_nodes - $nproc. Pass an "
+            "integer for an explicit count. Ignored when --auto-retry "
+            "is not set."
+        ),
+    )
+    parser.add_argument(
+        "--max-failover-retries",
+        type=_non_negative_int,
+        default=None,
+        dest="max_failover_retries",
+        help=(
+            "Upper bound on --auto-retry attempts. Default: unbounded "
+            "— termination is governed by the matrix in "
+            "docs/cli/launch/index.md (success, walltime, exhaustion, "
+            "stuck-pre-training, or SIGINT)."
         ),
     )
     if include_command:

--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -37,7 +37,8 @@ def _spare_nodes_value(value: str) -> "int | str":
     """argparse type for ``--spare-nodes``.
 
     Accepts either the literal string ``"auto"`` (derive from
-    ``total_pbs_nodes - $nproc``) or a non-negative integer. Returning
+    ``total_pbs_nodes - ceil($nproc / $ppn)``) or a non-negative
+    integer. Returning
     a union here keeps the auto/explicit distinction visible to the
     downstream resolver — `launch.py` checks for the string before
     treating the value as a count.
@@ -433,7 +434,8 @@ def build_launch_parser(
         help=(
             "Number of spare nodes to reserve for --auto-retry "
             "swap-ins. Pass 'auto' (the default when --auto-retry is "
-            "set) to derive from total_pbs_nodes - $nproc. Pass an "
+            "set) to derive from total_pbs_nodes - ceil($nproc / $ppn) "
+            "(ranks → hosts, since --nproc counts ranks). Pass an "
             "integer for an explicit count. Ignored when --auto-retry "
             "is not set."
         ),

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -825,8 +825,12 @@ def launch(
         autoretry_pool = _resolve_auto_retry_node_pool(
             selected_hostfile, nodelist
         )
-        gpus_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
-        nhosts_active = _ranks_to_hosts(ngpus, gpus_per_node)
+        # `--ppn` (== ngpu_per_host) sets ranks-per-node when given;
+        # fall back to the cluster's GPU count (the typical default,
+        # one rank per GPU) when not. `or 1` covers the degenerate
+        # case where get_gpus_per_node() returns 0 on a non-GPU node.
+        ranks_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
+        nhosts_active = _ranks_to_hosts(ngpus, ranks_per_node)
         autoretry_log_dir = _auto_retry_log_dir(jobid)
         autoretry_allocation, autoretry_hostfile = (
             _resolve_auto_retry_allocation(

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -814,11 +814,16 @@ def launch(
     autoretry_allocation = None
     autoretry_log_dir: Optional[Path] = None
     if auto_retry:
+        # CLI entrypoints (parse_args) already enforce this; the
+        # check here is the library-level precondition for direct
+        # `launch(auto_retry=True, ngpus=None)` callers. Same
+        # invariant, different audience.
         if ngpus is None:
-            raise SystemExit(
-                "--auto-retry requires --nproc (-n/--np) to be set "
-                "explicitly. We need to know the training rank count "
-                "to split the PBS allocation into active + spare."
+            raise ValueError(
+                "launch(auto_retry=True) requires ngpus to be set "
+                "explicitly. The auto-retry loop needs the training "
+                "rank count to split the node pool into active + "
+                "spare. (CLI: pass --nproc / -n / --np.)"
             )
         # Source the candidate node pool. Explicit --hostfile beats
         # the scheduler nodelist — see _resolve_auto_retry_node_pool.
@@ -893,9 +898,6 @@ def launch(
         )
         ar_config = AutoRetryConfig(
             cmd=list(cmd),
-            hostfile=Path(selected_hostfile)
-            if selected_hostfile is not None
-            else Path(),
             log_dir=autoretry_log_dir,
             idle_timeout_s=effective_timeout,
             max_failover_retries=max_failover_retries,

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -634,6 +634,19 @@ def build_executable(
     return executable
 
 
+def _ranks_to_hosts(nranks: int, ranks_per_host: int) -> int:
+    """Ceiling-divide ranks → hosts.
+
+    Example: 13 ranks on 12-GPU nodes → 2 hosts (not 1). We need
+    enough hosts to fit every rank, not "as many as fit cleanly."
+
+    Both args must be positive; the auto-retry wrapper validates
+    at call time. Extracted so the auto-retry resolver and tests
+    share a single canonical formula.
+    """
+    return (nranks + ranks_per_host - 1) // ranks_per_host
+
+
 def _resolve_auto_retry_allocation(
     full_nodelist: Sequence[str],
     nproc_active_hosts: int,
@@ -772,8 +785,7 @@ def launch(
                 "active job?). Cannot split into active + spare."
             )
         gpus_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
-        # Round-up division: 12 ranks on 4-gpu nodes → 3 nodes.
-        nhosts_active = (ngpus + gpus_per_node - 1) // gpus_per_node
+        nhosts_active = _ranks_to_hosts(ngpus, gpus_per_node)
         autoretry_log_dir = _auto_retry_log_dir(jobid)
         autoretry_allocation, autoretry_hostfile = (
             _resolve_auto_retry_allocation(

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -634,6 +634,47 @@ def build_executable(
     return executable
 
 
+def _resolve_auto_retry_node_pool(
+    hostfile: Optional[Path],
+    scheduler_nodelist: Optional[Sequence[str]],
+) -> list[str]:
+    """Pick the node pool for ``--auto-retry`` to split into active + spare.
+
+    Priority:
+
+    1. ``hostfile`` if the user passed one — they might have pre-
+       filtered the scheduler's list (e.g. dropped known-bad nodes
+       from a previous job) and silently switching back would undo
+       that work.
+    2. ``scheduler_nodelist`` from PBS/SLURM otherwise.
+
+    Raises :class:`SystemExit` if neither source yields a non-empty
+    list — auto-retry can't split a pool of zero hosts.
+    """
+    if hostfile is not None:
+        try:
+            lines = hostfile.read_text().splitlines()
+        except OSError as exc:
+            raise SystemExit(
+                f"--auto-retry: failed to read --hostfile {hostfile}: "
+                f"{exc}"
+            ) from exc
+        pool = [ln.strip() for ln in lines if ln.strip()]
+        if not pool:
+            raise SystemExit(
+                f"--auto-retry: --hostfile {hostfile} is empty. "
+                "Cannot split into active + spare."
+            )
+        return pool
+    if scheduler_nodelist:
+        return list(scheduler_nodelist)
+    raise SystemExit(
+        "--auto-retry: failed to read the PBS nodelist (no active "
+        "job?). Pass --hostfile explicitly or run inside a PBS/SLURM "
+        "job. Cannot split into active + spare."
+    )
+
+
 def _ranks_to_hosts(nranks: int, ranks_per_host: int) -> int:
     """Ceiling-divide ranks → hosts.
 
@@ -779,24 +820,26 @@ def launch(
                 "explicitly. We need to know the training rank count "
                 "to split the PBS allocation into active + spare."
             )
-        if nodelist is None or not nodelist:
-            raise SystemExit(
-                "--auto-retry: failed to read the PBS nodelist (no "
-                "active job?). Cannot split into active + spare."
-            )
+        # Source the candidate node pool. Explicit --hostfile beats
+        # the scheduler nodelist — see _resolve_auto_retry_node_pool.
+        autoretry_pool = _resolve_auto_retry_node_pool(
+            selected_hostfile, nodelist
+        )
         gpus_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
         nhosts_active = _ranks_to_hosts(ngpus, gpus_per_node)
         autoretry_log_dir = _auto_retry_log_dir(jobid)
         autoretry_allocation, autoretry_hostfile = (
             _resolve_auto_retry_allocation(
-                nodelist,
+                autoretry_pool,
                 nhosts_active,
                 spare_nodes,
                 autoretry_log_dir,
             )
         )
         # Override: subsequent build_executable + topology inference
-        # see the smaller active hostfile, not the full PBS aux file.
+        # see the smaller active hostfile, not the full PBS aux file
+        # (or the user-supplied --hostfile — both have been split into
+        # active + spare and only the active subset goes to the launcher).
         selected_hostfile = autoretry_hostfile
         nhosts = nhosts_active
 

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -279,6 +279,27 @@ def parse_args(argv: Optional[Sequence[str]] = None):
     # Unknown flags that precede the ``--`` separator are forwarded to the
     # underlying launcher (e.g., mpirun -x FOO=bar -- python ...).
     args.launcher_args = unknown if command_from_sep else []
+
+    # Cross-flag validation. argparse mutex groups can't express
+    # "--auto-retry vs --retries with a non-zero value" (since
+    # --retries defaults to 0), so do it here. Same for --auto-retry
+    # requiring an explicit --nproc — the value depends on whether
+    # the user passed -n at all, which argparse can't observe from
+    # inside the parser.
+    if getattr(args, "auto_retry", False):
+        if getattr(args, "retries", 0):
+            raise SystemExit(
+                "--auto-retry is mutually exclusive with --retries. "
+                "--retries is bounded per-process retry; --auto-retry "
+                "is unbounded node-level failover. Pick one."
+            )
+        if getattr(args, "nproc", -1) <= 0:
+            raise SystemExit(
+                "--auto-retry requires --nproc (-n/--np) to be set "
+                "explicitly. The auto-retry loop needs the training "
+                "rank count to split the PBS allocation into active "
+                "+ spare hosts."
+            )
     return args
 
 
@@ -613,6 +634,82 @@ def build_executable(
     return executable
 
 
+def _resolve_auto_retry_allocation(
+    full_nodelist: Sequence[str],
+    nproc_active_hosts: int,
+    spare_nodes: "int | str | None",
+    log_dir: Path,
+):
+    """Build a :class:`NodeAllocation` for ``--auto-retry``.
+
+    Validates the spare-node policy against the actual PBS allocation
+    and persists the active hostfile so the launcher (re-spawned each
+    attempt with the same path) sees the current active set.
+
+    ``spare_nodes`` semantics match the CLI flag:
+      * ``"auto"``  → derive ``total - nproc_active_hosts``
+      * ``int``     → explicit count (must fit in spare pool)
+      * ``None``    → also ``auto`` (default when --auto-retry is set)
+    """
+    from ezpz.launch_autoretry import NodeAllocation, derive_spare_count
+
+    total = len(full_nodelist)
+    if nproc_active_hosts > total:
+        raise SystemExit(
+            f"--auto-retry: need {nproc_active_hosts} active hosts but "
+            f"PBS allocation only has {total}"
+        )
+
+    spare_default = derive_spare_count(total, nproc_active_hosts)
+    if spare_nodes is None or spare_nodes == "auto":
+        resolved_spare = spare_default
+    else:
+        resolved_spare = int(spare_nodes)
+        if resolved_spare > spare_default:
+            raise SystemExit(
+                f"--auto-retry: requested {resolved_spare} spare nodes "
+                f"but allocation only has {spare_default} unused "
+                f"(total={total}, active={nproc_active_hosts})"
+            )
+
+    # We slice the nodelist active-first, spare-second — only the
+    # first nproc+resolved_spare hosts get used. Beyond that, the
+    # PBS-allocated hosts just sit idle (consistent with how
+    # failover.sh's `failover_init` truncates).
+    slice_len = nproc_active_hosts + resolved_spare
+    relevant_nodes = list(full_nodelist[:slice_len])
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    hostfile_path = log_dir / "active.hostfile"
+    bad_nodes_path = log_dir / "bad_nodes.txt"
+
+    allocation = NodeAllocation.from_full_nodelist(
+        relevant_nodes,
+        nproc_active_hosts,
+        hostfile_path,
+        bad_nodes_path,
+    )
+    logger.info(
+        "[auto-retry] %d total / %d active / %d spare. Active hostfile: %s",
+        total,
+        len(allocation.active),
+        len(allocation.spare),
+        hostfile_path,
+    )
+    return allocation, hostfile_path
+
+
+def _auto_retry_log_dir(jobid: str) -> Path:
+    """Per-job log directory for attempt-N.log + bad_nodes.txt.
+
+    Matches the bash lib's ``$FAILOVER_LOG_DIR`` shape
+    (``$(pwd)/logs/failover-<short_jobid>``) so users grepping
+    postmortems don't need to learn a second convention.
+    """
+    short = jobid.split(".", 1)[0]
+    return Path.cwd() / "logs" / f"failover-{short}"
+
+
 def launch(
     launch_cmd: Optional[str] = None,
     cmd_to_launch: Optional[str | list[str]] = None,
@@ -626,6 +723,9 @@ def launch(
     launcher_args: Optional[Sequence[str]] = None,
     idle_timeout_s: Optional[int] = None,
     retries: int = 0,
+    auto_retry: bool = False,
+    spare_nodes: "int | str | None" = None,
+    max_failover_retries: Optional[int] = None,
 ) -> int:
     """Launch a command on the current {PBS, SLURM} job."""
     start = time.perf_counter()
@@ -651,6 +751,43 @@ def launch(
             selected_hostfile,
         )
         selected_hostfile = None
+
+    # --auto-retry path: split the full nodelist into active + spare
+    # BEFORE building the launcher command, so the launcher's
+    # topology inference sees the (smaller) active hostfile and we
+    # don't trip _infer_topology's "ngpus > N_active*ppn" check on
+    # the unused spare hosts.
+    autoretry_allocation = None
+    autoretry_log_dir: Optional[Path] = None
+    if auto_retry:
+        if ngpus is None:
+            raise SystemExit(
+                "--auto-retry requires --nproc (-n/--np) to be set "
+                "explicitly. We need to know the training rank count "
+                "to split the PBS allocation into active + spare."
+            )
+        if nodelist is None or not nodelist:
+            raise SystemExit(
+                "--auto-retry: failed to read the PBS nodelist (no "
+                "active job?). Cannot split into active + spare."
+            )
+        gpus_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
+        # Round-up division: 12 ranks on 4-gpu nodes → 3 nodes.
+        nhosts_active = (ngpus + gpus_per_node - 1) // gpus_per_node
+        autoretry_log_dir = _auto_retry_log_dir(jobid)
+        autoretry_allocation, autoretry_hostfile = (
+            _resolve_auto_retry_allocation(
+                nodelist,
+                nhosts_active,
+                spare_nodes,
+                autoretry_log_dir,
+            )
+        )
+        # Override: subsequent build_executable + topology inference
+        # see the smaller active hostfile, not the full PBS aux file.
+        selected_hostfile = autoretry_hostfile
+        nhosts = nhosts_active
+
     logger.info(f"Job ID: {jobid}")
     logger.info(f"nodelist: {nodelist}")
     logger.info(f"hostfile: {selected_hostfile}")
@@ -678,9 +815,37 @@ def launch(
     os.environ["EZPZ_RUN_COMMAND"] = str(cmd)
     logger.info(f"Execution started @ {ezpz.get_timestamp()}...")
     cmd_start = time.perf_counter()
-    retcode = _run_with_retries(
-        cmd, idle_timeout_s=idle_timeout_s, retries=retries
-    )
+    if autoretry_allocation is not None:
+        from ezpz.launch_autoretry import (
+            AutoRetryConfig,
+            DEFAULT_AUTO_RETRY_IDLE_TIMEOUT_S,
+            run_with_auto_retry,
+        )
+
+        assert autoretry_log_dir is not None  # set above when auto_retry
+        # Default --auto-retry's idle watchdog to 30min if the caller
+        # didn't pass --timeout — matches FAILOVER_IDLE_TIMEOUT in
+        # failover.sh and prevents 5h xccl hangs from burning the
+        # full PBS walltime.
+        effective_timeout = (
+            idle_timeout_s
+            if idle_timeout_s is not None
+            else DEFAULT_AUTO_RETRY_IDLE_TIMEOUT_S
+        )
+        ar_config = AutoRetryConfig(
+            cmd=list(cmd),
+            hostfile=Path(selected_hostfile)
+            if selected_hostfile is not None
+            else Path(),
+            log_dir=autoretry_log_dir,
+            idle_timeout_s=effective_timeout,
+            max_failover_retries=max_failover_retries,
+        )
+        retcode = run_with_auto_retry(ar_config, autoretry_allocation)
+    else:
+        retcode = _run_with_retries(
+            cmd, idle_timeout_s=idle_timeout_s, retries=retries
+        )
     cmd_finish = time.perf_counter()
     _log_json_log_file(logger)
     logger.info(f"----[🍋 ezpz.launch][stop][{ezpz.get_timestamp()}]----")
@@ -746,6 +911,11 @@ def run(argv: Sequence[str] | None = None) -> int:
                 launcher_args=launcher_args,
                 idle_timeout_s=getattr(args, "idle_timeout_s", None),
                 retries=getattr(args, "retries", 0),
+                auto_retry=getattr(args, "auto_retry", False),
+                spare_nodes=getattr(args, "spare_nodes", None),
+                max_failover_retries=getattr(
+                    args, "max_failover_retries", None
+                ),
             )
             ezpz.distributed.cleanup()
             return rc

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -492,10 +492,35 @@ def _run_attempt_with_tee(
     reader = threading.Thread(target=_drain, daemon=True)
     reader.start()
 
+    # _drain_remaining: block until the reader thread fully consumes
+    # the stdout pipe and flushes attempt-N.log to disk. Caller
+    # (classify_attempt) reads the log immediately after we return —
+    # if we exit before the reader's last fh.write() lands, the
+    # classifier sees a truncated log and can misclassify the final
+    # outcome (Copilot review on PR #144).
+    #
+    # The reader exits naturally once the child closes its stdout
+    # (which the OS guarantees on process exit), so a generous join
+    # without a hard cap is safe — the child has already terminated,
+    # there's no scenario where the reader runs forever. We do bound
+    # it to a sane upper limit so a stuck kernel pipe doesn't hang
+    # the whole loop, and log a warning if we hit it.
+    _DRAIN_TIMEOUT_S = 30.0
+
+    def _drain_remaining() -> None:
+        reader_done.wait(timeout=_DRAIN_TIMEOUT_S)
+        if not reader_done.is_set():
+            logger.warning(
+                "[auto-retry] reader thread did not drain within %.0fs "
+                "after child exit; log file may be truncated",
+                _DRAIN_TIMEOUT_S,
+            )
+
     try:
         while True:
             rc = proc.poll()
             if rc is not None:
+                _drain_remaining()
                 return rc
             if idle_timeout_s > 0:
                 with activity_lock:
@@ -514,6 +539,7 @@ def _run_attempt_with_tee(
                     except subprocess.TimeoutExpired:
                         proc.kill()
                         proc.wait()
+                    _drain_remaining()
                     return _WATCHDOG_RC
                 sleep_for = min(1.0, max(0.1, idle_timeout_s - idle_for))
             else:
@@ -532,9 +558,10 @@ def _run_attempt_with_tee(
                 proc.kill()
             except ProcessLookupError:
                 pass
+        # No _drain_remaining on the SIGINT path: the caller throws
+        # the partial log away and exits with INTERRUPTED. Spending
+        # 30s on a doomed drain is worse than losing the tail.
         raise
-    finally:
-        reader_done.wait(timeout=2.0)
 
 
 def _backoff_for_attempt(attempt: int) -> float:

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -1,0 +1,690 @@
+"""Auto-retry loop for ``ezpz launch --auto-retry``.
+
+This is the Python counterpart to ``src/ezpz/bin/failover.sh``. Both
+share the same scraper (``ezpz.failover.scrape_bad_nodes``) and the
+same broad strategy (split hosts → active + spare, retry on bad-node
+failures, swap a spare in for each bad host) but the in-launch path
+is unbounded by default and terminates via the classifier below.
+
+Why not just call the bash lib from Python? The classifier is the
+hard part — nine outcome categories, regex-driven, sensitive to
+ANSI-coloring and walltime/bad-node disambiguation. Pure-Python is
+straightforward to unit-test; subprocessing into bash and parsing
+its stderr would not be.
+
+Public surface:
+
+  * :class:`AutoRetryConfig` — caller-supplied policy
+  * :class:`NodeAllocation` — active/spare tracker
+  * :class:`TerminationReason` — outcomes of :func:`classify_attempt`
+  * :func:`classify_attempt` — pure decision function over (rc, log)
+  * :func:`run_with_auto_retry` — the loop
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+import ezpz
+
+logger = ezpz.get_logger(__name__)
+
+
+# Default idle-output watchdog when --auto-retry is set. Matches
+# FAILOVER_IDLE_TIMEOUT in failover.sh. 30 minutes is long enough
+# for legitimate gaps (eval epochs, checkpoint saves) but short
+# enough that a 5h xccl hang doesn't burn the full walltime.
+DEFAULT_AUTO_RETRY_IDLE_TIMEOUT_S = 1800
+
+# Backoff between attempts. Same shape as _run_with_retries — short
+# enough to recover fast on transient failures, capped so we don't
+# wait forever between attempts under a long-running --auto-retry.
+_BACKOFF_BASE_S = 5.0
+_BACKOFF_CAP_S = 60.0
+
+# Crash patterns: lines whose presence in the log overrides a shell
+# exit 0 (the outer wrapper sometimes exits clean even when the
+# inner mpiexec child crashed) AND defeat the "exit 143 = walltime"
+# heuristic (a real bad-node failure can surface as 143 when mpiexec
+# teardown races the wallclock kill).
+#
+# Kept in sync with the same set in src/ezpz/bin/failover.sh — if
+# you add a pattern there, add it here too. The bash version's
+# inline comments cite the failure incidents that motivated each
+# entry; see those for the postmortem context.
+_CRASH_PATTERNS_RX = re.compile(
+    r"RuntimeError: \[.*gloo.*\] Connection closed by peer"
+    r"|RuntimeError: \[.*gloo.*\] Timed out waiting"
+    r"|OutOfMemoryError"
+    r"|UR_RESULT_ERROR_OUT_OF_RESOURCES"
+    r"|died from signal"
+    r"|EOFError: No data left in file"
+)
+
+# Strip ANSI color codes before parsing the "Execution finished with N"
+# trailer. The trailer is logged with color (the rc digits are wrapped
+# in \x1b[1;36m...\x1b[0m); a naive regex on the colored form pulls
+# "1" out of the [1;36m prefix instead of the actual rc.
+_ANSI_RX = re.compile(r"\x1b\[[0-9;]*m")
+
+# Walltime exit code. PBS exit -29 surfaces as bash 143 (128 + SIGTERM).
+_WALLTIME_RC = 143
+
+# Idle-output watchdog exit code (matches GNU timeout(1), set by
+# launch.py:_WATCHDOG_EXIT_CODE).
+_WATCHDOG_RC = 124
+
+# Progress marker: History.update prints `step=N` (or step=<N>) on
+# its summary line. If two consecutive attempts both contain zero
+# `step=` markers, the run is broken before training even started
+# (bad config, missing dataset, etc.) and no amount of node swapping
+# will help — bail out.
+_PROGRESS_MARKER_RX = re.compile(r"\bstep=\d+", re.MULTILINE)
+
+
+class TerminationReason(Enum):
+    """Outcomes of :func:`classify_attempt`.
+
+    Each value is the verb after ``FAILOVER STOP:`` in the postmortem
+    log line, so grep'ing the log for ``FAILOVER STOP`` always lands
+    on the final classifier verdict.
+
+    The first four (SUCCESS, WALLTIME, INTERRUPTED, plus the explicit
+    EXHAUSTED) are terminal — :func:`run_with_auto_retry` returns
+    immediately. The two BAD_NODE values trigger a swap-and-retry.
+    STUCK_PRE_TRAINING is the "two attempts with zero training
+    steps" guard; that's also terminal.
+    """
+
+    SUCCESS = "success"
+    WALLTIME = "walltime"
+    BAD_NODE_KNOWN = "bad_node_known"
+    BAD_NODE_BLIND = "bad_node_blind"
+    STUCK_PRE_TRAINING = "stuck_pre_training"
+    EXHAUSTED = "exhausted"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass
+class AutoRetryConfig:
+    """Caller-supplied policy for :func:`run_with_auto_retry`.
+
+    ``cmd`` is the full launcher command line *as already assembled*
+    (mpiexec + topology + user command). The auto-retry loop does
+    NOT re-assemble it between attempts — instead, it patches the
+    hostfile arg in place to point at the active hostfile, which
+    changes contents as nodes are swapped.
+    """
+
+    cmd: list[str]
+    """Full launcher command line (mpiexec + user command)."""
+
+    hostfile: Path
+    """Path to the active hostfile. Re-read at every attempt — the
+    same path, with its contents mutated by ``NodeAllocation.swap_in``
+    / ``swap_one_blind``. Pointing the launcher at this path means
+    the launcher always sees the current active set."""
+
+    log_dir: Path
+    """Directory for ``attempt-N.log`` files and ``bad_nodes.txt``."""
+
+    idle_timeout_s: int = DEFAULT_AUTO_RETRY_IDLE_TIMEOUT_S
+    """Per-attempt idle-output watchdog. 0 disables."""
+
+    max_failover_retries: Optional[int] = None
+    """Upper bound on retries. ``None`` = unbounded; loop terminates
+    only via the matrix in :func:`classify_attempt`."""
+
+    machine: Optional[str] = None
+    """Scrape pattern set. ``None`` = auto-detect via
+    ``ezpz.get_machine()``."""
+
+
+@dataclass
+class NodeAllocation:
+    """In-memory active + spare hostfile tracker.
+
+    Mirrors the on-disk state managed by ``failover_init`` /
+    ``failover_swap_in`` / ``failover_swap_one_blind`` in the bash
+    lib. After every mutation we re-write the active hostfile on
+    disk so the launcher (which we don't re-spawn for the hostfile
+    arg) picks up the new contents on the next attempt.
+
+    ``spare`` is a deque so we can ``popleft()`` cheaply when
+    rotating new hosts in. ``bad_nodes_path`` is appended-to once
+    per swap for postmortem.
+    """
+
+    active: list[str]
+    spare: deque[str]
+    hostfile_path: Path
+    bad_nodes_path: Path
+
+    @classmethod
+    def from_full_nodelist(
+        cls,
+        nodelist: Sequence[str],
+        nproc_active_hosts: int,
+        hostfile_path: Path,
+        bad_nodes_path: Path,
+    ) -> NodeAllocation:
+        """Split a full nodelist into active + spare and persist the
+        active subset to disk at ``hostfile_path``.
+
+        ``nproc_active_hosts`` is the number of *hosts* needed for
+        training (not ranks). Caller is responsible for the
+        nproc/ppn → nhosts arithmetic — see :func:`derive_spare_count`.
+        """
+        if nproc_active_hosts > len(nodelist):
+            raise ValueError(
+                f"need {nproc_active_hosts} active hosts but only "
+                f"{len(nodelist)} were given"
+            )
+        alloc = cls(
+            active=list(nodelist[:nproc_active_hosts]),
+            spare=deque(nodelist[nproc_active_hosts:]),
+            hostfile_path=hostfile_path,
+            bad_nodes_path=bad_nodes_path,
+        )
+        alloc._write_active()
+        bad_nodes_path.write_text("")
+        return alloc
+
+    def _write_active(self) -> None:
+        """Persist the active set to ``hostfile_path``.
+
+        Trailing newline matches the convention of PBS_NODEFILE and
+        the per-line tools (``wc -l``, ``head``) the rest of the
+        ecosystem expects.
+        """
+        self.hostfile_path.write_text(
+            "\n".join(self.active) + ("\n" if self.active else "")
+        )
+
+    def _append_bad(self, host: str) -> None:
+        """Append one bad host to ``bad_nodes_path`` for postmortem.
+
+        Open + append + close per call (cheap; swaps are rare and
+        a leaked fd outliving the process would be worse than the
+        extra syscall)."""
+        with self.bad_nodes_path.open("a") as f:
+            f.write(host + "\n")
+
+    def swap_in(self, bad_hosts: Sequence[str]) -> list[tuple[str, str]]:
+        """Swap each known-bad host out for a spare.
+
+        Skips hosts not currently in the active set (already
+        replaced, or scraped from an older log). Returns the list
+        of ``(bad, spare)`` pairs actually swapped — caller can
+        log a summary.
+
+        Raises :class:`RuntimeError` if a swap is wanted but no
+        spare is available. The caller catches that and ends the
+        loop via :attr:`TerminationReason.EXHAUSTED`.
+        """
+        swaps: list[tuple[str, str]] = []
+        for bad in bad_hosts:
+            if bad not in self.active:
+                logger.debug("skip swap: %s not in active set", bad)
+                continue
+            if not self.spare:
+                raise RuntimeError(
+                    f"out of spare nodes — cannot replace {bad}"
+                )
+            spare = self.spare.popleft()
+            idx = self.active.index(bad)
+            self.active[idx] = spare
+            self._append_bad(bad)
+            swaps.append((bad, spare))
+        if swaps:
+            self._write_active()
+        return swaps
+
+    def swap_one_blind(self) -> tuple[str, str]:
+        """Rotate the first active host out for a spare.
+
+        Used when the scraper can't pinpoint a culprit (silent hang,
+        unknown crash pattern). Picks the first active host because
+        that's also what the bash lib does — the choice is arbitrary
+        but stable, so consecutive blind rotations cycle through the
+        active set rather than thrashing on one host.
+        """
+        if not self.spare:
+            raise RuntimeError("out of spare nodes — cannot blind-rotate")
+        if not self.active:
+            raise RuntimeError("active set is empty — nothing to rotate")
+        bad = self.active[0]
+        spare = self.spare.popleft()
+        self.active[0] = spare
+        self._append_bad(bad)
+        self._write_active()
+        return bad, spare
+
+    @property
+    def has_spares(self) -> bool:
+        return len(self.spare) > 0
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RX.sub("", text)
+
+
+def _has_crash_patterns(log_text: str) -> bool:
+    return _CRASH_PATTERNS_RX.search(log_text) is not None
+
+
+def _has_progress_markers(log_text: str) -> bool:
+    return _PROGRESS_MARKER_RX.search(log_text) is not None
+
+
+def _extract_inner_rc(log_text: str) -> Optional[int]:
+    """Pull the last ``Execution finished with N`` rc from the log.
+
+    Strips ANSI first — ezpz launch colors the trailer and naive
+    regex extracts the wrong digit from the color prefix. Returns
+    ``None`` if no trailer is present (e.g. the wrapper crashed
+    before emitting it).
+    """
+    stripped = _strip_ansi(log_text)
+    # rfind avoids scanning the whole log via the regex when only
+    # the last hit matters.
+    marker = "Execution finished with "
+    idx = stripped.rfind(marker)
+    if idx < 0:
+        return None
+    tail = stripped[idx + len(marker) :].split(None, 1)[0]
+    # Strip trailing punctuation: the trailer is logged with a
+    # period (`Execution finished with 0.`) which would otherwise
+    # poison int().
+    tail = tail.rstrip(".,;:")
+    try:
+        return int(tail)
+    except ValueError:
+        return None
+
+
+def classify_attempt(
+    shell_rc: int,
+    log_path: Path,
+    scraped_bad_nodes: Sequence[str],
+    *,
+    prior_attempt_had_progress: Optional[bool] = None,
+    has_spares: bool = True,
+) -> TerminationReason:
+    """Decide what the auto-retry loop should do after an attempt.
+
+    Pure function — no side effects, no I/O beyond reading the log.
+    The full termination matrix from PR #3's handoff doc lives here:
+
+    | rc       | log signals                                 | result               |
+    |----------|---------------------------------------------|----------------------|
+    | 0        | inner_rc=0 OR absent OR no crash pattern    | SUCCESS              |
+    | 0        | inner_rc != 0 (wrapper lied about success)  | classify by inner_rc |
+    | 0        | crash patterns present                      | bad-node retry       |
+    | 143      | no crash patterns                           | WALLTIME             |
+    | 143      | crash patterns present                      | bad-node retry       |
+    | 124      | (idle-output watchdog tripped)              | BAD_NODE_BLIND       |
+    | non-zero | scraper found named host(s)                 | BAD_NODE_KNOWN       |
+    | non-zero | scraper empty                               | BAD_NODE_BLIND       |
+    | -        | this AND prior attempt both had 0 progress  | STUCK_PRE_TRAINING   |
+    | -        | bad-node verdict but no spares left         | EXHAUSTED            |
+
+    The "two consecutive attempts with no progress" guard is the
+    user's preferred substitute for a numeric cap on blind rotations.
+    It catches code bugs (broken config, missing dataset) that would
+    otherwise burn the entire spare pool. The current attempt's
+    progress status is checked against ``prior_attempt_had_progress``;
+    the caller is responsible for tracking the prior value across
+    iterations.
+
+    Caller still owns the SIGINT path — see :func:`run_with_auto_retry`.
+    """
+    log_text = log_path.read_text(errors="replace") if log_path.exists() else ""
+
+    inner_rc = _extract_inner_rc(log_text)
+    crash = _has_crash_patterns(log_text)
+    # Effective rc: trust the inner trailer over a clean shell exit
+    # when the wrapper lied (mpiexec teardown raced a SIGTERM, etc.)
+    effective_rc = shell_rc
+    if shell_rc == 0 and inner_rc is not None and inner_rc != 0:
+        effective_rc = inner_rc
+    elif shell_rc == 0 and crash:
+        # Wrapper said 0 but mass tracebacks landed in the log. Treat
+        # as a generic crash — let the scraper-empty path decide
+        # between named vs blind.
+        effective_rc = 1
+
+    # Success: shell exit 0, no contrary inner_rc, no crash patterns.
+    if effective_rc == 0:
+        return TerminationReason.SUCCESS
+
+    # Walltime guard. Real walltime: no point swapping nodes.
+    # Walltime races: a true bad-node failure can land here when
+    # mpiexec teardown races the wallclock kill. Use the crash
+    # patterns to disambiguate.
+    if effective_rc == _WALLTIME_RC and not crash:
+        return TerminationReason.WALLTIME
+
+    # The progress guard applies BEFORE we decide which swap path to
+    # take — there's no point swapping nodes if the run is dying
+    # before training starts. Note: we only check this on actual
+    # failure paths; success already returned above.
+    if prior_attempt_had_progress is False and not _has_progress_markers(
+        log_text
+    ):
+        return TerminationReason.STUCK_PRE_TRAINING
+
+    # Watchdog kill: launch.py couldn't see output for `idle_timeout_s`.
+    # The hang IS the silence, so the scraper rarely finds anything
+    # — blind-rotate a spare.
+    if effective_rc == _WATCHDOG_RC:
+        if not has_spares:
+            return TerminationReason.EXHAUSTED
+        return TerminationReason.BAD_NODE_BLIND
+
+    # General failure path. Scraper-named hosts win over blind.
+    if scraped_bad_nodes:
+        if not has_spares:
+            return TerminationReason.EXHAUSTED
+        return TerminationReason.BAD_NODE_KNOWN
+
+    if not has_spares:
+        return TerminationReason.EXHAUSTED
+    return TerminationReason.BAD_NODE_BLIND
+
+
+def _run_attempt_with_tee(
+    cmd: Sequence[str],
+    log_path: Path,
+    idle_timeout_s: int,
+) -> int:
+    """Run a single attempt, tee'ing combined stdout+stderr to
+    ``log_path`` while still emitting to this process's stdout.
+
+    Returns the child's exit code, or 124 if the idle-output watchdog
+    fired. SIGINT propagates: KeyboardInterrupt re-raises to the
+    caller after best-effort terminating the child.
+
+    Same buffering nudge as launch._run_with_watchdog: forces
+    PYTHONUNBUFFERED=1 so Python children flush per-line. Without
+    this, the watchdog kills healthy jobs that simply hadn't
+    block-flushed their stdout in time.
+    """
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    child_env = os.environ.copy()
+    child_env.setdefault("PYTHONUNBUFFERED", "1")
+
+    proc = subprocess.Popen(
+        list(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=child_env,
+    )
+
+    last_activity = time.monotonic()
+    activity_lock = threading.Lock()
+    reader_done = threading.Event()
+
+    def _drain() -> None:
+        nonlocal last_activity
+        assert proc.stdout is not None
+        try:
+            with log_path.open("w") as fh:
+                for line in proc.stdout:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+                    fh.write(line)
+                    fh.flush()
+                    with activity_lock:
+                        last_activity = time.monotonic()
+        finally:
+            reader_done.set()
+
+    reader = threading.Thread(target=_drain, daemon=True)
+    reader.start()
+
+    try:
+        while True:
+            rc = proc.poll()
+            if rc is not None:
+                return rc
+            if idle_timeout_s > 0:
+                with activity_lock:
+                    idle_for = time.monotonic() - last_activity
+                if idle_for >= idle_timeout_s:
+                    logger.error(
+                        "[auto-retry] watchdog: no output for %.1fs "
+                        "(timeout=%ds). Sending SIGTERM to PID %d.",
+                        idle_for,
+                        idle_timeout_s,
+                        proc.pid,
+                    )
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=10.0)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait()
+                    return _WATCHDOG_RC
+                sleep_for = min(1.0, max(0.1, idle_timeout_s - idle_for))
+            else:
+                sleep_for = 1.0
+            time.sleep(sleep_for)
+    except KeyboardInterrupt:
+        # Propagate Ctrl-C: try to take the child down cleanly first.
+        # The bare except is intentional — we want any sigint-like
+        # interrupt to surface as INTERRUPTED, not be misclassified.
+        logger.warning("[auto-retry] SIGINT received; terminating child")
+        try:
+            proc.terminate()
+            proc.wait(timeout=5.0)
+        except (subprocess.TimeoutExpired, ProcessLookupError):
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+        raise
+    finally:
+        reader_done.wait(timeout=2.0)
+
+
+def _backoff_for_attempt(attempt: int) -> float:
+    """Backoff before *attempt* (where attempt 1 is the first retry).
+
+    5, 10, 20, 40, 60, 60, ... — same shape as ``_run_with_retries``
+    in launch.py so users see consistent pacing whether they're on
+    ``--retries N`` or ``--auto-retry``.
+    """
+    return min(_BACKOFF_CAP_S, _BACKOFF_BASE_S * (2 ** (attempt - 1)))
+
+
+def derive_spare_count(
+    total_nodes: int,
+    active_nodes: int,
+) -> int:
+    """``--spare-nodes auto`` default: ``total - active``, never < 0.
+
+    Caller has already validated that ``active_nodes > 0``; this
+    helper only handles the arithmetic. A negative result (active >
+    total) is clamped to zero — the loop just won't have spares to
+    rotate, which surfaces as ``TerminationReason.EXHAUSTED``.
+    """
+    return max(0, total_nodes - active_nodes)
+
+
+def run_with_auto_retry(
+    config: AutoRetryConfig,
+    allocation: NodeAllocation,
+    scrape_fn: Optional[Callable[[Path], list[str]]] = None,
+) -> int:
+    """Drive attempts until the termination matrix says stop.
+
+    ``scrape_fn`` is injected for testability — defaults to
+    :func:`ezpz.failover.scrape_bad_nodes` bound with the configured
+    machine. Tests pass a stub that returns canned bad-host lists
+    without needing a real log file.
+
+    Returns the final shell exit code. Always logs a single
+    ``FAILOVER STOP: <reason>`` line so grep is reliable.
+    """
+    if scrape_fn is None:
+        from ezpz.failover import scrape_bad_nodes
+
+        machine = config.machine
+
+        def _default_scrape(p: Path) -> list[str]:
+            try:
+                return scrape_bad_nodes(p, machine=machine)
+            except FileNotFoundError:
+                return []
+
+        scrape_fn = _default_scrape
+
+    attempt = 0
+    last_rc = 0
+    prior_attempt_had_progress: Optional[bool] = None
+
+    while True:
+        attempt += 1
+        log_path = config.log_dir / f"attempt-{attempt}.log"
+
+        if attempt > 1:
+            backoff = _backoff_for_attempt(attempt - 1)
+            logger.warning(
+                "[auto-retry] attempt %d (prior rc=%d, sleeping %.0fs)...",
+                attempt,
+                last_rc,
+                backoff,
+            )
+            time.sleep(backoff)
+
+        if (
+            config.max_failover_retries is not None
+            and attempt > config.max_failover_retries + 1
+        ):
+            logger.error(
+                "[auto-retry] FAILOVER STOP: max_failover_retries=%d "
+                "exhausted (rc=%d)",
+                config.max_failover_retries,
+                last_rc,
+            )
+            return last_rc
+
+        logger.info(
+            "[auto-retry] attempt %d — active=%d hosts, spare=%d hosts",
+            attempt,
+            len(allocation.active),
+            len(allocation.spare),
+        )
+
+        try:
+            last_rc = _run_attempt_with_tee(
+                config.cmd,
+                log_path,
+                config.idle_timeout_s,
+            )
+        except KeyboardInterrupt:
+            logger.warning(
+                "[auto-retry] FAILOVER STOP: interrupted (SIGINT)"
+            )
+            # 128 + SIGINT is the conventional return for ^C.
+            return 128 + signal.SIGINT
+
+        scraped = scrape_fn(log_path)
+        reason = classify_attempt(
+            last_rc,
+            log_path,
+            scraped,
+            prior_attempt_had_progress=prior_attempt_had_progress,
+            has_spares=allocation.has_spares,
+        )
+
+        # Track progress for next iteration. Read once more rather
+        # than threading the result out of classify_attempt — keeps
+        # the classifier signature clean.
+        try:
+            log_text = log_path.read_text(errors="replace")
+        except FileNotFoundError:
+            log_text = ""
+        prior_attempt_had_progress = _has_progress_markers(log_text)
+
+        if reason is TerminationReason.SUCCESS:
+            logger.info(
+                "[auto-retry] FAILOVER STOP: success (attempt %d)", attempt
+            )
+            return last_rc
+
+        if reason is TerminationReason.WALLTIME:
+            logger.warning(
+                "[auto-retry] FAILOVER STOP: walltime (rc=%d, attempt %d)",
+                last_rc,
+                attempt,
+            )
+            return last_rc
+
+        if reason is TerminationReason.STUCK_PRE_TRAINING:
+            logger.error(
+                "[auto-retry] FAILOVER STOP: stuck_pre_training "
+                "(two consecutive attempts with zero step= markers, "
+                "rc=%d)",
+                last_rc,
+            )
+            return last_rc
+
+        if reason is TerminationReason.EXHAUSTED:
+            logger.error(
+                "[auto-retry] FAILOVER STOP: exhausted "
+                "(no spare nodes left, rc=%d)",
+                last_rc,
+            )
+            return last_rc
+
+        # Bad-node paths fall through to a swap + continue.
+        try:
+            if reason is TerminationReason.BAD_NODE_KNOWN:
+                swaps = allocation.swap_in(scraped)
+                logger.warning(
+                    "[auto-retry] bad nodes: %s — swapped %d",
+                    scraped,
+                    len(swaps),
+                )
+                # swap_in() may return an empty list if all named
+                # hosts were already replaced; that shouldn't normally
+                # happen, but if it does, fall back to blind rotation
+                # so we still make progress.
+                if not swaps:
+                    if not allocation.has_spares:
+                        logger.error(
+                            "[auto-retry] FAILOVER STOP: exhausted "
+                            "(named hosts already swapped, no spares)"
+                        )
+                        return last_rc
+                    bad, spare = allocation.swap_one_blind()
+                    logger.warning(
+                        "[auto-retry] blind rotation: %s -> %s",
+                        bad,
+                        spare,
+                    )
+            else:  # BAD_NODE_BLIND
+                bad, spare = allocation.swap_one_blind()
+                logger.warning(
+                    "[auto-retry] blind rotation: %s -> %s", bad, spare
+                )
+        except RuntimeError as exc:
+            logger.error(
+                "[auto-retry] FAILOVER STOP: exhausted (%s)", exc
+            )
+            return last_rc

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -597,16 +597,11 @@ def run_with_auto_retry(
         attempt += 1
         log_path = config.log_dir / f"attempt-{attempt}.log"
 
-        if attempt > 1:
-            backoff = _backoff_for_attempt(attempt - 1)
-            logger.warning(
-                "[auto-retry] attempt %d (prior rc=%d, sleeping %.0fs)...",
-                attempt,
-                last_rc,
-                backoff,
-            )
-            time.sleep(backoff)
-
+        # Cap check fires BEFORE backoff sleep — otherwise
+        # --max-failover-retries 0 would sleep 5s only to immediately
+        # exit, and even a non-zero cap would burn a backoff for the
+        # final exit decision. Cap counts retries, not attempts:
+        # attempt 1 is the initial run, attempt N+1 is the Nth retry.
         if (
             config.max_failover_retries is not None
             and attempt > config.max_failover_retries + 1
@@ -618,6 +613,16 @@ def run_with_auto_retry(
                 last_rc,
             )
             return last_rc
+
+        if attempt > 1:
+            backoff = _backoff_for_attempt(attempt - 1)
+            logger.warning(
+                "[auto-retry] attempt %d (prior rc=%d, sleeping %.0fs)...",
+                attempt,
+                last_rc,
+                backoff,
+            )
+            time.sleep(backoff)
 
         logger.info(
             "[auto-retry] attempt %d — active=%d hosts, spare=%d hosts",

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -110,17 +110,18 @@ _PROGRESS_MARKER_RX = re.compile(r"\bstep=\d+", re.MULTILINE)
 
 
 class TerminationReason(Enum):
-    """Outcomes of :func:`classify_attempt`.
+    """Outcomes that drive :func:`run_with_auto_retry`'s next step.
 
     Each value is the verb after ``FAILOVER STOP:`` in the postmortem
     log line, so grep'ing the log for ``FAILOVER STOP`` always lands
     on the final classifier verdict.
 
-    The first four (SUCCESS, WALLTIME, INTERRUPTED, plus the explicit
-    EXHAUSTED) are terminal — :func:`run_with_auto_retry` returns
-    immediately. The two BAD_NODE values trigger a swap-and-retry.
-    STUCK_PRE_TRAINING is the "two attempts with zero training
-    steps" guard; that's also terminal.
+    SUCCESS / WALLTIME / STUCK_PRE_TRAINING / EXHAUSTED are terminal:
+    :func:`run_with_auto_retry` returns immediately. The two BAD_NODE
+    values trigger a swap-and-retry. INTERRUPTED is produced by the
+    loop's SIGINT handler — :func:`classify_attempt` never returns it,
+    since the classifier never sees the interrupt path (we re-raise
+    KeyboardInterrupt before reaching the classifier).
     """
 
     SUCCESS = "success"
@@ -130,6 +131,20 @@ class TerminationReason(Enum):
     STUCK_PRE_TRAINING = "stuck_pre_training"
     EXHAUSTED = "exhausted"
     INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    """What the classifier decided + the progress flag for next-iter use.
+
+    Returning both in one struct lets the loop avoid a second read
+    of the same log to recompute ``has_progress`` (the previous
+    implementation re-read the log right after the classifier had
+    already parsed it once).
+    """
+
+    reason: TerminationReason
+    has_progress: bool
 
 
 @dataclass
@@ -357,11 +372,13 @@ def classify_attempt(
     *,
     prior_attempt_had_progress: Optional[bool] = None,
     has_spares: bool = True,
-) -> TerminationReason:
+) -> ClassificationResult:
     """Decide what the auto-retry loop should do after an attempt.
 
-    Pure function — no side effects, no I/O beyond reading the log.
-    The full termination matrix from PR #3's handoff doc lives here:
+    Pure function — no side effects, single log read. Returns both
+    the termination reason and the ``has_progress`` flag so the loop
+    can thread the latter through to the next call without re-reading
+    the log. The full termination matrix from PR #3's handoff doc:
 
     | rc       | log signals                                 | result               |
     |----------|---------------------------------------------|----------------------|
@@ -382,14 +399,18 @@ def classify_attempt(
     otherwise burn the entire spare pool. The current attempt's
     progress status is checked against ``prior_attempt_had_progress``;
     the caller is responsible for tracking the prior value across
-    iterations.
+    iterations (use the ``has_progress`` field of the returned
+    :class:`ClassificationResult`).
 
-    Caller still owns the SIGINT path — see :func:`run_with_auto_retry`.
+    INTERRUPTED is produced by the loop itself in the SIGINT handler,
+    not here — the classifier never sees the interrupt path because
+    KeyboardInterrupt is re-raised before we reach it.
     """
     log_text = log_path.read_text(errors="replace") if log_path.exists() else ""
 
     inner_rc = _extract_inner_rc(log_text)
     crash = _has_crash_patterns(log_text)
+    has_progress = _has_progress_markers(log_text)
     # Effective rc: trust the inner trailer over a clean shell exit
     # when the wrapper lied (mpiexec teardown raced a SIGTERM, etc.)
     effective_rc = shell_rc
@@ -401,43 +422,44 @@ def classify_attempt(
         # between named vs blind.
         effective_rc = 1
 
+    def _result(reason: TerminationReason) -> ClassificationResult:
+        return ClassificationResult(reason=reason, has_progress=has_progress)
+
     # Success: shell exit 0, no contrary inner_rc, no crash patterns.
     if effective_rc == 0:
-        return TerminationReason.SUCCESS
+        return _result(TerminationReason.SUCCESS)
 
     # Walltime guard. Real walltime: no point swapping nodes.
     # Walltime races: a true bad-node failure can land here when
     # mpiexec teardown races the wallclock kill. Use the crash
     # patterns to disambiguate.
     if effective_rc == _WALLTIME_RC and not crash:
-        return TerminationReason.WALLTIME
+        return _result(TerminationReason.WALLTIME)
 
     # The progress guard applies BEFORE we decide which swap path to
     # take — there's no point swapping nodes if the run is dying
     # before training starts. Note: we only check this on actual
     # failure paths; success already returned above.
-    if prior_attempt_had_progress is False and not _has_progress_markers(
-        log_text
-    ):
-        return TerminationReason.STUCK_PRE_TRAINING
+    if prior_attempt_had_progress is False and not has_progress:
+        return _result(TerminationReason.STUCK_PRE_TRAINING)
 
     # Watchdog kill: launch.py couldn't see output for `idle_timeout_s`.
     # The hang IS the silence, so the scraper rarely finds anything
     # — blind-rotate a spare.
     if effective_rc == _WATCHDOG_RC:
         if not has_spares:
-            return TerminationReason.EXHAUSTED
-        return TerminationReason.BAD_NODE_BLIND
+            return _result(TerminationReason.EXHAUSTED)
+        return _result(TerminationReason.BAD_NODE_BLIND)
 
     # General failure path. Scraper-named hosts win over blind.
     if scraped_bad_nodes:
         if not has_spares:
-            return TerminationReason.EXHAUSTED
-        return TerminationReason.BAD_NODE_KNOWN
+            return _result(TerminationReason.EXHAUSTED)
+        return _result(TerminationReason.BAD_NODE_KNOWN)
 
     if not has_spares:
-        return TerminationReason.EXHAUSTED
-    return TerminationReason.BAD_NODE_BLIND
+        return _result(TerminationReason.EXHAUSTED)
+    return _result(TerminationReason.BAD_NODE_BLIND)
 
 
 def _run_attempt_with_tee(
@@ -672,22 +694,17 @@ def run_with_auto_retry(
             return 128 + signal.SIGINT
 
         scraped = scrape_fn(log_path)
-        reason = classify_attempt(
+        result = classify_attempt(
             last_rc,
             log_path,
             scraped,
             prior_attempt_had_progress=prior_attempt_had_progress,
             has_spares=allocation.has_spares,
         )
-
-        # Track progress for next iteration. Read once more rather
-        # than threading the result out of classify_attempt — keeps
-        # the classifier signature clean.
-        try:
-            log_text = log_path.read_text(errors="replace")
-        except FileNotFoundError:
-            log_text = ""
-        prior_attempt_had_progress = _has_progress_markers(log_text)
+        reason = result.reason
+        # Thread the progress flag through to the next iteration —
+        # classifier already parsed the log, no need to re-read.
+        prior_attempt_had_progress = result.has_progress
 
         if reason is TerminationReason.SUCCESS:
             logger.info(

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -72,6 +72,22 @@ _CRASH_PATTERNS_RX = re.compile(
     r"|EOFError: No data left in file"
 )
 
+# Innocent rank-cascade lines. These are emitted by mpiexec when a
+# PRIMARY kill on one node propagates SIGTERM/SIGSEGV outward to
+# every other rank — the named rank wasn't the culprit, it's just
+# a downstream victim. Matching these as bad-node indicators would
+# tag innocent ranks and (worse) override a clean walltime exit
+# into a node-swap retry that burns spares for nothing. Strip
+# these lines BEFORE the crash match runs.
+#
+# Mirrors the `grep -v "rank N died from signal (11|15)"` strip in
+# src/ezpz/bin/failover.sh and the scraper-side exclusion
+# documented in tests/test_failover_scrape.py
+# ::test_innocent_rank_signal_11_not_matched (job 8466848 postmortem).
+_INNOCENT_RANK_CASCADE_RX = re.compile(
+    r"rank \d+ died from signal (?:11|15)"
+)
+
 # Strip ANSI color codes before parsing the "Execution finished with N"
 # trailer. The trailer is logged with color (the rc digits are wrapped
 # in \x1b[1;36m...\x1b[0m); a naive regex on the colored form pulls
@@ -281,7 +297,27 @@ def _strip_ansi(text: str) -> str:
 
 
 def _has_crash_patterns(log_text: str) -> bool:
-    return _CRASH_PATTERNS_RX.search(log_text) is not None
+    """Return True iff the log contains a real hardware-style death.
+
+    Strips innocent rank-cascade lines BEFORE matching so a clean
+    walltime kill (which fires SIGTERM at every rank, generating
+    dozens of `rank N died from signal 15` lines) doesn't get
+    misclassified as a bad-node failure. See _INNOCENT_RANK_CASCADE_RX
+    for the postmortem context.
+
+    The strip preserves real signals: `shepherd died from signal 9`
+    (PALS shepherd kill), `died from signal 6` (SIGABRT from a real
+    assert), `died from signal 9` on a process other than `rank N`,
+    etc. all still match.
+    """
+    if not log_text:
+        return False
+    filtered = "\n".join(
+        line
+        for line in log_text.splitlines()
+        if not _INNOCENT_RANK_CASCADE_RX.search(line)
+    )
+    return _CRASH_PATTERNS_RX.search(filtered) is not None
 
 
 def _has_progress_markers(log_text: str) -> bool:

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -152,20 +152,20 @@ class AutoRetryConfig:
     """Caller-supplied policy for :func:`run_with_auto_retry`.
 
     ``cmd`` is the full launcher command line *as already assembled*
-    (mpiexec + topology + user command). The auto-retry loop does
-    NOT re-assemble it between attempts — instead, it patches the
-    hostfile arg in place to point at the active hostfile, which
-    changes contents as nodes are swapped.
+    (mpiexec + topology + user command), with the ``--hostfile``
+    argument already pointing at :attr:`NodeAllocation.hostfile_path`.
+    The auto-retry loop does NOT re-assemble ``cmd`` between attempts
+    — :class:`NodeAllocation` mutates the file at that path in place
+    as nodes are swapped, and the launcher (re-spawned per attempt)
+    reads the fresh contents on each re-launch.
     """
 
     cmd: list[str]
-    """Full launcher command line (mpiexec + user command)."""
+    """Full launcher command line (mpiexec + user command).
 
-    hostfile: Path
-    """Path to the active hostfile. Re-read at every attempt — the
-    same path, with its contents mutated by ``NodeAllocation.swap_in``
-    / ``swap_one_blind``. Pointing the launcher at this path means
-    the launcher always sees the current active set."""
+    Must already contain ``--hostfile=<path>`` where ``<path>``
+    matches :attr:`NodeAllocation.hostfile_path`. The active hostfile
+    is what mutates between attempts; this command is constant."""
 
     log_dir: Path
     """Directory for ``attempt-N.log`` files and ``bad_nodes.txt``."""
@@ -483,7 +483,17 @@ def _run_attempt_with_tee(
     child_env = os.environ.copy()
     child_env.setdefault("PYTHONUNBUFFERED", "1")
 
-    proc = subprocess.Popen(
+    # Safety note (Sourcery security warning): Popen with a dynamic
+    # argv is fine here because:
+    #   1. shell=False (the default) — no shell metacharacter
+    #      expansion, every list element becomes a direct argv slot.
+    #   2. cmd originates from `ezpz launch`'s argparse REMAINDER,
+    #      which is the user's own shell already past their own
+    #      shell expansion. Equivalent to typing the command into
+    #      a terminal — no privilege boundary is crossed here.
+    # Sourcery's lint can't distinguish "user-runs-their-own-code"
+    # from "untrusted-input-to-shell"; this is the former.
+    proc = subprocess.Popen(  # noqa: S603 — see comment above
         list(cmd),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -652,6 +652,61 @@ class TestRunWithAutoRetry:
         assert rc == 1
         assert len(runner.calls) == 2
 
+    def test_max_failover_retries_zero_no_retry(
+        self, tmp_path, monkeypatch
+    ):
+        # Codex P2 regression: cap=0 means "no retries", just the
+        # initial attempt. Previously the loop would sleep for
+        # backoff before checking the cap, burning 5s on the way
+        # to immediate exit.
+        config = _config(tmp_path, max_failover_retries=0)
+        allocation = _alloc(tmp_path)
+        runner = _FakeRunner(
+            [(1, "Execution finished with 1\niter step=1\n")]
+        )
+        sleeps: list[float] = []
+        rc = _run(
+            monkeypatch,
+            config,
+            allocation,
+            runner,
+            sleep_capture=sleeps,
+        )
+        assert rc == 1
+        assert len(runner.calls) == 1
+        # Critical: no backoff sleep was issued on the way to giving
+        # up. The runner's first (and only) attempt happens before
+        # any sleep call.
+        assert sleeps == [], f"unexpected sleeps: {sleeps}"
+
+    def test_max_failover_retries_one_sleeps_once(
+        self, tmp_path, monkeypatch
+    ):
+        # Companion to the cap=0 test: cap=1 means "one retry", so
+        # we DO sleep once (before attempt 2) but NOT a second time
+        # on the way to the cap-exhausted exit.
+        config = _config(tmp_path, max_failover_retries=1)
+        allocation = _alloc(
+            tmp_path, full=("h1", "h2", "h3", "h4"), active=2
+        )
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\niter step=1\n"),
+                (1, "Execution finished with 1\niter step=2\n"),
+            ]
+        )
+        sleeps: list[float] = []
+        _run(
+            monkeypatch,
+            config,
+            allocation,
+            runner,
+            sleep_capture=sleeps,
+        )
+        # Exactly one backoff sleep (between attempt 1 and 2), none
+        # before the cap-exit.
+        assert len(sleeps) == 1, f"unexpected sleeps: {sleeps}"
+
     def test_progress_clears_stuck_guard_for_next_attempt(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -1,0 +1,665 @@
+"""Tests for ``ezpz launch --auto-retry`` (the failover loop).
+
+Coverage targets one row per termination-matrix case plus the
+argparse validations. The classifier is a pure function so most
+tests can exercise it directly without subprocess overhead. The
+loop itself is tested by injecting a stub ``scrape_fn`` and using
+a fake ``NodeAllocation`` so we never spawn a real child.
+
+Why no end-to-end test that actually launches a process? The
+existing ``test_launch_watchdog.py`` already exercises the
+shell-out plumbing (sh -c scripts, SIGTERM handling, watchdog
+exit codes). What's unique here is the *classification* and
+*swap policy* — those are pure and easier to reason about with
+fake inputs.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from ezpz.launch import parse_args
+from ezpz.launch_autoretry import (
+    AutoRetryConfig,
+    NodeAllocation,
+    TerminationReason,
+    _backoff_for_attempt,
+    _extract_inner_rc,
+    _has_crash_patterns,
+    _has_progress_markers,
+    _strip_ansi,
+    classify_attempt,
+    derive_spare_count,
+    run_with_auto_retry,
+)
+
+# Most tests don't shell out, but argparse paths and the run-loop
+# tests need POSIX-y env semantics (env var inheritance, etc.).
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="auto-retry assumes POSIX subprocess semantics",
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    """Small pure functions: ANSI stripping, inner_rc, crash detection."""
+
+    def test_strip_ansi_removes_color_codes(self):
+        assert (
+            _strip_ansi("Execution finished with \x1b[1;36m127\x1b[0m")
+            == "Execution finished with 127"
+        )
+
+    def test_strip_ansi_passthrough_no_codes(self):
+        assert _strip_ansi("no codes") == "no codes"
+
+    def test_extract_inner_rc_basic(self):
+        assert _extract_inner_rc("Execution finished with 0\n") == 0
+        assert _extract_inner_rc("Execution finished with 137\n") == 137
+
+    def test_extract_inner_rc_ansi(self):
+        # The trailer is ANSI-colored in practice; regex on the raw
+        # form would pick up the "1" from "[1;36m" instead of 127.
+        log = "Execution finished with \x1b[1;36m127\x1b[0m.\n"
+        assert _extract_inner_rc(log) == 127
+
+    def test_extract_inner_rc_trailing_punctuation(self):
+        # Logger formats it with a period.
+        assert _extract_inner_rc("Execution finished with 0.\n") == 0
+
+    def test_extract_inner_rc_takes_last(self):
+        # If multiple trailers landed (retry happened upstream),
+        # the final outcome wins.
+        log = "Execution finished with 0\nExecution finished with 3\n"
+        assert _extract_inner_rc(log) == 3
+
+    def test_extract_inner_rc_absent(self):
+        assert _extract_inner_rc("nothing here") is None
+
+    def test_crash_patterns_oom(self):
+        assert _has_crash_patterns("torch.OutOfMemoryError: ...")
+
+    def test_crash_patterns_gloo(self):
+        msg = (
+            "RuntimeError: [enforce fail at gloo/.../tcp.cc:127] "
+            "Connection closed by peer [10.0.0.1]:53121"
+        )
+        assert _has_crash_patterns(msg)
+
+    def test_crash_patterns_shepherd(self):
+        assert _has_crash_patterns("x4502.hsn: shepherd died from signal 9")
+
+    def test_crash_patterns_negative(self):
+        assert not _has_crash_patterns("Training complete\nFinal loss: 0.5")
+
+    def test_progress_markers_step_equals(self):
+        assert _has_progress_markers("iter=10 step=5 loss=0.1")
+
+    def test_progress_markers_absent(self):
+        # No step=N anywhere.
+        assert not _has_progress_markers("loading dataset...\nERROR: cuda")
+
+    def test_derive_spare_count_unused(self):
+        assert derive_spare_count(10, 8) == 2
+
+    def test_derive_spare_count_exactly_full(self):
+        assert derive_spare_count(8, 8) == 0
+
+    def test_derive_spare_count_overcommitted_clamps(self):
+        # Caller asked for more than available — clamp to 0 rather
+        # than return negative. The loop will surface this as
+        # EXHAUSTED on the first failure.
+        assert derive_spare_count(5, 8) == 0
+
+    def test_backoff_progression(self):
+        # 5, 10, 20, 40, 60, 60, 60, ...
+        assert _backoff_for_attempt(1) == 5.0
+        assert _backoff_for_attempt(2) == 10.0
+        assert _backoff_for_attempt(3) == 20.0
+        assert _backoff_for_attempt(4) == 40.0
+        assert _backoff_for_attempt(5) == 60.0
+        assert _backoff_for_attempt(10) == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Classifier — one test per termination-matrix row
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text)
+    return path
+
+
+class TestClassifyAttempt:
+    """One test per row of the termination matrix in pr3_handoff.md."""
+
+    def test_success_clean_exit(self, tmp_path):
+        log = _write(tmp_path / "log", "Execution finished with 0\n")
+        assert classify_attempt(0, log, []) is TerminationReason.SUCCESS
+
+    def test_walltime_no_crash_patterns(self, tmp_path):
+        log = _write(tmp_path / "log", "Execution finished with 0\n")
+        # rc=143 (walltime SIGTERM), no crash signatures in the log
+        assert classify_attempt(143, log, []) is TerminationReason.WALLTIME
+
+    def test_walltime_with_crash_patterns_is_bad_node(self, tmp_path):
+        # Real bad-node failure that races the walltime kill: we DO
+        # retry, even though rc=143.
+        log = _write(
+            tmp_path / "log",
+            "Execution finished with 0\nOutOfMemoryError on rank 5\n",
+        )
+        assert (
+            classify_attempt(143, log, [])
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_watchdog_124_triggers_blind(self, tmp_path):
+        log = _write(tmp_path / "log", "starting...\n")
+        assert (
+            classify_attempt(124, log, [])
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_nonzero_with_named_bad_node(self, tmp_path):
+        log = _write(
+            tmp_path / "log",
+            "Execution finished with 1\nx4502: shepherd died from signal 9\n",
+        )
+        assert (
+            classify_attempt(1, log, ["x4502.hsn.cm.aurora.alcf.anl.gov"])
+            is TerminationReason.BAD_NODE_KNOWN
+        )
+
+    def test_nonzero_blind_when_scraper_empty(self, tmp_path):
+        log = _write(
+            tmp_path / "log", "Execution finished with 1\nrandom error\n"
+        )
+        assert (
+            classify_attempt(1, log, [])
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_stuck_pre_training_when_prior_also_zero_steps(self, tmp_path):
+        # Prior attempt: no progress. Current attempt: also no progress.
+        # → STUCK_PRE_TRAINING regardless of rc shape.
+        log = _write(
+            tmp_path / "log", "Execution finished with 1\nimport error\n"
+        )
+        assert (
+            classify_attempt(
+                1, log, [], prior_attempt_had_progress=False
+            )
+            is TerminationReason.STUCK_PRE_TRAINING
+        )
+
+    def test_progress_overrides_stuck_guard(self, tmp_path):
+        # The "step=" marker on the CURRENT attempt means training
+        # started this time — even if the prior attempt had no
+        # progress, we shouldn't bail.
+        log = _write(
+            tmp_path / "log",
+            "Execution finished with 1\niter step=5 loss=0.1\n",
+        )
+        assert (
+            classify_attempt(
+                1, log, ["x4502"], prior_attempt_had_progress=False
+            )
+            is TerminationReason.BAD_NODE_KNOWN
+        )
+
+    def test_exhausted_when_no_spares_left_known(self, tmp_path):
+        log = _write(tmp_path / "log", "Execution finished with 1\n")
+        assert (
+            classify_attempt(1, log, ["host"], has_spares=False)
+            is TerminationReason.EXHAUSTED
+        )
+
+    def test_exhausted_when_no_spares_left_blind(self, tmp_path):
+        log = _write(tmp_path / "log", "Execution finished with 1\n")
+        assert (
+            classify_attempt(1, log, [], has_spares=False)
+            is TerminationReason.EXHAUSTED
+        )
+
+    def test_exhausted_when_no_spares_left_watchdog(self, tmp_path):
+        log = _write(tmp_path / "log", "hang\n")
+        assert (
+            classify_attempt(124, log, [], has_spares=False)
+            is TerminationReason.EXHAUSTED
+        )
+
+    def test_wrapper_lied_inner_rc_overrides_clean_shell_exit(
+        self, tmp_path
+    ):
+        # Outer shell said 0 but the inner trailer says 7 — wrapper
+        # lied. Treat as failure.
+        log = _write(tmp_path / "log", "Execution finished with 7\n")
+        assert (
+            classify_attempt(0, log, [])
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_crash_patterns_override_clean_shell_exit(self, tmp_path):
+        # rc=0, no inner trailer, but log has crash signatures —
+        # treat as failure (mass-traceback).
+        log = _write(
+            tmp_path / "log",
+            "training...\nUR_RESULT_ERROR_OUT_OF_RESOURCES on rank 4\n",
+        )
+        assert (
+            classify_attempt(0, log, [])
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_missing_log_file_safe(self, tmp_path):
+        # Log was never written (the child died before stdout
+        # touched disk). Classifier still has to return *something*
+        # sensible — should not crash.
+        log = tmp_path / "nonexistent.log"
+        result = classify_attempt(1, log, [])
+        # rc=1, no scraper, no log → blind rotation.
+        assert result is TerminationReason.BAD_NODE_BLIND
+
+
+# ---------------------------------------------------------------------------
+# NodeAllocation
+# ---------------------------------------------------------------------------
+
+
+class TestNodeAllocation:
+    def _make(self, tmp_path, full=("h1", "h2", "h3", "h4", "h5"), active=3):
+        hf = tmp_path / "active.hostfile"
+        bf = tmp_path / "bad_nodes.txt"
+        return (
+            NodeAllocation.from_full_nodelist(list(full), active, hf, bf),
+            hf,
+            bf,
+        )
+
+    def test_split_active_and_spare(self, tmp_path):
+        alloc, hf, bf = self._make(tmp_path)
+        assert alloc.active == ["h1", "h2", "h3"]
+        assert list(alloc.spare) == ["h4", "h5"]
+        assert hf.read_text() == "h1\nh2\nh3\n"
+        assert bf.read_text() == ""
+
+    def test_split_rejects_too_many_active(self, tmp_path):
+        hf = tmp_path / "active.hostfile"
+        bf = tmp_path / "bad_nodes.txt"
+        with pytest.raises(ValueError, match="only"):
+            NodeAllocation.from_full_nodelist(["h1"], 5, hf, bf)
+
+    def test_swap_in_replaces_named_host(self, tmp_path):
+        alloc, hf, bf = self._make(tmp_path)
+        swaps = alloc.swap_in(["h2"])
+        assert swaps == [("h2", "h4")]
+        assert alloc.active == ["h1", "h4", "h3"]
+        assert list(alloc.spare) == ["h5"]
+        # Persisted on disk for the next launcher attempt.
+        assert hf.read_text() == "h1\nh4\nh3\n"
+        # Bad nodes appended for postmortem.
+        assert bf.read_text() == "h2\n"
+
+    def test_swap_in_skips_hosts_not_in_active(self, tmp_path):
+        alloc, _, _ = self._make(tmp_path)
+        swaps = alloc.swap_in(["not-in-active"])
+        assert swaps == []
+        # No spare consumed.
+        assert list(alloc.spare) == ["h4", "h5"]
+
+    def test_swap_in_multiple_consumes_multiple_spares(self, tmp_path):
+        alloc, hf, _ = self._make(tmp_path)
+        swaps = alloc.swap_in(["h1", "h2"])
+        assert swaps == [("h1", "h4"), ("h2", "h5")]
+        assert alloc.active == ["h4", "h5", "h3"]
+        assert list(alloc.spare) == []
+        assert hf.read_text() == "h4\nh5\nh3\n"
+
+    def test_swap_in_raises_when_out_of_spares(self, tmp_path):
+        alloc, _, _ = self._make(
+            tmp_path, full=("h1", "h2", "h3"), active=3
+        )
+        with pytest.raises(RuntimeError, match="out of spare"):
+            alloc.swap_in(["h1"])
+
+    def test_swap_one_blind_rotates_first_active(self, tmp_path):
+        alloc, hf, bf = self._make(tmp_path)
+        bad, spare = alloc.swap_one_blind()
+        assert bad == "h1" and spare == "h4"
+        assert alloc.active == ["h4", "h2", "h3"]
+        assert list(alloc.spare) == ["h5"]
+        assert hf.read_text() == "h4\nh2\nh3\n"
+        assert bf.read_text() == "h1\n"
+
+    def test_swap_one_blind_raises_when_no_spares(self, tmp_path):
+        alloc, _, _ = self._make(
+            tmp_path, full=("h1", "h2"), active=2
+        )
+        with pytest.raises(RuntimeError, match="out of spare"):
+            alloc.swap_one_blind()
+
+    def test_has_spares_property(self, tmp_path):
+        alloc, _, _ = self._make(tmp_path)
+        assert alloc.has_spares
+        # Drain
+        alloc.swap_one_blind()
+        alloc.swap_one_blind()
+        assert not alloc.has_spares
+
+
+# ---------------------------------------------------------------------------
+# run_with_auto_retry — the loop, with a stubbed scrape_fn
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner:
+    """Stand-in for ``_run_attempt_with_tee``.
+
+    Each call writes ``log_text`` to the requested attempt-N.log
+    path and returns the corresponding rc. The list of (rc, log)
+    pairs is consumed in order; if exhausted, raises so the test
+    catches an unexpected extra attempt.
+    """
+
+    def __init__(self, attempts: list[tuple[int, str]]):
+        self.attempts = list(attempts)
+        self.calls: list[tuple[list[str], Path, int]] = []
+
+    def __call__(self, cmd, log_path: Path, idle_timeout_s: int) -> int:
+        if not self.attempts:
+            raise AssertionError(
+                "ran out of canned attempts — loop made more "
+                "attempts than the test expected"
+            )
+        rc, text = self.attempts.pop(0)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(text)
+        self.calls.append((list(cmd), log_path, idle_timeout_s))
+        return rc
+
+
+def _config(tmp_path: Path, **overrides) -> AutoRetryConfig:
+    """Test-friendly default AutoRetryConfig (no real cmd)."""
+    base = dict(
+        cmd=["echo", "x"],
+        hostfile=tmp_path / "active.hostfile",
+        log_dir=tmp_path / "logs",
+        idle_timeout_s=0,  # disable watchdog for tests
+        max_failover_retries=None,
+    )
+    base.update(overrides)
+    # mypy/dict-merge tolerance
+    return AutoRetryConfig(**base)  # type: ignore[arg-type]
+
+
+def _alloc(tmp_path: Path, full=("h1", "h2", "h3", "h4"), active=2):
+    hf = tmp_path / "active.hostfile"
+    bf = tmp_path / "bad_nodes.txt"
+    return NodeAllocation.from_full_nodelist(list(full), active, hf, bf)
+
+
+def _run(
+    monkeypatch,
+    config,
+    allocation,
+    fake_runner: _FakeRunner,
+    scrape_fn: Callable[[Path], list[str]] = lambda _: [],
+    sleep_capture: list | None = None,
+):
+    """Drive run_with_auto_retry with the fake runner.
+
+    Also monkeypatches time.sleep so the backoff doesn't actually
+    sleep during tests — captured into ``sleep_capture`` for
+    assertions if provided.
+    """
+    monkeypatch.setattr(
+        "ezpz.launch_autoretry._run_attempt_with_tee", fake_runner
+    )
+
+    captured = sleep_capture if sleep_capture is not None else []
+
+    def _no_sleep(s):
+        captured.append(s)
+
+    monkeypatch.setattr("ezpz.launch_autoretry.time.sleep", _no_sleep)
+
+    return run_with_auto_retry(config, allocation, scrape_fn=scrape_fn)
+
+
+class TestRunWithAutoRetry:
+    def test_success_first_attempt(self, tmp_path, monkeypatch):
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+        runner = _FakeRunner([(0, "Execution finished with 0\n")])
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 0
+        assert len(runner.calls) == 1
+
+    def test_succeeds_on_second_attempt_after_blind_rotation(
+        self, tmp_path, monkeypatch
+    ):
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\niter step=1 loss=0.1\n"),
+                (0, "Execution finished with 0\n"),
+            ]
+        )
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 0
+        assert len(runner.calls) == 2
+        # One spare consumed by the blind rotation.
+        assert list(allocation.spare) == ["h4"]
+
+    def test_named_bad_node_swap_then_success(
+        self, tmp_path, monkeypatch
+    ):
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\niter step=1\n"),
+                (0, "Execution finished with 0\n"),
+            ]
+        )
+
+        def scrape(_log: Path):
+            # First call: name h1 as bad. Second call: log shows
+            # success, but the loop calls scrape regardless.
+            return ["h1"] if not allocation.bad_nodes_path.read_text() else []
+
+        rc = _run(monkeypatch, config, allocation, runner, scrape_fn=scrape)
+        assert rc == 0
+        # Named swap: h1 → h3 (first spare)
+        assert "h1" not in allocation.active
+        assert "h3" in allocation.active
+        assert allocation.bad_nodes_path.read_text() == "h1\n"
+
+    def test_walltime_no_retry(self, tmp_path, monkeypatch):
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+        runner = _FakeRunner([(143, "Execution finished with 0\n")])
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 143
+        assert len(runner.calls) == 1
+
+    def test_stuck_pre_training_two_zero_progress_attempts(
+        self, tmp_path, monkeypatch
+    ):
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+        # Both attempts have NO step= markers → STUCK guard fires
+        # on the second attempt.
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\nimport error\n"),
+                (1, "Execution finished with 1\nimport error\n"),
+            ]
+        )
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 1
+        assert len(runner.calls) == 2
+
+    def test_exhausted_when_spares_drained(self, tmp_path, monkeypatch):
+        config = _config(tmp_path)
+        # 1 spare → 1 swap possible, then EXHAUSTED on next failure.
+        allocation = _alloc(
+            tmp_path, full=("h1", "h2", "h3"), active=2
+        )
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\niter step=1\n"),
+                (1, "Execution finished with 1\niter step=2\n"),
+            ]
+        )
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 1
+        # 1st attempt fails → blind swap (consumes h3). 2nd attempt
+        # fails with no spares left → EXHAUSTED, no 3rd attempt.
+        assert len(runner.calls) == 2
+        assert list(allocation.spare) == []
+
+    def test_max_failover_retries_cap(self, tmp_path, monkeypatch):
+        # 3 spares but cap=1 → attempt 1 + 1 retry = 2 total, then bail.
+        config = _config(tmp_path, max_failover_retries=1)
+        allocation = _alloc(
+            tmp_path, full=("h1", "h2", "h3", "h4", "h5"), active=2
+        )
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\niter step=1\n"),
+                (1, "Execution finished with 1\niter step=2\n"),
+            ]
+        )
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 1
+        assert len(runner.calls) == 2
+
+    def test_progress_clears_stuck_guard_for_next_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        # Attempt 1: no progress (would trip the guard on its own).
+        # Attempt 2: progress (clears the guard). Attempt 3: no
+        # progress again — but prior was YES, so guard doesn't trip.
+        config = _config(tmp_path)
+        allocation = _alloc(
+            tmp_path, full=("h1", "h2", "h3", "h4"), active=2
+        )
+        runner = _FakeRunner(
+            [
+                (1, "Execution finished with 1\nimport error\n"),
+                (1, "Execution finished with 1\niter step=3 loss=0.2\n"),
+                (0, "Execution finished with 0\niter step=10\n"),
+            ]
+        )
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 0
+        assert len(runner.calls) == 3
+
+    def test_unbounded_default_runs_until_exhaustion(
+        self, tmp_path, monkeypatch
+    ):
+        # max_failover_retries=None and 3 spares → loop runs until
+        # spares are drained, never hits a numeric cap.
+        config = _config(tmp_path, max_failover_retries=None)
+        allocation = _alloc(
+            tmp_path, full=("h1", "h2", "h3", "h4", "h5"), active=2
+        )
+        # Each attempt makes some progress (clears STUCK guard)
+        # but fails. Should exhaust 3 spares → 4 attempts total
+        # (initial + 3 retries), then EXHAUSTED on the 4th's
+        # classifier (has_spares=False).
+        attempts = [
+            (1, f"Execution finished with 1\niter step={i}\n")
+            for i in range(1, 5)
+        ]
+        runner = _FakeRunner(attempts)
+        rc = _run(monkeypatch, config, allocation, runner)
+        assert rc == 1
+        assert len(runner.calls) == 4
+
+
+# ---------------------------------------------------------------------------
+# Argparse: cross-flag validation
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseValidation:
+    def test_auto_retry_requires_explicit_nproc(self):
+        with pytest.raises(SystemExit, match="requires --nproc"):
+            parse_args(["--auto-retry", "--", "echo", "x"])
+
+    def test_auto_retry_mutex_with_retries(self):
+        with pytest.raises(SystemExit, match="mutually exclusive"):
+            parse_args(
+                ["--auto-retry", "--retries", "3", "--np", "8", "--",
+                 "echo", "x"]
+            )
+
+    def test_auto_retry_with_zero_retries_is_fine(self):
+        # --retries defaults to 0; not providing it shouldn't trip
+        # the mutex check (only nonzero --retries conflicts).
+        args = parse_args(["--auto-retry", "--np", "8", "--", "echo", "x"])
+        assert args.auto_retry is True
+        assert args.retries == 0
+
+    def test_spare_nodes_accepts_auto_literal(self):
+        args = parse_args(
+            ["--auto-retry", "--spare-nodes", "auto", "--np", "8",
+             "--", "echo", "x"]
+        )
+        assert args.spare_nodes == "auto"
+
+    def test_spare_nodes_accepts_int(self):
+        args = parse_args(
+            ["--auto-retry", "--spare-nodes", "4", "--np", "8",
+             "--", "echo", "x"]
+        )
+        assert args.spare_nodes == 4
+
+    def test_spare_nodes_rejects_uppercase_auto(self):
+        # Case-sensitive: only the literal lowercase "auto" works.
+        # (Same case-handling lesson as machine= override on the
+        # scraper — see ezpz.failover.scrape._resolve_machine_key.)
+        with pytest.raises(SystemExit):
+            parse_args(
+                ["--auto-retry", "--spare-nodes", "AUTO", "--np", "8",
+                 "--", "echo", "x"]
+            )
+
+    def test_spare_nodes_rejects_negative(self):
+        with pytest.raises(SystemExit):
+            parse_args(
+                ["--auto-retry", "--spare-nodes", "-1", "--np", "8",
+                 "--", "echo", "x"]
+            )
+
+    def test_max_failover_retries_rejects_negative(self):
+        with pytest.raises(SystemExit):
+            parse_args(
+                ["--auto-retry", "--max-failover-retries", "-1",
+                 "--np", "8", "--", "echo", "x"]
+            )
+
+    def test_back_compat_no_auto_retry(self):
+        # Existing --retries / --timeout flags still work without
+        # --auto-retry.
+        args = parse_args(
+            ["--np", "8", "--retries", "3", "--timeout", "600",
+             "--", "echo", "x"]
+        )
+        assert args.auto_retry is False
+        assert args.retries == 3
+        assert args.idle_timeout_s == 600

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -31,6 +31,7 @@ from ezpz.launch import (
 )
 from ezpz.launch_autoretry import (
     AutoRetryConfig,
+    ClassificationResult,
     NodeAllocation,
     TerminationReason,
     _backoff_for_attempt,
@@ -217,12 +218,12 @@ class TestClassifyAttempt:
 
     def test_success_clean_exit(self, tmp_path):
         log = _write(tmp_path / "log", "Execution finished with 0\n")
-        assert classify_attempt(0, log, []) is TerminationReason.SUCCESS
+        assert classify_attempt(0, log, []).reason is TerminationReason.SUCCESS
 
     def test_walltime_no_crash_patterns(self, tmp_path):
         log = _write(tmp_path / "log", "Execution finished with 0\n")
         # rc=143 (walltime SIGTERM), no crash signatures in the log
-        assert classify_attempt(143, log, []) is TerminationReason.WALLTIME
+        assert classify_attempt(143, log, []).reason is TerminationReason.WALLTIME
 
     def test_walltime_with_crash_patterns_is_bad_node(self, tmp_path):
         # Real bad-node failure that races the walltime kill: we DO
@@ -232,7 +233,7 @@ class TestClassifyAttempt:
             "Execution finished with 0\nOutOfMemoryError on rank 5\n",
         )
         assert (
-            classify_attempt(143, log, [])
+            classify_attempt(143, log, []).reason
             is TerminationReason.BAD_NODE_BLIND
         )
 
@@ -251,7 +252,7 @@ class TestClassifyAttempt:
             "rank 1 died from signal 15\n"
             "rank 2 died from signal 15\n",
         )
-        assert classify_attempt(143, log, []) is TerminationReason.WALLTIME
+        assert classify_attempt(143, log, []).reason is TerminationReason.WALLTIME
 
     def test_walltime_with_cascade_and_real_death_is_bad_node(
         self, tmp_path
@@ -265,14 +266,14 @@ class TestClassifyAttempt:
             "rank 1 died from signal 11\n",
         )
         assert (
-            classify_attempt(143, log, [])
+            classify_attempt(143, log, []).reason
             is TerminationReason.BAD_NODE_BLIND
         )
 
     def test_watchdog_124_triggers_blind(self, tmp_path):
         log = _write(tmp_path / "log", "starting...\n")
         assert (
-            classify_attempt(124, log, [])
+            classify_attempt(124, log, []).reason
             is TerminationReason.BAD_NODE_BLIND
         )
 
@@ -282,7 +283,7 @@ class TestClassifyAttempt:
             "Execution finished with 1\nx4502: shepherd died from signal 9\n",
         )
         assert (
-            classify_attempt(1, log, ["x4502.hsn.cm.aurora.alcf.anl.gov"])
+            classify_attempt(1, log, ["x4502.hsn.cm.aurora.alcf.anl.gov"]).reason
             is TerminationReason.BAD_NODE_KNOWN
         )
 
@@ -291,7 +292,7 @@ class TestClassifyAttempt:
             tmp_path / "log", "Execution finished with 1\nrandom error\n"
         )
         assert (
-            classify_attempt(1, log, [])
+            classify_attempt(1, log, []).reason
             is TerminationReason.BAD_NODE_BLIND
         )
 
@@ -304,7 +305,7 @@ class TestClassifyAttempt:
         assert (
             classify_attempt(
                 1, log, [], prior_attempt_had_progress=False
-            )
+            ).reason
             is TerminationReason.STUCK_PRE_TRAINING
         )
 
@@ -319,28 +320,28 @@ class TestClassifyAttempt:
         assert (
             classify_attempt(
                 1, log, ["x4502"], prior_attempt_had_progress=False
-            )
+            ).reason
             is TerminationReason.BAD_NODE_KNOWN
         )
 
     def test_exhausted_when_no_spares_left_known(self, tmp_path):
         log = _write(tmp_path / "log", "Execution finished with 1\n")
         assert (
-            classify_attempt(1, log, ["host"], has_spares=False)
+            classify_attempt(1, log, ["host"], has_spares=False).reason
             is TerminationReason.EXHAUSTED
         )
 
     def test_exhausted_when_no_spares_left_blind(self, tmp_path):
         log = _write(tmp_path / "log", "Execution finished with 1\n")
         assert (
-            classify_attempt(1, log, [], has_spares=False)
+            classify_attempt(1, log, [], has_spares=False).reason
             is TerminationReason.EXHAUSTED
         )
 
     def test_exhausted_when_no_spares_left_watchdog(self, tmp_path):
         log = _write(tmp_path / "log", "hang\n")
         assert (
-            classify_attempt(124, log, [], has_spares=False)
+            classify_attempt(124, log, [], has_spares=False).reason
             is TerminationReason.EXHAUSTED
         )
 
@@ -351,7 +352,7 @@ class TestClassifyAttempt:
         # lied. Treat as failure.
         log = _write(tmp_path / "log", "Execution finished with 7\n")
         assert (
-            classify_attempt(0, log, [])
+            classify_attempt(0, log, []).reason
             is TerminationReason.BAD_NODE_BLIND
         )
 
@@ -363,7 +364,7 @@ class TestClassifyAttempt:
             "training...\nUR_RESULT_ERROR_OUT_OF_RESOURCES on rank 4\n",
         )
         assert (
-            classify_attempt(0, log, [])
+            classify_attempt(0, log, []).reason
             is TerminationReason.BAD_NODE_BLIND
         )
 
@@ -374,7 +375,28 @@ class TestClassifyAttempt:
         log = tmp_path / "nonexistent.log"
         result = classify_attempt(1, log, [])
         # rc=1, no scraper, no log → blind rotation.
-        assert result is TerminationReason.BAD_NODE_BLIND
+        assert result.reason is TerminationReason.BAD_NODE_BLIND
+        # Empty log → no progress markers either.
+        assert result.has_progress is False
+
+    def test_returns_classification_result_with_progress_flag(
+        self, tmp_path
+    ):
+        # The classifier returns ClassificationResult so the loop
+        # doesn't need a second log read to recompute has_progress.
+        log = _write(
+            tmp_path / "log",
+            "Execution finished with 0\niter step=42 loss=0.1\n",
+        )
+        result = classify_attempt(0, log, [])
+        assert isinstance(result, ClassificationResult)
+        assert result.reason is TerminationReason.SUCCESS
+        assert result.has_progress is True
+
+    def test_classification_result_no_progress_flag(self, tmp_path):
+        log = _write(tmp_path / "log", "Execution finished with 1\n")
+        result = classify_attempt(1, log, [])
+        assert result.has_progress is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -26,6 +26,7 @@ from ezpz.launch import (
     _auto_retry_log_dir,
     _ranks_to_hosts,
     _resolve_auto_retry_allocation,
+    _resolve_auto_retry_node_pool,
     parse_args,
 )
 from ezpz.launch_autoretry import (
@@ -852,6 +853,65 @@ class TestRanksToHosts:
         # Edge case: 1 rank always needs 1 host regardless of ppn.
         assert _ranks_to_hosts(1, 12) == 1
         assert _ranks_to_hosts(1, 1) == 1
+
+
+class TestResolveAutoRetryNodePool:
+    """--hostfile beats scheduler nodelist; either-empty errors."""
+
+    def test_hostfile_takes_priority_over_scheduler_nodelist(
+        self, tmp_path
+    ):
+        # User pre-filtered their nodelist (e.g. dropped known-bad
+        # nodes from a previous job). Silently switching to the
+        # scheduler's larger list would undo that work.
+        hf = tmp_path / "filtered.hostfile"
+        hf.write_text("good1\ngood2\ngood3\n")
+        scheduler = ["bad1", "good1", "bad2", "good2", "bad3", "good3"]
+        pool = _resolve_auto_retry_node_pool(hf, scheduler)
+        assert pool == ["good1", "good2", "good3"]
+
+    def test_hostfile_strips_whitespace_and_blank_lines(self, tmp_path):
+        hf = tmp_path / "messy.hostfile"
+        # PBS_NODEFILE-style files can have trailing whitespace and
+        # an EOF newline; we tolerate both rather than splitting and
+        # producing empty hostnames.
+        hf.write_text("  host1  \n\nhost2\n   \nhost3\n\n")
+        assert _resolve_auto_retry_node_pool(hf, None) == [
+            "host1",
+            "host2",
+            "host3",
+        ]
+
+    def test_falls_back_to_scheduler_nodelist_when_no_hostfile(self):
+        pool = _resolve_auto_retry_node_pool(None, ["h1", "h2", "h3"])
+        assert pool == ["h1", "h2", "h3"]
+
+    def test_empty_hostfile_errors(self, tmp_path):
+        hf = tmp_path / "empty.hostfile"
+        hf.write_text("")
+        with pytest.raises(SystemExit, match="empty"):
+            _resolve_auto_retry_node_pool(hf, ["h1", "h2"])
+
+    def test_hostfile_with_only_whitespace_errors(self, tmp_path):
+        # `\n\n   \n\n` is "empty" by the same logic as a truly
+        # empty file — all candidate lines were blank.
+        hf = tmp_path / "blank.hostfile"
+        hf.write_text("\n\n   \n\n")
+        with pytest.raises(SystemExit, match="empty"):
+            _resolve_auto_retry_node_pool(hf, ["h1"])
+
+    def test_missing_hostfile_errors(self, tmp_path):
+        hf = tmp_path / "nonexistent.hostfile"
+        with pytest.raises(SystemExit, match="failed to read"):
+            _resolve_auto_retry_node_pool(hf, ["h1"])
+
+    def test_no_hostfile_no_scheduler_nodelist_errors(self):
+        with pytest.raises(SystemExit, match="failed to read"):
+            _resolve_auto_retry_node_pool(None, None)
+
+    def test_no_hostfile_empty_scheduler_nodelist_errors(self):
+        with pytest.raises(SystemExit, match="failed to read"):
+            _resolve_auto_retry_node_pool(None, [])
 
 
 class TestAutoRetryLogDir:

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -1074,3 +1074,74 @@ class TestResolveAutoRetryAllocation:
         assert len(alloc.active) == 8
         assert list(alloc.spare) == ["h8", "h9"]
         # h10..h19 are NOT in the allocation.
+
+
+# ---------------------------------------------------------------------------
+# _run_attempt_with_tee — the real subprocess path
+# ---------------------------------------------------------------------------
+
+
+class TestRunAttemptWithTee:
+    """The real tee+watchdog path, not the fake-runner test double.
+
+    These exercise the actual subprocess + threading machinery. Skip
+    on non-POSIX because the test scripts use `sh -c`.
+    """
+
+    def test_full_log_captured_after_child_exit(self, tmp_path):
+        # Regression for the Copilot review on PR #144: the reader
+        # thread may still be draining stdout when proc.poll() shows
+        # an exit code. Previously _run_attempt_with_tee returned
+        # immediately on poll, with only a 2s best-effort drain in
+        # `finally`. Now it does a 30s explicit drain BEFORE return
+        # so the classifier sees the full log.
+        #
+        # The child writes a large burst right before exit (more
+        # than a typical 4-8KB pipe buffer can hold) and we verify
+        # every line landed in the log file.
+        from ezpz.launch_autoretry import _run_attempt_with_tee
+
+        log_path = tmp_path / "burst.log"
+        # 1000 lines of ~50 chars each = ~50KB, well beyond a pipe
+        # buffer's instantaneous capacity. The exit comes immediately
+        # after the last write, so this is exactly the "child gone
+        # but pipe still draining" race.
+        script = (
+            "for i in $(seq 1 1000); do "
+            "echo \"line $i with extra padding to push past buffer ${i}\"; "
+            "done"
+        )
+        rc = _run_attempt_with_tee(
+            ["sh", "-c", script],
+            log_path,
+            idle_timeout_s=0,
+        )
+        assert rc == 0
+        lines = log_path.read_text().splitlines()
+        assert len(lines) == 1000, f"got {len(lines)} lines"
+        # Specifically: the LAST line — most vulnerable to truncation.
+        assert "line 1000" in lines[-1]
+
+    def test_short_program_log_captured(self, tmp_path):
+        from ezpz.launch_autoretry import _run_attempt_with_tee
+
+        log_path = tmp_path / "short.log"
+        rc = _run_attempt_with_tee(
+            ["sh", "-c", "echo hello; echo world"],
+            log_path,
+            idle_timeout_s=0,
+        )
+        assert rc == 0
+        assert log_path.read_text().splitlines() == ["hello", "world"]
+
+    def test_nonzero_exit_still_drains(self, tmp_path):
+        # The drain path runs on any exit, not just success.
+        from ezpz.launch_autoretry import _run_attempt_with_tee
+
+        log_path = tmp_path / "fail.log"
+        script = "echo before-exit; exit 7"
+        rc = _run_attempt_with_tee(
+            ["sh", "-c", script], log_path, idle_timeout_s=0
+        )
+        assert rc == 7
+        assert "before-exit" in log_path.read_text()

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -520,7 +520,6 @@ def _config(tmp_path: Path, **overrides) -> AutoRetryConfig:
     """Test-friendly default AutoRetryConfig (no real cmd)."""
     base = dict(
         cmd=["echo", "x"],
-        hostfile=tmp_path / "active.hostfile",
         log_dir=tmp_path / "logs",
         idle_timeout_s=0,  # disable watchdog for tests
         max_failover_retries=None,

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -146,6 +146,27 @@ class TestPureHelpers:
         log = "rank 4 died from signal 6\n"
         assert _has_crash_patterns(log)
 
+    def test_crash_patterns_real_ur_oom_with_cascade_regression(self):
+        # Regression for an actual Aurora torchtitan log shape (job
+        # 2026-05-12): 18 successful training steps, then a real
+        # level_zero UR_RESULT_ERROR_OUT_OF_RESOURCES, then mpiexec
+        # tore down the job and emitted a `rank 14 died from signal 15`
+        # cascade line as part of the teardown. The strip should
+        # remove the cascade but preserve the OOM signal so the loop
+        # correctly retries on a different node.
+        log = (
+            "step:  1  loss: 12.94587  ...\n"
+            "step: 18  loss: 10.27772  ...\n"
+            "[rank7]: RuntimeError: level_zero backend failed with "
+            "error: 40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)\n"
+            "x4610c4s3b0n0.hsn.cm.aurora.alcf.anl.gov: rank 7 exited "
+            "with code 1\n"
+            "x4610c4s5b0n0.hsn.cm.aurora.alcf.anl.gov: rank 14 died "
+            "from signal 15\n"
+            "Execution finished with 143.\n"
+        )
+        assert _has_crash_patterns(log)
+
     def test_progress_markers_step_equals(self):
         assert _has_progress_markers("iter=10 step=5 loss=0.1")
 

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -22,7 +22,12 @@ from typing import Callable
 
 import pytest
 
-from ezpz.launch import parse_args
+from ezpz.launch import (
+    _auto_retry_log_dir,
+    _ranks_to_hosts,
+    _resolve_auto_retry_allocation,
+    parse_args,
+)
 from ezpz.launch_autoretry import (
     AutoRetryConfig,
     NodeAllocation,
@@ -512,7 +517,7 @@ def _run(
     monkeypatch,
     config,
     allocation,
-    fake_runner: _FakeRunner,
+    fake_runner,  # duck-typed: any callable (cmd, log_path, idle_timeout_s) -> int
     scrape_fn: Callable[[Path], list[str]] = lambda _: [],
     sleep_capture: list | None = None,
 ):
@@ -667,6 +672,58 @@ class TestRunWithAutoRetry:
         assert rc == 0
         assert len(runner.calls) == 3
 
+    def test_sigint_during_attempt_returns_interrupted(
+        self, tmp_path, monkeypatch
+    ):
+        # Row 9 of the termination matrix: a KeyboardInterrupt raised
+        # by _run_attempt_with_tee (Ctrl-C from the user, or any
+        # SIGINT-equivalent during the child's lifetime) propagates
+        # up through run_with_auto_retry as INTERRUPTED. Returns
+        # 128 + SIGINT (130 on POSIX), logs FAILOVER STOP: interrupted,
+        # does not retry.
+        import signal as _signal
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+
+        sigint_raiser_calls = []
+
+        def _raises_sigint(cmd, log_path: Path, idle_timeout_s: int) -> int:
+            # Simulate Ctrl-C: write a partial log (the child got
+            # killed mid-attempt) then raise KeyboardInterrupt as
+            # the real _run_attempt_with_tee would after SIGINT
+            # reaches it.
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text("starting...\nkilled by user\n")
+            sigint_raiser_calls.append(log_path)
+            raise KeyboardInterrupt()
+
+        rc = _run(monkeypatch, config, allocation, _raises_sigint)
+        assert rc == 128 + _signal.SIGINT
+        # Exactly one attempt before the interrupt — NO retry.
+        assert len(sigint_raiser_calls) == 1
+        # No nodes swapped — the interrupt short-circuited before
+        # the classifier ran.
+        assert allocation.bad_nodes_path.read_text() == ""
+
+    def test_sigint_on_first_attempt_doesnt_consume_spares(
+        self, tmp_path, monkeypatch
+    ):
+        # Specifically: Ctrl-C on the very first attempt must not
+        # touch the spare pool. Catches a regression where the
+        # interrupt handler somehow falls through into the swap
+        # logic.
+        config = _config(tmp_path)
+        allocation = _alloc(tmp_path)
+        original_spare = list(allocation.spare)
+
+        def _raises_sigint(cmd, log_path: Path, idle_timeout_s: int) -> int:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text("")
+            raise KeyboardInterrupt()
+
+        _run(monkeypatch, config, allocation, _raises_sigint)
+        assert list(allocation.spare) == original_spare
+
     def test_unbounded_default_runs_until_exhaustion(
         self, tmp_path, monkeypatch
     ):
@@ -762,3 +819,143 @@ class TestArgparseValidation:
         assert args.auto_retry is False
         assert args.retries == 3
         assert args.idle_timeout_s == 600
+
+
+# ---------------------------------------------------------------------------
+# Helpers in launch.py — the bridge between CLI args and the loop
+# ---------------------------------------------------------------------------
+
+
+class TestRanksToHosts:
+    """Ceiling-divide rank counts to host counts."""
+
+    def test_exact_division(self):
+        # 24 ranks on 12-GPU nodes → 2 hosts cleanly.
+        assert _ranks_to_hosts(24, 12) == 2
+
+    def test_single_host(self):
+        # 8 ranks on 12-GPU nodes → 1 host (everything fits).
+        assert _ranks_to_hosts(8, 12) == 1
+
+    def test_round_up_on_overflow(self):
+        # 13 ranks on 12-GPU nodes → 2 hosts. The point: a partial
+        # host still needs to be reserved or rank 12 has nowhere to
+        # land. The opposite (`13 // 12 = 1`) would drop a rank.
+        assert _ranks_to_hosts(13, 12) == 2
+
+    def test_polaris_4_gpu_nodes(self):
+        # Realistic Polaris example: 12 ranks on 4-GPU nodes.
+        assert _ranks_to_hosts(12, 4) == 3
+        assert _ranks_to_hosts(13, 4) == 4
+
+    def test_one_rank(self):
+        # Edge case: 1 rank always needs 1 host regardless of ppn.
+        assert _ranks_to_hosts(1, 12) == 1
+        assert _ranks_to_hosts(1, 1) == 1
+
+
+class TestAutoRetryLogDir:
+    def test_strips_pbs_jobid_suffix(self, tmp_path, monkeypatch):
+        # PBS jobids on Aurora are formatted as `<num>.aurora-pbs-...`;
+        # the log dir name uses only the leading numeric segment so
+        # ls'ing logs/ doesn't get a wall of hostnames.
+        monkeypatch.chdir(tmp_path)
+        result = _auto_retry_log_dir("12345.aurora-pbs-0001.alcf.anl.gov")
+        assert result == tmp_path / "logs" / "failover-12345"
+
+    def test_handles_bare_numeric_jobid(self, tmp_path, monkeypatch):
+        # SLURM-style bare numeric jobids — no `.` to split on.
+        monkeypatch.chdir(tmp_path)
+        result = _auto_retry_log_dir("987654")
+        assert result == tmp_path / "logs" / "failover-987654"
+
+
+class TestResolveAutoRetryAllocation:
+    """The bridge: full PBS nodelist → NodeAllocation with active/spare split."""
+
+    def test_auto_default_uses_full_spare_pool(self, tmp_path):
+        # 10 nodes, 8 active → "auto" = 2 spares
+        nodelist = [f"h{i}" for i in range(10)]
+        alloc, hf = _resolve_auto_retry_allocation(
+            nodelist, 8, "auto", tmp_path
+        )
+        assert len(alloc.active) == 8
+        assert list(alloc.spare) == ["h8", "h9"]
+        assert hf == tmp_path / "active.hostfile"
+        # Persisted on disk so the launcher's hostfile arg picks it up.
+        assert hf.read_text().splitlines() == alloc.active
+
+    def test_none_treated_as_auto(self, tmp_path):
+        # spare_nodes=None (the CLI default when --auto-retry is set
+        # but --spare-nodes is omitted) behaves the same as "auto".
+        nodelist = [f"h{i}" for i in range(5)]
+        alloc, _ = _resolve_auto_retry_allocation(
+            nodelist, 3, None, tmp_path
+        )
+        assert list(alloc.spare) == ["h3", "h4"]
+
+    def test_explicit_int_caps_spare_pool(self, tmp_path):
+        # 10 nodes, 8 active, --spare-nodes 1 → use only 1 spare,
+        # ignore the other available host. The 10th node sits idle.
+        nodelist = [f"h{i}" for i in range(10)]
+        alloc, _ = _resolve_auto_retry_allocation(
+            nodelist, 8, 1, tmp_path
+        )
+        assert len(alloc.active) == 8
+        assert list(alloc.spare) == ["h8"]
+
+    def test_explicit_int_exceeds_available_errors(self, tmp_path):
+        # 10 nodes, 8 active → only 2 spare available. Asking for
+        # 5 must error at parse-time-equivalent (SystemExit) rather
+        # than silently using 2.
+        nodelist = [f"h{i}" for i in range(10)]
+        with pytest.raises(SystemExit, match="spare nodes"):
+            _resolve_auto_retry_allocation(nodelist, 8, 5, tmp_path)
+
+    def test_nproc_exceeds_allocation_errors(self, tmp_path):
+        # 3 nodes, 8 active requested → impossible.
+        nodelist = [f"h{i}" for i in range(3)]
+        with pytest.raises(SystemExit, match="active hosts"):
+            _resolve_auto_retry_allocation(nodelist, 8, "auto", tmp_path)
+
+    def test_single_host_no_spares_succeeds(self, tmp_path):
+        # 1 node, 1 active, 0 spare. Legal — the loop will just
+        # surface EXHAUSTED on the first failure. We don't refuse
+        # at allocation time (user might be debugging on a 1-node job).
+        nodelist = ["h0"]
+        alloc, _ = _resolve_auto_retry_allocation(
+            nodelist, 1, "auto", tmp_path
+        )
+        assert alloc.active == ["h0"]
+        assert list(alloc.spare) == []
+        assert not alloc.has_spares
+
+    def test_explicit_zero_spares(self, tmp_path):
+        # --spare-nodes 0 explicitly: caller wants the failover loop
+        # WITHOUT a swap pool. Useful for testing the classifier
+        # paths in isolation. EXHAUSTED on the first failure.
+        nodelist = [f"h{i}" for i in range(5)]
+        alloc, _ = _resolve_auto_retry_allocation(
+            nodelist, 3, 0, tmp_path
+        )
+        assert len(alloc.active) == 3
+        assert list(alloc.spare) == []
+
+    def test_bad_nodes_file_initialized_empty(self, tmp_path):
+        nodelist = [f"h{i}" for i in range(5)]
+        alloc, _ = _resolve_auto_retry_allocation(
+            nodelist, 3, "auto", tmp_path
+        )
+        assert alloc.bad_nodes_path == tmp_path / "bad_nodes.txt"
+        assert alloc.bad_nodes_path.read_text() == ""
+
+    def test_idle_nodes_beyond_active_plus_spare_truncated(self, tmp_path):
+        # 20 nodes, 8 active, --spare-nodes 2 → only 10 hosts used.
+        # The other 10 sit idle. Mirrors failover_init's truncation.
+        nodelist = [f"h{i}" for i in range(20)]
+        alloc, _ = _resolve_auto_retry_allocation(
+            nodelist, 8, 2, tmp_path
+        )
+        assert len(alloc.active) == 8
+        assert list(alloc.spare) == ["h8", "h9"]
+        # h10..h19 are NOT in the allocation.

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -101,6 +101,51 @@ class TestPureHelpers:
     def test_crash_patterns_negative(self):
         assert not _has_crash_patterns("Training complete\nFinal loss: 0.5")
 
+    def test_crash_patterns_excludes_innocent_rank_11_cascade(self):
+        # `rank N died from signal 11` is a downstream cascade from a
+        # primary kill on a different node — NOT a bad-node indicator.
+        # Same exclusion the scraper applies (job 8466848 postmortem).
+        log = (
+            "rank 0 died from signal 11\n"
+            "rank 1 died from signal 11\n"
+            "rank 2 died from signal 11\n"
+        )
+        assert not _has_crash_patterns(log)
+
+    def test_crash_patterns_excludes_innocent_rank_15_cascade(self):
+        # Same for SIGTERM (15) cascading from a primary walltime kill.
+        log = (
+            "rank 0 died from signal 15\n"
+            "rank 1 died from signal 15\n"
+        )
+        assert not _has_crash_patterns(log)
+
+    def test_crash_patterns_preserves_real_death_among_cascades(self):
+        # Critical regression: a real OOM mixed with innocent rank
+        # cascades MUST still register as a crash. The strip should
+        # only remove the cascade lines, not the real signal.
+        log = (
+            "rank 0 died from signal 15\n"
+            "rank 1 died from signal 11\n"
+            "torch.OutOfMemoryError: CUDA OOM\n"
+            "rank 2 died from signal 15\n"
+        )
+        assert _has_crash_patterns(log)
+
+    def test_crash_patterns_preserves_shepherd_9(self):
+        # `shepherd died from signal 9` is a PALS daemon kill — real
+        # hardware failure, never an innocent cascade. Must still match.
+        log = "x4502.hsn: shepherd died from signal 9\n"
+        assert _has_crash_patterns(log)
+
+    def test_crash_patterns_preserves_died_from_signal_other_than_11_15(
+        self,
+    ):
+        # Signal 6 = SIGABRT (assertion failures, etc.). Not a cascade
+        # signal — still counts.
+        log = "rank 4 died from signal 6\n"
+        assert _has_crash_patterns(log)
+
     def test_progress_markers_step_equals(self):
         assert _has_progress_markers("iter=10 step=5 loss=0.1")
 
@@ -158,6 +203,39 @@ class TestClassifyAttempt:
         log = _write(
             tmp_path / "log",
             "Execution finished with 0\nOutOfMemoryError on rank 5\n",
+        )
+        assert (
+            classify_attempt(143, log, [])
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_walltime_with_only_innocent_rank_cascade_is_walltime(
+        self, tmp_path
+    ):
+        # rc=143 + log full of `rank N died from signal 15` (cascade
+        # from the walltime SIGTERM raining outward). Without the
+        # innocent-cascade strip, the loose `died from signal` would
+        # override into a bad-node retry — burning spares for nothing.
+        # Must stay WALLTIME.
+        log = _write(
+            tmp_path / "log",
+            "Execution finished with 0\n"
+            "rank 0 died from signal 15\n"
+            "rank 1 died from signal 15\n"
+            "rank 2 died from signal 15\n",
+        )
+        assert classify_attempt(143, log, []) is TerminationReason.WALLTIME
+
+    def test_walltime_with_cascade_and_real_death_is_bad_node(
+        self, tmp_path
+    ):
+        # Mixed log: cascade lines AND a real OOM. The real signal
+        # survives the strip → bad-node retry, not walltime.
+        log = _write(
+            tmp_path / "log",
+            "rank 0 died from signal 15\n"
+            "torch.OutOfMemoryError: CUDA out of memory\n"
+            "rank 1 died from signal 11\n",
         )
         assert (
             classify_attempt(143, log, [])


### PR DESCRIPTION
## Summary

**PR 3 of 3** in the failover integration plan (PR 1 = #142 scrape, PR 2 = #143 bash lib). This PR adds `ezpz launch --auto-retry` — the ergonomic UX wrapper that the failover-integration project memory called out as the final piece.

The user-facing shape (verbatim from the brief):

```bash
# 522 nodes allocated; train on 512, reserve the rest as spares.
# Loop until success, walltime, or spare exhaustion.
ezpz launch --auto-retry --timeout 600 --np 512 -- python3 -m ezpz.examples.test
```

## What's here

### Five commits, each atomic

1. **`feat(launch): add launch_autoretry module with classifier + loop`** — new `src/ezpz/launch_autoretry.py`. Pure-Python implementation of the failover loop. No bash lib dependency (the classifier is too complex to test through shell). 690 LOC.

2. **`feat(cli): add --auto-retry / --spare-nodes / --max-failover-retries flags`** — argparse surface only. Bisectable: this commit alone is a no-op on behavior. Reuses `_non_negative_int` validator from #136; adds new `_spare_nodes_value` for the `"auto"` literal.

3. **`feat(launch): wire --auto-retry through launch() and parse_args()`** — the wire-up. Cross-flag validation (mutex with `--retries`, requires explicit `--nproc`) lives in `parse_args` since argparse mutex groups can't express "non-zero `--retries`" vs the implicit-zero default. When `--auto-retry` is set, splits the PBS nodelist into active + spare, persists active to `logs/failover-<jobid>/active.hostfile`, points the launcher at that path, and dispatches through `run_with_auto_retry` instead of `_run_with_retries`.

4. **`test(launch): cover --auto-retry classifier, allocation, and loop`** — 58 tests across 5 classes. One per row of the termination matrix.

5. **`docs(launch): document --auto-retry, --spare-nodes, --max-failover-retries`** — new section in `docs/cli/launch/index.md` with the termination matrix as a markdown table.

## The termination matrix

The classifier (`launch_autoretry.classify_attempt`) is a pure function over `(rc, log_path, scraped_bad_nodes, prior_had_progress, has_spares)`. Nine outcomes:

| # | Condition                                              | Result                |
|---|--------------------------------------------------------|-----------------------|
| 1 | exit 0 (clean inner trailer, no crash patterns)        | **SUCCESS** → return 0 |
| 2 | exit 143 (walltime SIGTERM), no crash patterns         | **WALLTIME** → return rc |
| 3 | exit 143 *with* crash patterns in log                  | bad-node retry (real failure raced the walltime kill) |
| 4 | exit 124 (idle-output watchdog tripped)                | bad-node retry (silent hang → blind rotation) |
| 5 | any other non-zero, scraper found named host(s)        | swap_in named → retry |
| 6 | any other non-zero, scraper found nothing              | swap_one_blind → retry |
| 7 | two consecutive attempts with zero `step=` markers     | **STUCK_PRE_TRAINING** → return rc |
| 8 | bad-node verdict but no spares left                    | **EXHAUSTED** → return rc |
| 9 | SIGINT (Ctrl-C)                                        | **INTERRUPTED** → return 130 |

Every termination logs `FAILOVER STOP: <reason>` for post-mortem grep.

The #7 guard (two attempts with zero `step=` markers) replaces a numeric "max consecutive blind rotations" cap. The intent is to catch broken configs / missing datasets / pre-training-loop bugs *before* they burn the entire spare pool — if two attempts in a row die before `History.update` prints its first `step=N` line, no amount of node-swapping will help.

## Design decisions (preserving user intent)

- **`--auto-retry` and `--retries` are separate flags, not merged.** Two distinct concepts: `--retries N` is bounded process-level retry on the *same* nodes. `--auto-retry` is unbounded node-level failover. They're mutually exclusive.
- **`--auto-retry` requires explicit `--nproc`.** We refuse to guess the active-host count. Errors at parse time with a clear message.
- **`--spare-nodes` defaults to `"auto"` (= `total_pbs - $nproc`).** Pass an int for explicit cap; pass nothing and you get the whole unused allocation.
- **Default `--timeout` becomes 1800s** when `--auto-retry` is set (matches `FAILOVER_IDLE_TIMEOUT` in `failover.sh`). Catches silent xccl hangs before they burn full walltime.
- **Pure Python, no bash-lib dependency.** The classifier has too many edge cases to test through shell. The two paths (`--auto-retry` and `src/ezpz/bin/failover.sh`) share the scraper (`ezpz.failover.scrape_bad_nodes`) but have independent retry/swap mechanics. ~25 lines of `sed` in the bash lib isn't worth sharing.

## Hard-won crash-detection logic (cross-checked with `failover.sh`)

The same regex set lives in both places (`src/ezpz/launch_autoretry.py:_CRASH_PATTERNS_RX` and `src/ezpz/bin/failover.sh`). If you add a pattern to one, add it to the other.

- **ANSI-stripping before parsing `Execution finished with N`** — the trailer is colored; naive regex pulls `1` out of `[1;36m` instead of the real exit code (e.g. 127). Test: `TestPureHelpers.test_extract_inner_rc_ansi`.
- **Crash-pattern override on shell exit 0** — the wrapper sometimes exits clean even when the mpiexec child crashed. If the log shows OOM / gloo / shepherd-9 / EOFError signatures, treat as failure.
- **Crash-pattern override on exit 143** — real bad-node failures can surface as walltime SIGTERM when mpiexec teardown races the wallclock kill.

## Tests

`tests/test_launch_autoretry.py` — 58 tests across 5 classes:

- **TestPureHelpers (14)** — ANSI stripping, `inner_rc` extraction (incl. the colored-trailer regression), crash patterns, progress markers, spare-count derivation, backoff progression.
- **TestClassifyAttempt (14)** — one test per row of the termination matrix above, plus wrapper-lied-success override, crash-on-clean-exit override, missing-log safety.
- **TestNodeAllocation (8)** — split semantics, `active.hostfile` + `bad_nodes.txt` round-trip, `swap_in` skip-unknown / multi-host / out-of-spares handling, `swap_one_blind` rotation order, `has_spares` property.
- **TestRunWithAutoRetry (8)** — the loop with `_FakeRunner` substituted for `_run_attempt_with_tee`. Covers success-first-attempt, recovery-after-blind, named-host-swap-then-success, walltime-no-retry, the STUCK_PRE_TRAINING guard, EXHAUSTED-when-spares-drain, max_failover_retries cap, progress-clearing-the-guard, and unbounded-default exhausting all spares.
- **TestArgparseValidation (9)** — cross-flag mutex, required-explicit-nproc, `--spare-nodes` accepts `"auto"` literal + int, rejects `"AUTO"` (case-sensitive — same lesson as the scraper's `_resolve_machine_key`) and negatives, back-compat for existing `--retries` / `--timeout` without `--auto-retry`.

## Results

- **58/58 new tests pass** locally
- **131/131** in the combined launch + watchdog + scrape suite (no regressions)

## Follow-up

- [ ] On a real Aurora allocation: run `ezpz launch --auto-retry --np <N>` against a known-flaky job, verify the swap-and-retry actually swaps and retries (the bash lib has the same need from PR #143; both can be validated in one Aurora session)
- [ ] Consider adding an `ezpz launch --auto-retry --dry-run` mode that prints the resolved (active, spare, timeout) plan and exits, so users can sanity-check the allocation split before burning compute

## Test plan

- [x] `pytest tests/test_launch_autoretry.py -q` → 58/58 PASS
- [x] `pytest tests/test_launch_autoretry.py tests/test_launch_watchdog.py tests/test_launch.py tests/test_failover_scrape.py -q` → 131/131 PASS
- [ ] On Aurora: `ezpz launch --auto-retry --np <N> --timeout 600 -- python3 -m ezpz.examples.test`, kill one of the assigned nodes mid-run, verify the loop swaps and continues

## Summary by Sourcery

Introduce an auto-retry failover mode to `ezpz launch` that automatically reallocates work from bad nodes using spare nodes and a classification-driven retry loop.

New Features:
- Add `--auto-retry`, `--spare-nodes`, and `--max-failover-retries` flags to `ezpz launch` for automatic bad-node failover with configurable spare capacity and retry bounds.
- Implement a Python-based auto-retry engine that classifies attempt outcomes from logs and exit codes to drive node swapping and retries, including idle-output watchdog handling.

Enhancements:
- Wire the new auto-retry engine into the launch path so host allocation is split into active and spare sets before topology inference, with per-job failover logs and hostfiles written under `logs/failover-<jobid>`.

Documentation:
- Extend the `ezpz launch` CLI documentation with a dedicated section for `--auto-retry`, describing required flags, spare-node policy, default timeouts, termination matrix, and generated log artifacts.

Tests:
- Add a comprehensive test suite for the auto-retry logic, covering helper functions, the termination classifier, node allocation behavior, the retry loop, and argparse validation for the new flags.