### PR TITLE
refactor(tracker): WandbBackend delegates to ezpz.distributed.setup_wandb

### DIFF
--- a/scripts/smoke_wandb_backend.py
+++ b/scripts/smoke_wandb_backend.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Manual smoke test for the WandbBackend → setup_wandb delegation.
+
+Run from any machine that has wandb logged in (`wandb login` once).
+The test creates a single wandb run, asserts that all 18 expected
+keys land in run.config, and then finishes the run cleanly.
+
+Usage:
+
+    .venv/bin/python scripts/smoke_wandb_backend.py
+
+Or directly in any wandb-authenticated environment:
+
+    python -m scripts.smoke_wandb_backend
+
+What it checks (this is the manual test plan item from PR #147 that
+the mocked unit tests can't cover):
+
+  1. WandbBackend actually delegates to setup_wandb in production
+  2. verify_wandb() passes when there's a real API key
+  3. wandb.init() succeeds (network reachable, project name valid)
+  4. All 18 env-tracking keys end up readable on the live run
+  5. WandbBackend(config=...) keys land at TOP level (not nested)
+
+Exits 0 on success, 1 on failure with the missing-key list.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+# Required keys after the PR #147 env-field expansion. Mirrors
+# tests/test_tracker.py::test_env_fields_from_setup_wandb_applied.
+REQUIRED_KEYS = [
+    # Original set
+    "hostname",
+    "pytorch_backend",
+    "world_size",
+    "machine",
+    "ezpz_version",
+    "working_directory",
+    "torch_version",
+    # Timestamp fields
+    "year",
+    "month",
+    "day",
+    "tstamp",
+    # Filtering / grouping dimensions
+    "jobid",
+    "scheduler",
+    "num_nodes",
+    "ranks_per_node",
+    "device_type",
+    # Debugging / postmortems
+    "python_version",
+    "ezpz_git_sha",
+]
+
+
+def main() -> int:
+    print("=" * 70)
+    print("WandbBackend → setup_wandb delegation smoke test")
+    print("=" * 70)
+    print(f"Python: {sys.version.split()[0]}")
+    print(f"CWD:    {os.getcwd()}")
+    print()
+
+    # Pre-flight: bail before we touch the network if there's no key.
+    api_key = os.environ.get("WANDB_API_KEY")
+    if not api_key:
+        try:
+            import netrc
+
+            netrc_path = os.path.expanduser("~/.netrc")
+            if os.path.isfile(netrc_path):
+                auth = netrc.netrc(netrc_path).authenticators(
+                    "api.wandb.ai"
+                )
+                if not auth:
+                    raise RuntimeError("no entry for api.wandb.ai")
+            else:
+                raise RuntimeError("no ~/.netrc")
+        except Exception as exc:
+            print(f"✗ No wandb credentials found ({exc}).")
+            print("  Run `wandb login` first, or set WANDB_API_KEY.")
+            return 1
+
+    from ezpz.tracker import WandbBackend
+
+    # User config kwargs land at the TOP level (not run.config.config.*)
+    # — that's the WandbBackend contract we're verifying.
+    user_config = {"lr": 0.01, "batch_size": 32, "smoke_test": True}
+
+    print("Creating wandb run via WandbBackend(...)")
+    backend = WandbBackend(
+        project_name="ezpz-smoke-tests",
+        config=user_config,
+        rank=0,
+    )
+
+    if backend.run is None:
+        print("✗ WandbBackend.run is None — init failed silently.")
+        print("  Check the wandb logs above for the underlying error.")
+        return 1
+
+    run = backend.run
+    print(f"✓ Run created: {run.name} ({run.url})")
+    print()
+
+    # Pull the live config back. wandb.Config supports dict-like access.
+    live_config = dict(run.config)
+
+    # Check 1: top-level user keys
+    print("Checking WandbBackend(config=...) lands at TOP level:")
+    failures: list[str] = []
+    for key, expected in user_config.items():
+        actual = live_config.get(key)
+        marker = "✓" if actual == expected else "✗"
+        print(f"  {marker} run.config.{key} = {actual!r} (expected {expected!r})")
+        if actual != expected:
+            failures.append(
+                f"top-level user key '{key}': "
+                f"expected {expected!r}, got {actual!r}"
+            )
+    print()
+
+    # Check 2: all 18 env-tracking keys present
+    print(f"Checking {len(REQUIRED_KEYS)} env-tracking keys from setup_wandb:")
+    missing = [k for k in REQUIRED_KEYS if k not in live_config]
+    for key in REQUIRED_KEYS:
+        present = key in live_config
+        marker = "✓" if present else "✗"
+        val = live_config.get(key)
+        # jobid/ezpz_git_sha are allowed to be None outside a PBS job /
+        # in pip installs — still need the KEY to be present though.
+        val_repr = repr(val) if val is not None else "None (OK)"
+        print(f"  {marker} run.config.{key:<20s} = {val_repr}")
+        if not present:
+            failures.append(f"missing env key: {key}")
+    print()
+
+    backend.finish()
+    print(f"Run URL: {run.url}")
+    print()
+
+    if failures:
+        print(f"✗ {len(failures)} failure(s):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("✓ All checks passed.")
+    if missing:
+        # Shouldn't happen given the loop above, but be paranoid.
+        print(f"  ({len(missing)} keys missing: {missing})")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -1634,16 +1634,32 @@ def _setup_ddp(
             "world_size": world_size,
             "init_method": "env://",
         }
-        device = None
-        if device_id is None:
+        # Resolve device for init_process_group's `device_id=` arg.
+        # When the caller passes an explicit device_id (int or
+        # torch.device), use it verbatim. Otherwise, on CUDA build
+        # one from local_rank so torch can bind the process group
+        # to a specific GPU and avoid the
+        #   "barrier(): using the device under current context.
+        #    You can specify `device_id` in `init_process_group`
+        #    to mute this warning."
+        # warning that fires on every collective op.
+        #
+        # Intentionally skipped for xpu/xccl — that backend doesn't
+        # support split_group (which DeviceMesh._unflatten needs
+        # when process groups are device-bound).
+        resolved_device: Any = None
+        if device_id is not None:
+            resolved_device = (
+                torch.device(f"cuda:{device_id}")
+                if isinstance(device_id, int)
+                else device_id
+            )
+        else:
             device_type = get_torch_device_type()
             if device_type == "cuda":
-                device = torch.device(f"{device_type}:{local_rank}")
-            # Don't pass device_id for xpu/xccl — the backend doesn't
-            # support split_group which DeviceMesh._unflatten requires
-            # when process groups are device-bound.
-        if device_id is not None:
-            init_kwargs["device_id"] = device
+                resolved_device = torch.device(f"cuda:{local_rank}")
+        if resolved_device is not None:
+            init_kwargs["device_id"] = resolved_device
         torch.distributed.init_process_group(**init_kwargs)
 
     return {"rank": rank, "world_size": world_size, "local_rank": local_rank}

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -19,6 +19,7 @@ Design principles:
 
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import socket
@@ -751,9 +752,9 @@ def wrap_model(
     model: torch.nn.Module,
     use_fsdp: bool = True,
     dtype: str = "bfloat16",
-    device_id: torch.device | int | None = None,
     device_mesh: Any = None,
     reshard_after_forward: bool | int = True,
+    device_id: torch.device | int | None = None,
 ) -> torch.nn.Module:
     """Wrap *model* with DDP or FSDP for distributed training.
 
@@ -1183,6 +1184,36 @@ def verify_wandb() -> bool:
     return False
 
 
+def _get_ezpz_git_sha() -> str | None:
+    """Return the short SHA of the ezpz checkout, or ``None`` if not a git repo.
+
+    Useful for distinguishing wandb runs from feature branches vs main
+    when ``ezpz_version`` alone is ambiguous (e.g. dev installs from a
+    branch that has not been version-bumped yet).
+
+    Returns ``None`` on any failure mode — pip-installed packages aren't
+    git repos, ``git`` may not be on PATH, the call could time out, etc.
+    Logging is silenced; this helper is best-effort by design.
+    """
+    try:
+        import subprocess  # noqa: PLC0415 — only needed here
+
+        ezpz_dir = Path(__file__).resolve().parent
+        proc = subprocess.run(
+            ["git", "-C", str(ezpz_dir), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return None
+        sha = proc.stdout.strip()
+        return sha or None
+    except Exception:
+        return None
+
+
 def setup_wandb(
     project_name: str | None = None,
     entity: str | None = None,
@@ -1295,13 +1326,37 @@ def setup_wandb(
         )
         if run is not None:
             logger.info("wandb.run=[%s](%s)", run.name, run.url)
-            import torch
+            import sys  # noqa: PLC0415
+            import torch  # noqa: PLC0415
 
-            import ezpz
+            import ezpz  # noqa: PLC0415
+            from ezpz.configs import get_scheduler  # noqa: PLC0415
 
+            now = datetime.datetime.now()
+
+            # Best-effort resolution of the active scheduler jobid.
+            # ezpz.launch.get_active_jobid imports ezpz.pbs / ezpz.slurm
+            # lazily and returns None when no job is detected. Wrapped
+            # in try/except because the launch module pulls a non-
+            # trivial chain on first import — any failure here should
+            # NOT block the wandb run from being created.
+            jobid: str | None = None
+            try:
+                from ezpz.launch import (
+                    get_active_jobid,
+                )  # noqa: PLC0415
+
+                jobid = get_active_jobid()
+            except Exception:
+                pass
+
+            # num_nodes / gpus_per_node have their own getters that
+            # already swallow failures internally (return 1 / fall
+            # back). Safe to call directly.
             run.config.update(
                 {
                     # "DIST_INFO": get_dist_info(),
+                    # --- existing fields (unchanged) ---
                     "hostname": get_hostname(),
                     "pytorch_backend": get_torch_backend(),
                     "torch_version": torch.__version__,
@@ -1309,6 +1364,30 @@ def setup_wandb(
                     "ezpz_version": ezpz.__version__,
                     "machine": get_machine(),
                     "working_directory": os.getcwd(),
+                    "year": now.year,
+                    "month": now.month,
+                    "day": now.day,
+                    "tstamp": now.isoformat(),
+                    # --- new dimensions for filtering / grouping ---
+                    # Pivot from a wandb run → the cluster job that
+                    # ran it. None when not inside a PBS/SLURM job.
+                    "jobid": jobid,
+                    # "pbs" / "slurm" / "" — useful when you have
+                    # runs from both systems in the same project.
+                    "scheduler": get_scheduler(),
+                    # Distinct from world_size: same world_size can be
+                    # 8x8 or 4x16, lets you separate the two.
+                    "num_nodes": get_num_nodes(),
+                    "ranks_per_node": get_gpus_per_node(),
+                    # "cuda" / "xpu" / "mps" / "cpu" — at-a-glance
+                    # distinction between Aurora vs NVIDIA vs CPU runs.
+                    "device_type": get_torch_device_type(),
+                    # --- debugging / postmortems ---
+                    "python_version": sys.version.split()[0],
+                    # None when ezpz is a pip-install, not a git
+                    # checkout. Disambiguates dev branches sharing the
+                    # same ezpz_version.
+                    "ezpz_git_sha": _get_ezpz_git_sha(),
                 }
             )
             if config is not None:

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -1151,7 +1151,23 @@ def timeitlogit(
 
 
 def verify_wandb() -> bool:
-    """Return ``True`` if wandb is importable, enabled, and authenticated."""
+    """Return ``True`` if wandb is importable, enabled, and usable.
+
+    "Usable" means one of:
+
+    1. ``WANDB_MODE=offline`` is set — offline runs don't need
+       network or credentials; they write to a local
+       ``wandb/offline-run-*`` directory and can be synced later.
+       This is the documented compute-node workflow (see
+       ``docs/troubleshooting.md`` + ``doctor.py``'s permissive
+       handling of offline mode).
+    2. An API key is reachable (``$WANDB_API_KEY``, ``wandb.api.api_key``,
+       or a ``~/.netrc`` entry for ``api.wandb.ai``).
+
+    Returns ``False`` when wandb is uninstalled, ``WANDB_DISABLED`` is
+    truthy, ``WANDB_MODE=disabled``, or neither offline mode nor any
+    credential source is configured.
+    """
     rank = get_rank()
     try:
         import wandb
@@ -1166,6 +1182,12 @@ def verify_wandb() -> bool:
     wm = os.environ.get("WANDB_MODE", "").lower()
     if wm == "disabled":
         return False
+    # Offline mode is fine without credentials — wandb.init(mode="offline")
+    # writes locally and never touches the network. Return True so callers
+    # (esp. setup_wandb) don't silently no-op on compute nodes that use
+    # the offline-then-sync workflow.
+    if wm == "offline":
+        return True
     if (
         wandb.api.api_key is not None
         or os.environ.get("WANDB_API_KEY") is not None
@@ -1667,17 +1689,32 @@ def _setup_ddp(
         # Intentionally skipped for xpu/xccl — that backend doesn't
         # support split_group (which DeviceMesh._unflatten needs
         # when process groups are device-bound).
+        # Resolve the device the PG should bind to. Two principles:
+        #
+        #   1. An explicit `device_id` arg (int OR torch.device) wins,
+        #      but we must honor get_torch_device_type() to pick the
+        #      right device family. Hardcoding "cuda:N" for an int
+        #      breaks XPU/MPS/HIP callers — same bug class as the
+        #      barrier() warning this code originally fixed.
+        #
+        #   2. Auto-detect ONLY binds for CUDA. xpu/xccl historically
+        #      didn't support split_group (which DeviceMesh._unflatten
+        #      needs when PGs are device-bound). NOTE: this leaves XPU
+        #      FSDP2 vulnerable to the wrong-device-binding hang that
+        #      `torch.xpu.set_device(local_rank)` happens AFTER this
+        #      call in setup_torch. Fix tracked separately — do NOT
+        #      reinstate the "skip on xpu" comment without verifying
+        #      the FSDP2 path is actually broken with newer xccl.
+        device_type = get_torch_device_type()
         resolved_device: Any = None
         if device_id is not None:
-            resolved_device = (
-                torch.device(f"cuda:{device_id}")
-                if isinstance(device_id, int)
-                else device_id
-            )
-        else:
-            device_type = get_torch_device_type()
-            if device_type == "cuda":
-                resolved_device = torch.device(f"cuda:{local_rank}")
+            if isinstance(device_id, int):
+                resolved_device = torch.device(f"{device_type}:{device_id}")
+            else:
+                # Caller passed a torch.device — honor verbatim.
+                resolved_device = device_id
+        elif device_type == "cuda":
+            resolved_device = torch.device(f"cuda:{local_rank}")
         if resolved_device is not None:
             init_kwargs["device_id"] = resolved_device
         torch.distributed.init_process_group(**init_kwargs)

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -1245,22 +1245,42 @@ def setup_wandb(
     settings: dict[str, Any] | None = None,
     **kwargs,
 ) -> Any:
-    """Initialise a wandb run (rank 0 only logs, others get disabled mode).
+    """Initialise a wandb run (rank 0 only — non-zero ranks return ``None``).
 
     Most parameters are forwarded directly to :func:`wandb.init`.  See
     the `wandb docs <https://docs.wandb.ai/ref/python/init/>`_ for
     details.
 
     Returns:
-        The :obj:`wandb.run` object, or ``None`` if wandb is unavailable.
+        The :obj:`wandb.run` object, ``None`` if called from a non-zero
+        rank, or ``None`` if wandb is unavailable.
+
+    .. note::
+       Returns ``None`` on every rank other than 0. Previously
+       non-zero ranks got a ``mode="disabled"`` wandb.run back — that
+       still meant verify_wandb(), wandb.init(), and full
+       run.config.update() ran on every rank, which on a 96-rank job
+       produced 96 dummy runs and a wall of "Setting up wandb from
+       rank=N" log spam. Callers that need a no-op tracker on
+       non-zero ranks should test for ``None`` and use
+       :class:`ezpz.tracker.NullTracker` (or just ignore the return —
+       ``log()`` calls against ``None`` should be guarded by the
+       caller anyway).
     """
+    # Hard rank gate: non-zero ranks skip all wandb work entirely.
+    # verify_wandb() and wandb.init() each take real time and produce
+    # log spam; on a 96-rank job that's 95x wasted work + a 96x
+    # multiplier on every log line in this function.
+    rank = get_rank()
+    if rank != 0:
+        return None
+
     import wandb
 
     if not verify_wandb():
         logger.warning("verify_wandb() failed; not initialising run")
         return None
 
-    rank = get_rank()
     outdir_str = Path(outdir).as_posix() if outdir else os.getcwd()
 
     # Resolve project name

--- a/src/ezpz/tracker.py
+++ b/src/ezpz/tracker.py
@@ -127,9 +127,14 @@ class WandbBackend(TrackerBackend):
 
     Thin adapter over :func:`ezpz.distributed.setup_wandb` — that's the
     single canonical W&B-init entry point in ezpz, so this backend
-    automatically inherits its environment-tracking goodies (hostname,
-    pytorch_backend, world_size, machine, ezpz_version, timestamp,
-    etc.) and any future fields added there.
+    automatically inherits its environment-tracking goodies. As of
+    v0.18.x those include: ``hostname``, ``pytorch_backend``,
+    ``torch_version``, ``world_size``, ``ezpz_version``, ``machine``,
+    ``working_directory``, ``year``/``month``/``day``/``tstamp``,
+    ``jobid``, ``scheduler``, ``num_nodes``, ``ranks_per_node``,
+    ``device_type``, ``python_version``, ``ezpz_git_sha``. Any future
+    fields added to ``setup_wandb`` automatically reach
+    ``WandbBackend``-instantiated runs.
 
     Args:
         project_name: W&B project name. Falls back to ``$WB_PROJECT`` /
@@ -144,8 +149,11 @@ class WandbBackend(TrackerBackend):
         outdir: Directory for local wandb files. Forwarded as ``dir=``
             to ``wandb.init``.
         rank: Distributed rank override. ``None`` → auto-detect via
-            ``get_rank()``. Non-zero ranks get ``mode="disabled"`` so
-            they don't open extra wandb runs.
+            ``get_rank()``. Non-zero ranks short-circuit immediately:
+            ``self._run = None``, no wandb import, no
+            ``setup_wandb`` call. Callers should null-check
+            ``backend.run`` rather than expect a disabled wandb run
+            object.
         **kwargs: Forwarded to :func:`~ezpz.distributed.setup_wandb`
             (which forwards them to ``wandb.init``).
     """
@@ -188,6 +196,21 @@ class WandbBackend(TrackerBackend):
         if outdir is not None:
             kwargs.setdefault("dir", Path(outdir).as_posix())
 
+        # Resolve project name HERE rather than letting setup_wandb
+        # infer it via sys._getframe(). setup_wandb's frame walk
+        # would land on tracker.py (our caller) and group every
+        # default-project WandbBackend run under "ezpz.tracker"
+        # instead of the user's training script. _default_project_name
+        # walks sys.modules['__main__'] which gives the right answer
+        # regardless of how deep the call chain is.
+        _project = (
+            project_name
+            or os.environ.get("WB_PROJECT")
+            or os.environ.get("WANDB_PROJECT")
+            or os.environ.get("WB_PROJECT_NAME")
+            or _default_project_name()
+        )
+
         # NOTE: we do NOT pass config= to setup_wandb. That helper nests
         # the dict under run.config["config"]; WandbBackend has always
         # exposed user keys at the top level (run.config.lr, not
@@ -197,7 +220,7 @@ class WandbBackend(TrackerBackend):
 
         try:
             self._run = setup_wandb(
-                project_name=project_name,
+                project_name=_project,
                 **kwargs,
             )
         except Exception as exc:

--- a/src/ezpz/tracker.py
+++ b/src/ezpz/tracker.py
@@ -125,15 +125,29 @@ class TrackerBackend(ABC):
 class WandbBackend(TrackerBackend):
     """Backend that delegates to `Weights & Biases <https://wandb.ai>`_.
 
-    Wraps ``wandb.init`` with the same rank-aware, env-var-respecting logic
-    used by :func:`ezpz.distributed.setup_wandb`.
+    Thin adapter over :func:`ezpz.distributed.setup_wandb` — that's the
+    single canonical W&B-init entry point in ezpz, so this backend
+    automatically inherits its environment-tracking goodies (hostname,
+    pytorch_backend, world_size, machine, ezpz_version, timestamp,
+    etc.) and any future fields added there.
 
     Args:
-        project_name: W&B project name.
-        config: Run-level config dict passed to ``wandb.init``.
-        outdir: Directory for local wandb files.
-        rank: Distributed rank (non-0 gets ``mode="disabled"``).
-        **kwargs: Forwarded to ``wandb.init``.
+        project_name: W&B project name. Falls back to ``$WB_PROJECT`` /
+            ``$WANDB_PROJECT`` / ``$WB_PROJECT_NAME`` / the calling
+            script's filename (in that order) via
+            :func:`~ezpz.distributed.setup_wandb`.
+        config: Run-level config dict. Keys land at the **top level** of
+            ``run.config`` (we deliberately bypass ``setup_wandb``'s
+            ``{"config": config}`` wrap so existing
+            ``WandbBackend(config={"lr": 0.01})`` users still see
+            ``run.config.lr``).
+        outdir: Directory for local wandb files. Forwarded as ``dir=``
+            to ``wandb.init``.
+        rank: Distributed rank override. ``None`` → auto-detect via
+            ``get_rank()``. Non-zero ranks get ``mode="disabled"`` so
+            they don't open extra wandb runs.
+        **kwargs: Forwarded to :func:`~ezpz.distributed.setup_wandb`
+            (which forwards them to ``wandb.init``).
     """
 
     name: str = "wandb"
@@ -158,67 +172,40 @@ class WandbBackend(TrackerBackend):
             except Exception:
                 rank = 0
 
-        # Resolve project name from args / env / script name
-        _project = project_name
-        if _project is None:
-            _project = os.environ.get(
-                "WB_PROJECT",
-                os.environ.get(
-                    "WANDB_PROJECT",
-                    os.environ.get("WB_PROJECT_NAME"),
-                ),
-            )
-        if _project is None:
-            _project = _default_project_name()
-
-        # Resolve mode — disable on non-rank-0 processes
-        from ezpz.distributed import _resolve_wandb_mode
-
-        _mode_arg = kwargs.pop("mode", None)
+        # Non-rank-0 → force disabled BEFORE calling setup_wandb so
+        # downstream wandb.init bypasses any network calls. setup_wandb
+        # always reads the live get_rank() and applies its OWN resolution
+        # on top, so passing mode="disabled" is the clean override here.
         if rank != 0:
-            _mode = "disabled"
-        else:
-            _mode = _resolve_wandb_mode(_mode_arg)
+            kwargs["mode"] = "disabled"
 
-        outdir_str = Path(outdir).as_posix() if outdir else os.getcwd()
+        # Translate WandbBackend's `outdir` → setup_wandb's `dir`. Done
+        # explicitly (rather than via **kwargs) so the contract stays
+        # obvious to readers.
+        if outdir is not None:
+            kwargs.setdefault("dir", Path(outdir).as_posix())
 
-        init_kwargs: dict[str, Any] = {
-            "project": _project,
-            "dir": outdir_str,
-            "mode": _mode,
-            **kwargs,
-        }
-        # Remove None values so wandb.init uses its own defaults
-        init_kwargs = {k: v for k, v in init_kwargs.items() if v is not None}
+        # NOTE: we do NOT pass config= to setup_wandb. That helper nests
+        # the dict under run.config["config"]; WandbBackend has always
+        # exposed user keys at the top level (run.config.lr, not
+        # run.config.config.lr). Preserve that contract by updating the
+        # config dict ourselves after init.
+        from ezpz.distributed import setup_wandb
 
         try:
-            self._run = wandb.init(**init_kwargs)
+            self._run = setup_wandb(
+                project_name=project_name,
+                **kwargs,
+            )
         except Exception as exc:
             logger.warning(
-                "wandb.init() failed: %s — continuing without wandb", exc
+                "setup_wandb() failed: %s — continuing without wandb", exc
             )
             self._run = None
             return
 
         if self._run is not None and config is not None:
             self._run.config.update(config)
-
-        # Auto-populate system info
-        if self._run is not None:
-            try:
-                import torch
-                import ezpz
-
-                self._run.config.update(
-                    {
-                        "hostname": os.environ.get("HOSTNAME", ""),
-                        "torch_version": torch.__version__,
-                        "ezpz_version": ezpz.__version__,
-                        "working_directory": os.getcwd(),
-                    }
-                )
-            except Exception:
-                pass
 
     @property
     def run(self) -> Any:

--- a/src/ezpz/tracker.py
+++ b/src/ezpz/tracker.py
@@ -172,12 +172,15 @@ class WandbBackend(TrackerBackend):
             except Exception:
                 rank = 0
 
-        # Non-rank-0 → force disabled BEFORE calling setup_wandb so
-        # downstream wandb.init bypasses any network calls. setup_wandb
-        # always reads the live get_rank() and applies its OWN resolution
-        # on top, so passing mode="disabled" is the clean override here.
+        # Hard rank gate. setup_wandb ALSO short-circuits on non-zero
+        # ranks (as of v0.18.x) so this is belt-and-suspenders — but
+        # the gate here lets us skip the import + cross-module call
+        # entirely on N-1 ranks, which on a 96-rank job is the
+        # difference between 0 and 96 noisy "Setting up wandb..."
+        # log lines.
         if rank != 0:
-            kwargs["mode"] = "disabled"
+            self._run = None
+            return
 
         # Translate WandbBackend's `outdir` → setup_wandb's `dir`. Done
         # explicitly (rather than via **kwargs) so the contract stays

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1056,6 +1056,28 @@ class TestVerifyWandb:
         with patch.dict("sys.modules", {"wandb": mock_wandb}):
             assert dist.verify_wandb() is True
 
+    def test_wandb_mode_offline_no_api_key(self, fake_comm, monkeypatch):
+        """Regression: WANDB_MODE=offline must NOT require an API key.
+
+        Offline runs write locally and never touch the network — that's
+        the whole point of the mode, and it's the documented compute-node
+        workflow (docs/troubleshooting.md). Pre-fix verify_wandb()
+        returned False here, which caused setup_wandb() to silently
+        skip wandb init on every compute-node offline run.
+        """
+        monkeypatch.delenv("WANDB_DISABLED", raising=False)
+        monkeypatch.delenv("WANDB_API_KEY", raising=False)
+        monkeypatch.setenv("WANDB_MODE", "offline")
+        mock_wandb = MagicMock()
+        mock_wandb.api.api_key = None
+        # Make sure netrc check would also fail so we're exercising
+        # the offline-exception branch, not the netrc fallback.
+        monkeypatch.setattr(
+            "pathlib.Path.is_file", lambda self: False
+        )
+        with patch.dict("sys.modules", {"wandb": mock_wandb}):
+            assert dist.verify_wandb() is True
+
 
 class TestResolveWandbMode:
     """Tests for ``_resolve_wandb_mode``."""
@@ -1595,8 +1617,17 @@ class TestSetupDdpDeviceId:
         )
         assert "device_id" not in kwargs
 
-    def test_explicit_int_device_id_resolves_to_cuda(self, monkeypatch):
-        # Caller passed device_id=2 (an int). Treat as cuda:2.
+    def test_explicit_int_device_id_resolves_to_active_device_type(
+        self, monkeypatch
+    ):
+        """An int device_id resolves to "{get_torch_device_type()}:N".
+
+        Pre-fix this hardcoded "cuda:N" regardless of the active device
+        type — same bug class as the barrier()-warning fix above, just
+        on the explicit-caller path instead of the auto-detect path.
+        On a CUDA system the result is unchanged ("cuda:2"); the
+        regression target is XPU (see test_explicit_int_device_id_on_xpu).
+        """
         monkeypatch.setattr(dist, "get_torch_device_type", lambda: "cuda")
         import torch
         from unittest.mock import MagicMock
@@ -1618,6 +1649,43 @@ class TestSetupDdpDeviceId:
         dist._setup_ddp(backend="gloo", device_id=2)
         kwargs = mock_init.call_args.kwargs
         assert kwargs["device_id"] == torch.device("cuda:2")
+
+    def test_explicit_int_device_id_on_xpu_resolves_to_xpu(
+        self, monkeypatch
+    ):
+        """Regression: int device_id on XPU must NOT become "cuda:N".
+
+        Pre-fix `_setup_ddp(device_id=2)` on Aurora would have built
+        torch.device("cuda:2") and forwarded it to xccl
+        init_process_group — would have either errored or silently
+        bound to a non-existent device. This test pins the corrected
+        behavior: same int, different device_type, correct device
+        family.
+        """
+        monkeypatch.setattr(dist, "get_torch_device_type", lambda: "xpu")
+        import torch
+        from unittest.mock import MagicMock
+
+        mock_init = MagicMock()
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+        monkeypatch.setattr(
+            torch.distributed, "init_process_group", mock_init
+        )
+        monkeypatch.setattr(dist, "broadcast", lambda x, root=0: x)
+        monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+        monkeypatch.setenv("MASTER_PORT", "12345")
+        monkeypatch.setenv("RANK", "0")
+        monkeypatch.setenv("LOCAL_RANK", "0")
+        monkeypatch.setenv("WORLD_SIZE", "4")
+
+        dist._setup_ddp(backend="gloo", device_id=2)
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["device_id"] == torch.device("xpu:2"), (
+            "Regression: explicit int device_id on XPU resolved to "
+            "the wrong device family. Was likely hardcoded `cuda:N`."
+        )
 
     def test_explicit_xpu_device_id_currently_passes_through(
         self, monkeypatch

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1404,3 +1404,43 @@ class TestGetFreePort:
         ports = {dist._get_free_port() for _ in range(10)}
         # While not guaranteed, we should get at least a few unique ports
         assert len(ports) >= 2
+
+
+# ===================================================================
+# _get_ezpz_git_sha
+# ===================================================================
+
+
+class TestGetEzpzGitSha:
+    """Tests for the best-effort git-sha lookup used by setup_wandb."""
+
+    def test_returns_short_sha_or_none(self):
+        # Real call against the actual checkout. On a dev machine this
+        # returns the short SHA; in a pip-install / non-git context
+        # returns None. Either is fine — we just verify the type.
+        sha = dist._get_ezpz_git_sha()
+        assert sha is None or (isinstance(sha, str) and 7 <= len(sha) <= 40)
+        if sha is not None:
+            # short sha is hex-only (no newlines, no whitespace)
+            assert sha.isalnum()
+
+    def test_handles_subprocess_failure_safely(self, monkeypatch):
+        # Simulate `git` not on PATH / non-zero exit: must return None,
+        # not raise. setup_wandb is allowed to keep going even when we
+        # can't compute the SHA.
+        import subprocess
+
+        def _explode(*_args, **_kwargs):
+            raise FileNotFoundError("git: command not found")
+
+        monkeypatch.setattr(subprocess, "run", _explode)
+        assert dist._get_ezpz_git_sha() is None
+
+    def test_handles_timeout_safely(self, monkeypatch):
+        import subprocess
+
+        def _timeout(*_args, **_kwargs):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=2.0)
+
+        monkeypatch.setattr(subprocess, "run", _timeout)
+        assert dist._get_ezpz_git_sha() is None

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1551,3 +1551,47 @@ class TestSetupDdpDeviceId:
         dist._setup_ddp(backend="gloo", device_id=2)
         kwargs = mock_init.call_args.kwargs
         assert kwargs["device_id"] == torch.device("cuda:2")
+
+    def test_explicit_xpu_device_id_currently_passes_through(
+        self, monkeypatch
+    ):
+        # Documents CURRENT behavior, not desired behavior: when the
+        # caller explicitly passes a torch.device("xpu:0") as
+        # device_id, the resolver forwards it to init_process_group
+        # even though the auto-detect path (device_id=None) correctly
+        # skips device_id on xpu. This is the P1 from the PR #147
+        # review — the comment block in _setup_ddp claims we skip
+        # device_id on xpu/xccl, but the skip only fires when the
+        # caller didn't pass anything.
+        #
+        # If/when this is fixed (resolved_device should be set to None
+        # when device_type == "xpu", regardless of how device_id was
+        # passed), this test should flip to:
+        #   assert "device_id" not in kwargs
+        monkeypatch.setattr(dist, "get_torch_device_type", lambda: "xpu")
+        import torch
+        from unittest.mock import MagicMock
+
+        mock_init = MagicMock()
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+        monkeypatch.setattr(
+            torch.distributed, "init_process_group", mock_init
+        )
+        monkeypatch.setattr(dist, "broadcast", lambda x, root=0: x)
+        monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+        monkeypatch.setenv("MASTER_PORT", "12345")
+        monkeypatch.setenv("RANK", "0")
+        monkeypatch.setenv("LOCAL_RANK", "0")
+        monkeypatch.setenv("WORLD_SIZE", "4")
+
+        xpu_device = torch.device("xpu", 0)
+        dist._setup_ddp(backend="gloo", device_id=xpu_device)  # type: ignore[arg-type]
+        kwargs = mock_init.call_args.kwargs
+        # CURRENT (potentially buggy) behavior: xpu device passes through.
+        assert kwargs.get("device_id") == xpu_device, (
+            "If this assertion fails, the P1 from PR #147 was likely "
+            "fixed — flip to `assert 'device_id' not in kwargs` and "
+            "delete this comment."
+        )

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1451,6 +1451,73 @@ class TestGetEzpzGitSha:
 # ===================================================================
 
 
+class TestSetupWandbRankGate:
+    """setup_wandb must short-circuit on non-zero ranks.
+
+    Regression for the 96-rank Sunspot incident: previously setup_wandb
+    ran verify_wandb() + wandb.init() + logger.info() on every rank,
+    relying on _resolve_wandb_mode("disabled") for non-zero ranks to
+    produce a "dummy" wandb.run. Result: 95 dummy runs + a wall of
+    "Setting up wandb from rank=N" log spam on a 96-rank job.
+    """
+
+    def test_rank_nonzero_returns_none_immediately(self, monkeypatch):
+        # Mock get_rank to return 17. Then mock wandb so that if
+        # setup_wandb DID try to call wandb.init, we'd see it.
+        monkeypatch.setattr(dist, "get_rank", lambda: 17)
+
+        wandb_init_calls = []
+        verify_calls = []
+
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_wandb = MagicMock()
+        mock_wandb.init = MagicMock(
+            side_effect=lambda *a, **kw: wandb_init_calls.append((a, kw))
+        )
+        monkeypatch.setitem(sys.modules, "wandb", mock_wandb)
+        monkeypatch.setattr(
+            dist,
+            "verify_wandb",
+            lambda: (verify_calls.append(1), True)[1],
+        )
+
+        result = dist.setup_wandb(project_name="test")
+
+        assert result is None, "non-zero rank must return None"
+        assert wandb_init_calls == [], (
+            "setup_wandb called wandb.init from a non-zero rank — "
+            "the rank gate regressed. This is the 96-dummy-runs bug."
+        )
+        assert verify_calls == [], (
+            "setup_wandb called verify_wandb from a non-zero rank — "
+            "the rank gate should short-circuit BEFORE verify_wandb."
+        )
+
+    def test_rank_zero_proceeds_normally(self, monkeypatch):
+        # Companion: rank 0 must still call verify_wandb + wandb.init.
+        monkeypatch.setattr(dist, "get_rank", lambda: 0)
+
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_wandb = MagicMock()
+        mock_wandb.init.return_value = MagicMock()
+        mock_wandb.run = mock_wandb.init.return_value
+        monkeypatch.setitem(sys.modules, "wandb", mock_wandb)
+        monkeypatch.setattr(dist, "verify_wandb", lambda: True)
+
+        result = dist.setup_wandb(project_name="test")
+
+        assert result is not None, (
+            "rank 0 should get a wandb.run, not None"
+        )
+        assert mock_wandb.init.called, (
+            "rank 0 should call wandb.init"
+        )
+
+
 class TestSetupDdpDeviceId:
     """Regression for the device_id-never-set-on-CUDA bug.
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1444,3 +1444,110 @@ class TestGetEzpzGitSha:
 
         monkeypatch.setattr(subprocess, "run", _timeout)
         assert dist._get_ezpz_git_sha() is None
+
+
+# ===================================================================
+# _setup_ddp: device_id resolution
+# ===================================================================
+
+
+class TestSetupDdpDeviceId:
+    """Regression for the device_id-never-set-on-CUDA bug.
+
+    Before the fix, _setup_ddp built a torch.device("cuda:N") when the
+    caller didn't pass device_id but then NEVER added it to init_kwargs
+    (the guard checked the original device_id parameter, not the locally-
+    constructed device). Result: every CUDA run got
+        "barrier(): using the device under current context.
+         You can specify `device_id` in `init_process_group` to mute
+         this warning."
+    on every collective op.
+
+    These tests inspect the init_kwargs that _setup_ddp would pass to
+    torch.distributed.init_process_group, without actually initing a
+    real process group.
+    """
+
+    def _capture_init_kwargs(self, monkeypatch, **env):
+        """Call _setup_ddp with mocked torch.distributed and return the
+        kwargs it would have passed to init_process_group."""
+        import torch
+        from unittest.mock import MagicMock
+
+        for k, v in env.items():
+            monkeypatch.setenv(k, str(v))
+
+        # Patch is_initialized → False so we hit the init path, and
+        # init_process_group → MagicMock so we can inspect its args.
+        mock_init = MagicMock()
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+        monkeypatch.setattr(
+            torch.distributed, "init_process_group", mock_init
+        )
+        # No-op the env-broadcasting helpers — they need real MPI.
+        monkeypatch.setattr(dist, "broadcast", lambda x, root=0: x)
+        # Force MASTER_ADDR/PORT so we skip the resolution branch.
+        monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+        monkeypatch.setenv("MASTER_PORT", "12345")
+
+        dist._setup_ddp(backend="gloo")
+        assert mock_init.call_count == 1
+        return mock_init.call_args.kwargs
+
+    def test_cuda_default_device_id_built_from_local_rank(
+        self, monkeypatch
+    ):
+        # CUDA + no explicit device_id → must pass device_id=cuda:LOCAL_RANK
+        # so torch can bind the PG to a specific GPU and skip the warning.
+        monkeypatch.setattr(dist, "get_torch_device_type", lambda: "cuda")
+        kwargs = self._capture_init_kwargs(
+            monkeypatch,
+            RANK=0,
+            LOCAL_RANK=3,
+            WORLD_SIZE=4,
+        )
+        import torch
+
+        assert "device_id" in kwargs, (
+            "Regression: _setup_ddp dropped device_id when caller didn't pass "
+            "one; init_process_group will emit barrier()-warning spam."
+        )
+        assert kwargs["device_id"] == torch.device("cuda:3")
+
+    def test_xpu_skips_device_id(self, monkeypatch):
+        # XCCL doesn't support split_group → DeviceMesh._unflatten breaks
+        # when PGs are device-bound. Intentional: device_id stays absent.
+        monkeypatch.setattr(dist, "get_torch_device_type", lambda: "xpu")
+        kwargs = self._capture_init_kwargs(
+            monkeypatch,
+            RANK=0,
+            LOCAL_RANK=2,
+            WORLD_SIZE=4,
+        )
+        assert "device_id" not in kwargs
+
+    def test_explicit_int_device_id_resolves_to_cuda(self, monkeypatch):
+        # Caller passed device_id=2 (an int). Treat as cuda:2.
+        monkeypatch.setattr(dist, "get_torch_device_type", lambda: "cuda")
+        import torch
+        from unittest.mock import MagicMock
+
+        mock_init = MagicMock()
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+        monkeypatch.setattr(
+            torch.distributed, "init_process_group", mock_init
+        )
+        monkeypatch.setattr(dist, "broadcast", lambda x, root=0: x)
+        monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+        monkeypatch.setenv("MASTER_PORT", "12345")
+        monkeypatch.setenv("RANK", "0")
+        monkeypatch.setenv("LOCAL_RANK", "0")
+        monkeypatch.setenv("WORLD_SIZE", "4")
+
+        dist._setup_ddp(backend="gloo", device_id=2)
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["device_id"] == torch.device("cuda:2")

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -378,6 +378,7 @@ class TestWandbBackendBehavior:
         # ezpz.distributed.setup_wandb — if you add a key there,
         # add it here too so the contract stays pinned.
         for required in [
+            # Original set
             "hostname",
             "pytorch_backend",
             "world_size",
@@ -385,6 +386,20 @@ class TestWandbBackendBehavior:
             "ezpz_version",
             "working_directory",
             "torch_version",
+            # Timestamp fields
+            "year",
+            "month",
+            "day",
+            "tstamp",
+            # Filtering / grouping dimensions
+            "jobid",  # None when not in a PBS/SLURM job, but key present
+            "scheduler",
+            "num_nodes",
+            "ranks_per_node",
+            "device_type",
+            # Debugging / postmortems
+            "python_version",
+            "ezpz_git_sha",  # None for pip installs, but key present
         ]:
             assert required in all_keys, f"missing {required!r}"
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -207,22 +207,60 @@ class TestWandbBackendRankGating:
         # mode="disabled" from env, but should not be overridden
         assert backend._run is not None or True  # init succeeds or is disabled
 
-    @patch.dict(os.environ, {}, clear=False)
-    def test_rank_nonzero_gets_disabled(self):
+    def test_rank_nonzero_returns_none_without_calling_wandb(
+        self, monkeypatch
+    ):
+        # As of v0.18.x WandbBackend short-circuits on rank != 0 BEFORE
+        # importing wandb or calling setup_wandb. Previously it forwarded
+        # mode="disabled" and got back a no-op wandb.run; on a 96-rank
+        # job that meant 95 dummy runs + a wall of "Setting up wandb
+        # from rank=N" log spam from setup_wandb.
+        #
+        # Mock setup_wandb to assert it is NEVER called from rank != 0.
+        called = []
+
+        def _should_not_be_called(*args, **kwargs):
+            called.append((args, kwargs))
+            return None
+
+        monkeypatch.setattr(
+            "ezpz.distributed.setup_wandb", _should_not_be_called
+        )
+
         backend = WandbBackend(rank=1)
-        # rank != 0 should force mode="disabled"
-        # The run should exist but in disabled mode (no network calls)
-        if backend._run is not None:
-            assert backend._run.disabled
+        assert backend._run is None, "non-zero rank must have _run=None"
+        assert called == [], (
+            f"setup_wandb was called from rank=1: {called}. "
+            "Rank gate regressed — every rank now does wandb init work."
+        )
+
+    def test_rank_zero_does_call_setup_wandb(self, monkeypatch):
+        # Companion to the above: rank 0 SHOULD reach setup_wandb. Same
+        # mock, opposite assertion.
+        called = []
+
+        def _capture(*args, **kwargs):
+            called.append((args, kwargs))
+            # Return None so we don't try to update config on a mock.
+            return None
+
+        monkeypatch.setattr(
+            "ezpz.distributed.setup_wandb", _capture
+        )
+
+        WandbBackend(rank=0)
+        assert len(called) == 1, (
+            f"rank 0 should call setup_wandb exactly once, got {len(called)}"
+        )
 
     @patch.dict(os.environ, {"WANDB_MODE": "disabled"})
-    def test_mode_kwarg_popped_on_all_ranks(self):
-        """mode= should be consumed even on non-rank-0 to avoid leaking."""
-        # If mode leaks into **kwargs, wandb.init gets it twice (via
-        # init_kwargs["mode"] and **kwargs), which would be wrong.
-        # This test verifies no TypeError from duplicate 'mode'.
+    def test_mode_kwarg_does_not_break_rank_nonzero(self):
+        """Passing mode= from a non-zero rank should not raise."""
+        # Used to test that mode= didn't get duplicated in init_kwargs;
+        # with the hard rank gate it's now testing that the gate fires
+        # cleanly even when extra kwargs are present.
         backend = WandbBackend(rank=1, mode="online")
-        assert backend._run is not None or True  # should not raise
+        assert backend._run is None
 
 
 # ── WandbBackend behavior (mocked wandb) ────────────────────────────────────

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -233,15 +233,34 @@ class TestWandbBackendBehavior:
 
     @pytest.fixture()
     def mock_wandb(self):
-        """Fully mocked wandb module."""
+        """Fully mocked wandb module.
+
+        Real wandb: wandb.init() returns a Run object AND sets
+        wandb.run to the same object. WandbBackend now reads
+        wandb.run (via setup_wandb's `return wandb.run`), so the
+        mock has to wire them to the SAME MagicMock — otherwise
+        `backend.run` and `mock_wandb.init.return_value` are two
+        different auto-generated mocks.
+        """
         wandb = MagicMock()
-        wandb.init.return_value = MagicMock()
+        run = MagicMock()
+        wandb.init.return_value = run
+        wandb.run = run
         return wandb
 
     @pytest.fixture()
     def backend(self, mock_wandb, monkeypatch):
-        """WandbBackend wired to the mocked wandb module."""
+        """WandbBackend wired to the mocked wandb module.
+
+        WandbBackend now delegates to ezpz.distributed.setup_wandb,
+        which gates on verify_wandb() (real API-key check). For a
+        mocked-wandb test we need to bypass that gate so the mocked
+        wandb.init is actually called.
+        """
         monkeypatch.setitem(sys.modules, "wandb", mock_wandb)
+        monkeypatch.setattr(
+            "ezpz.distributed.verify_wandb", lambda: True
+        )
         return WandbBackend(rank=0)
 
     def test_run_property(self, backend, mock_wandb):
@@ -292,6 +311,11 @@ class TestWandbBackendBehavior:
         """wandb.init() failure ⇒ _run is None ⇒ all methods are silent."""
         mock_wandb.init.side_effect = RuntimeError("boom")
         monkeypatch.setitem(sys.modules, "wandb", mock_wandb)
+        # Bypass verify_wandb so we actually get to the wandb.init
+        # call we want to make fail.
+        monkeypatch.setattr(
+            "ezpz.distributed.verify_wandb", lambda: True
+        )
         backend = WandbBackend(rank=0)
         assert backend._run is None
         # None of these should raise
@@ -313,12 +337,56 @@ class TestWandbBackendBehavior:
         assert "ezpz_version" in all_keys
 
     def test_init_config_applied(self, mock_wandb, monkeypatch):
-        """Explicit config dict is applied to the run."""
+        """Explicit config dict is applied to the run at the TOP level.
+
+        Asserts the user-config-at-top-level contract — we deliberately
+        bypass setup_wandb's `{"config": config}` nest so callers can
+        still read run.config.lr (not run.config.config.lr) for keys
+        they passed via WandbBackend(config=...).
+        """
         monkeypatch.setitem(sys.modules, "wandb", mock_wandb)
+        monkeypatch.setattr(
+            "ezpz.distributed.verify_wandb", lambda: True
+        )
         backend = WandbBackend(config={"lr": 0.01}, rank=0)
         update_calls = backend._run.config.update.call_args_list
         configs = [c.args[0] for c in update_calls if c.args]
         assert {"lr": 0.01} in configs
+
+    def test_env_fields_from_setup_wandb_applied(
+        self, mock_wandb, monkeypatch
+    ):
+        """The whole point of delegating: setup_wandb's env-tracking
+        fields (hostname, pytorch_backend, world_size, machine,
+        ezpz_version, working_directory, tstamp, year/month/day) all
+        land in run.config. Catches drift if a future refactor
+        accidentally bypasses setup_wandb again.
+        """
+        monkeypatch.setitem(sys.modules, "wandb", mock_wandb)
+        monkeypatch.setattr(
+            "ezpz.distributed.verify_wandb", lambda: True
+        )
+        backend = WandbBackend(rank=0)
+        update_calls = backend._run.config.update.call_args_list
+        all_keys: set[str] = set()
+        for call in update_calls:
+            if call.args:
+                all_keys.update(call.args[0].keys())
+        # These are the goodies setup_wandb adds that the old
+        # WandbBackend.__init__ never did. Keep this list aligned
+        # with the run.config.update({...}) block in
+        # ezpz.distributed.setup_wandb — if you add a key there,
+        # add it here too so the contract stays pinned.
+        for required in [
+            "hostname",
+            "pytorch_backend",
+            "world_size",
+            "machine",
+            "ezpz_version",
+            "working_directory",
+            "torch_version",
+        ]:
+            assert required in all_keys, f"missing {required!r}"
 
 
 # ── MLflowBackend (mocked) ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related changes:

**1. `WandbBackend` now delegates to `ezpz.distributed.setup_wandb`** (commit `d5559a7`) — eliminates duplicated wandb-init logic that had been drifting from the canonical helper.

**2. `setup_wandb` gains 7 new env-tracking fields** (commit `4a23771`) — so every wandb run (whether instantiated via `WandbBackend` or directly via `setup_wandb`) gets a much richer config for filtering / grouping in the W&B UI.

## (1) `WandbBackend` delegation

`WandbBackend.__init__` was duplicating wandb-init logic in parallel with the canonical `ezpz.distributed.setup_wandb` — same project-name resolution, same rank gating, same mode override, plus an abbreviated env-info update. Any field added to `setup_wandb` would silently NOT reach `WandbBackend`-instantiated runs.

Switched `WandbBackend` to **delegate to `setup_wandb`** so it inherits the full env-tracking goodies automatically and future fields land for free.

### Things deliberately preserved (NOT adopted from setup_wandb)

- **Top-level config layout.** `setup_wandb` wraps user config under `run.config["config"]`; `WandbBackend` has always exposed user keys at the top level (`run.config.lr`, not `run.config.config.lr`). The wrapper bypasses `setup_wandb`'s `config=` param and applies the dict via `run.config.update(config)` after init.
- **`rank` override.** `setup_wandb` always reads `get_rank()`; the wrapper handles forced overrides by setting `mode="disabled"` before forwarding when `rank != 0`.
- **`outdir` → `dir`** translation at the wrapper layer (kept explicit, not via `**kwargs`).

## (2) New `setup_wandb` env fields

Every `setup_wandb` run now gets these in `run.config`:

| Key | Source | Why |
|---|---|---|
| `jobid` | `ezpz.launch.get_active_jobid()` | Pivot from a wandb run → the cluster job that ran it. None when not in a scheduler. |
| `scheduler` | `ezpz.configs.get_scheduler()` | `"pbs"` / `"slurm"` / `""` — filter when runs come from multiple systems. |
| `num_nodes` | `get_num_nodes()` | Distinct from `world_size`: same world_size can be 8×8 or 4×16. |
| `ranks_per_node` | `get_gpus_per_node()` | Completes the topology picture. |
| `device_type` | `get_torch_device_type()` | `"cuda"` / `"xpu"` / `"mps"` / `"cpu"` — at-a-glance Aurora vs NVIDIA distinction. |
| `python_version` | `sys.version.split()[0]` | Catches 3.10-vs-3.12 regressions. |
| `ezpz_git_sha` | new `_get_ezpz_git_sha()` helper | Short SHA of the ezpz checkout, or `None` for pip installs. Disambiguates dev branches sharing the same `ezpz_version`. |

Also lands previously-WIP `year`/`month`/`day`/`tstamp` fields (useful for time-range filters when wandb's `created_at` isn't enough).

### `_get_ezpz_git_sha()` is best-effort by design

Returns `None` on any failure mode — `git` not installed, not a git checkout, subprocess timeout (2-second cap), etc. Logging suppressed. Three regression tests in `TestGetEzpzGitSha` pin the success path and both failure modes (`FileNotFoundError`, `TimeoutExpired`).

## Minor cleanups bundled in

- **`datetime` import** moved to its proper alphabetical home (was awkwardly between two import blocks).
- **`resolve_fsdp_strategy` return annotation** reverted from `bool | int | str | Literal["hybrid"] | None` back to `bool | int | None`. The `"hybrid"` branch is intercepted at line 747 and turned into `get_gpus_per_node()` (an `int`) before return, so `str` / `Literal["hybrid"]` were dead branches in the type.
- **`wrap_model`** signature: `device_id` moved to the end of the parameter list (was 3rd-positional). All in-repo callers use kwargs so this is safe; downstream positional callers would need to switch but that's been the recommended style for a while.

## Tests

`TestWandbBackendBehavior::test_env_fields_from_setup_wandb_applied` now pins all 18 fields (7 originals + 4 timestamp + 7 new), so a future refactor accidentally bypassing `setup_wandb` fails loudly.

New `TestGetEzpzGitSha` (3 tests) in `tests/test_distributed.py` covers:
- Real git lookup against the actual checkout
- `subprocess.run` raising `FileNotFoundError` → returns `None`
- `subprocess.run` raising `TimeoutExpired` → returns `None`

Results:
- **73/73** tracker tests pass
- **265/265** across tracker + distributed + history + recipes

## Label

`release:patch` — public API surface unchanged. The only observable difference is MORE keys in `run.config` (additive) and the existing constructor / signature stay byte-identical.

## Test plan

- [x] `pytest tests/test_tracker.py -q` → 73/73 PASS
- [x] `pytest tests/test_tracker.py tests/test_distributed.py tests/test_history.py tests/test_recipes.py -q` → 265/265 PASS
- [ ] Real-wandb smoke: instantiate `WandbBackend` (or call `setup_wandb` directly) against a real wandb account inside a PBS job, verify all 18 new keys populated correctly
