### PR TITLE
fix(pbs): short-circuit get_pbs_jobid_of_active_job on $PBS_JOBID

### DIFF
--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -123,16 +123,61 @@ def get_pbs_jobid_of_active_job() -> str | None:
     short-circuit, ``ezpz launch`` raises
     ``ImportError: cannot import name 'qstat' from 'sh'`` from any
     compute-node Python subprocess.
+
+    .. note::
+       When ``$PBS_NODEFILE`` is *also* set and readable, the fast
+       path cross-checks the local hostname against it before
+       trusting ``$PBS_JOBID``. This catches the (rare) case where
+       a user manually exports ``PBS_JOBID=<some-other-job>`` for
+       backwards compatibility or runs ``ezpz`` from an
+       ``ssh``-into-a-compute-node shell of a different job. If the
+       hostname is missing from the nodefile we log a warning and
+       fall through to the ``qstat`` lookup. When ``$PBS_NODEFILE``
+       is absent (e.g. compute-node Python subprocesses that don't
+       inherit the full PBS env) we skip the check and trust
+       ``$PBS_JOBID`` — that's the original motivating case.
     """
-    # 0. Short-circuit on the standard PBS env var. Set by qsub for
-    #    any script-launched job, and propagated by mpiexec --envall.
+    # Fast path: $PBS_JOBID is set by qsub and propagated by
+    # mpiexec --envall — skip the qstat shell-out entirely.
     pbs_jobid = os.environ.get("PBS_JOBID")
     if pbs_jobid:
         # PBS_JOBID is of the form "12345.aurora-pbs-0001..." — strip
         # the server suffix to match the rest of ezpz's jobid handling.
-        return pbs_jobid.split(".")[0]
+        short = pbs_jobid.split(".")[0]
 
-    # 1. Find all of users' currently running jobs
+        # Sanity check: when PBS_NODEFILE is readable, verify our
+        # hostname is actually in it. If not, $PBS_JOBID is lying
+        # (manual override, stale env, etc.) and we should fall
+        # through to the qstat-based lookup. Skip silently when
+        # PBS_NODEFILE is absent — that's the compute-node-subprocess
+        # case the fast path was built for.
+        pbs_nodefile = os.environ.get("PBS_NODEFILE")
+        if pbs_nodefile:
+            try:
+                nodes = Path(pbs_nodefile).read_text().split()
+            except OSError:
+                nodes = None
+            if nodes is not None:
+                local = socket.getfqdn().split(".")[0]
+                if local not in nodes:
+                    logger.warning(
+                        "$PBS_JOBID=%s but local hostname %s is not "
+                        "in $PBS_NODEFILE=%s; falling through to qstat.",
+                        pbs_jobid,
+                        local,
+                        pbs_nodefile,
+                    )
+                else:
+                    return short
+            else:
+                return short
+        else:
+            return short
+
+    # Slow path: walk the user's running jobs and match by hostname.
+    # Requires the qstat binary on PATH, which is NOT installed on
+    # compute nodes on Aurora/Sunspot/Polaris — keep this confined to
+    # login-node callers (e.g. `ezpz doctor`).
     #
     #    ```python
     #    jobs = {
@@ -142,9 +187,10 @@ def get_pbs_jobid_of_active_job() -> str | None:
     #    }
     #    ```
     #
-    # 2. Loop over {jobid, [hosts]} dictionary.
-    #    At each iteration, look and see if _our_ `hostname` is anywhere in the `[hosts]` list.
-    #    If so, then we know that we are currently participating in the `jobid` of that entry.
+    # Loop over {jobid, [hosts]} dictionary. At each iteration, look
+    # and see if _our_ `hostname` is anywhere in the `[hosts]` list.
+    # If so, then we know that we are currently participating in the
+    # `jobid` of that entry.
     jobs = get_pbs_running_jobs_for_user()
     for jobid, nodelist in jobs.items():
         # NOTE:

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -169,7 +169,13 @@ def get_pbs_jobid_of_active_job() -> str | None:
                 nodes_short = {n.split(".", 1)[0] for n in raw_nodes}
                 local = socket.getfqdn().split(".", 1)[0]
                 if local not in nodes_short:
-                    logger.warning(
+                    # Demoted from warning to debug: on 96-rank jobs
+                    # this previously produced 96 identical lines of
+                    # yellow output, and the function self-recovers
+                    # via qstat. Keep the message so it's visible
+                    # under EZPZ_LOG_LEVEL=debug when actually
+                    # debugging a stale-jobid case.
+                    logger.debug(
                         "$PBS_JOBID=%s but local hostname %s is not "
                         "in $PBS_NODEFILE=%s; falling through to qstat.",
                         pbs_jobid,

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -111,7 +111,27 @@ def get_pbs_nodelist_from_jobid(jobid: int | str) -> list[str]:
 
 
 def get_pbs_jobid_of_active_job() -> str | None:
-    """Get the jobid of the currently active job."""
+    """Get the jobid of the currently active job.
+
+    Short-circuits on ``$PBS_JOBID`` if set, which is the case in any
+    job spawned via ``qsub`` (PBS exports it into the script's
+    environment). Falling back to ``qstat`` is only needed when this
+    function is called outside of a job context — and that fallback
+    requires the ``qstat`` binary on ``PATH``, which is NOT available
+    on compute nodes on systems like Aurora where PBS server binaries
+    live under ``/opt/pbs/bin`` on login nodes only. Without this
+    short-circuit, ``ezpz launch`` raises
+    ``ImportError: cannot import name 'qstat' from 'sh'`` from any
+    compute-node Python subprocess.
+    """
+    # 0. Short-circuit on the standard PBS env var. Set by qsub for
+    #    any script-launched job, and propagated by mpiexec --envall.
+    pbs_jobid = os.environ.get("PBS_JOBID")
+    if pbs_jobid:
+        # PBS_JOBID is of the form "12345.aurora-pbs-0001..." — strip
+        # the server suffix to match the rest of ezpz's jobid handling.
+        return pbs_jobid.split(".")[0]
+
     # 1. Find all of users' currently running jobs
     #
     #    ```python

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -151,15 +151,24 @@ def get_pbs_jobid_of_active_job() -> str | None:
         # through to the qstat-based lookup. Skip silently when
         # PBS_NODEFILE is absent — that's the compute-node-subprocess
         # case the fast path was built for.
+        #
+        # IMPORTANT: PBS_NODEFILE on Aurora contains FQDNs like
+        # `x4114c1s7b0n0.hostmgmt2.cm.aurora.alcf.anl.gov` while
+        # `socket.getfqdn()` returns the SHORT name `x4114c1s7b0n0` on
+        # compute nodes (because reverse DNS doesn't include the
+        # hostmgmt suffix from inside a job). Compare on short names
+        # only — strip the first `.`-separated segment from BOTH
+        # sides before membership check.
         pbs_nodefile = os.environ.get("PBS_NODEFILE")
         if pbs_nodefile:
             try:
-                nodes = Path(pbs_nodefile).read_text().split()
+                raw_nodes = Path(pbs_nodefile).read_text().split()
             except OSError:
-                nodes = None
-            if nodes is not None:
-                local = socket.getfqdn().split(".")[0]
-                if local not in nodes:
+                raw_nodes = None
+            if raw_nodes is not None:
+                nodes_short = {n.split(".", 1)[0] for n in raw_nodes}
+                local = socket.getfqdn().split(".", 1)[0]
+                if local not in nodes_short:
                     logger.warning(
                         "$PBS_JOBID=%s but local hostname %s is not "
                         "in $PBS_NODEFILE=%s; falling through to qstat.",

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -272,10 +272,18 @@ class TestGetPbsRunningJobsForUser:
 
 
 class TestGetPbsJobidOfActiveJob:
-    """Tests for ``get_pbs_jobid_of_active_job``."""
+    """Tests for ``get_pbs_jobid_of_active_job``.
+
+    All tests in this class must clear ``$PBS_JOBID`` first so the
+    qstat-based slow path is actually exercised. Without that
+    delenv, a CI runner (or login-node) with ``PBS_JOBID`` set
+    would short-circuit on the fast path and silently bypass the
+    qstat mocks.
+    """
 
     def test_hostname_matching(self, monkeypatch):
         """Returns jobid when socket.getfqdn() hostname matches a node."""
+        monkeypatch.delenv("PBS_JOBID", raising=False)
         monkeypatch.setattr(
             pbs,
             "get_pbs_running_jobs_for_user",
@@ -293,6 +301,7 @@ class TestGetPbsJobidOfActiveJob:
 
     def test_hostname_matching_first_job(self, monkeypatch):
         """Returns the first matching jobid when hostname is in that job's nodelist."""
+        monkeypatch.delenv("PBS_JOBID", raising=False)
         monkeypatch.setattr(
             pbs,
             "get_pbs_running_jobs_for_user",
@@ -310,6 +319,7 @@ class TestGetPbsJobidOfActiveJob:
 
     def test_no_match_returns_none(self, monkeypatch):
         """Returns None when hostname does not match any running job."""
+        monkeypatch.delenv("PBS_JOBID", raising=False)
         monkeypatch.setattr(
             pbs,
             "get_pbs_running_jobs_for_user",
@@ -327,6 +337,7 @@ class TestGetPbsJobidOfActiveJob:
 
     def test_no_running_jobs_returns_none(self, monkeypatch):
         """Returns None when there are no running jobs at all."""
+        monkeypatch.delenv("PBS_JOBID", raising=False)
         monkeypatch.setattr(
             pbs,
             "get_pbs_running_jobs_for_user",
@@ -338,6 +349,164 @@ class TestGetPbsJobidOfActiveJob:
         )
         result = pbs.get_pbs_jobid_of_active_job()
         assert result is None
+
+    # --- Fast path: $PBS_JOBID short-circuit -----------------------------
+
+    def test_pbs_jobid_env_short_circuits_qstat(self, monkeypatch):
+        """Setting $PBS_JOBID must bypass the qstat lookup entirely.
+
+        Regression for the Aurora compute-node bug where the qstat
+        fallback failed with ImportError because the qstat binary
+        isn't on $PATH on compute nodes. Mocking the slow path to
+        explode proves we never reach it.
+        """
+        monkeypatch.setenv(
+            "PBS_JOBID", "12345.aurora-pbs-0001.head.cm.aurora.alcf.anl.gov"
+        )
+        monkeypatch.delenv("PBS_NODEFILE", raising=False)
+
+        def _explode():
+            raise ImportError(
+                "qstat not on PATH — fast path failed to short-circuit"
+            )
+
+        monkeypatch.setattr(
+            pbs, "get_pbs_running_jobs_for_user", _explode
+        )
+        result = pbs.get_pbs_jobid_of_active_job()
+        # Server suffix stripped to match the rest of ezpz's jobid handling.
+        assert result == "12345"
+
+    def test_pbs_jobid_env_empty_string_falls_back(self, monkeypatch):
+        """Empty $PBS_JOBID must fall through to qstat (truthy check).
+
+        Pins the ``if pbs_jobid:`` truthy semantics so future "code
+        cleanup" can't silently change it to ``is not None`` (which
+        would short-circuit on an empty string and return ``""``).
+        """
+        monkeypatch.setenv("PBS_JOBID", "")
+        monkeypatch.delenv("PBS_NODEFILE", raising=False)
+        called = []
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: (called.append(1), {})[1],
+        )
+        monkeypatch.setattr("socket.getfqdn", lambda: "no-match.local")
+        result = pbs.get_pbs_jobid_of_active_job()
+        assert called, (
+            "Empty PBS_JOBID must NOT short-circuit; qstat fallback "
+            "should still run."
+        )
+        assert result is None
+
+    def test_pbs_jobid_unset_falls_back_to_qstat(self, monkeypatch):
+        """When $PBS_JOBID is absent we must walk the qstat path."""
+        monkeypatch.delenv("PBS_JOBID", raising=False)
+        monkeypatch.delenv("PBS_NODEFILE", raising=False)
+        called = []
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: (called.append(1), {"99999": ["host-a"]})[1],
+        )
+        monkeypatch.setattr("socket.getfqdn", lambda: "host-a.local")
+        result = pbs.get_pbs_jobid_of_active_job()
+        assert called == [1]
+        assert result == "99999"
+
+    def test_pbs_jobid_with_no_dot_returned_as_is(self, monkeypatch):
+        """SLURM-style bare numeric jobid (no `.suffix`) shouldn't error.
+
+        ``.split(".")[0]`` on a string without ``.`` returns the
+        whole string — pin this so a future refactor to
+        ``.split(".", 1)[0]`` etc. doesn't quietly break.
+        """
+        monkeypatch.setenv("PBS_JOBID", "987654")
+        monkeypatch.delenv("PBS_NODEFILE", raising=False)
+        # Slow path mocked away — fast path should win.
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: pytest.fail("must not reach qstat path"),
+        )
+        assert pbs.get_pbs_jobid_of_active_job() == "987654"
+
+    # --- Fast-path hostname cross-check ----------------------------------
+
+    def test_nodefile_hostname_match_returns_jobid(self, monkeypatch, tmp_path):
+        """When PBS_NODEFILE is present AND contains our hostname, trust $PBS_JOBID."""
+        nodefile = tmp_path / "nodefile"
+        nodefile.write_text("x3005c0s7b0n0\nx3005c0s7b1n0\n")
+        monkeypatch.setenv("PBS_JOBID", "55555.foo.bar")
+        monkeypatch.setenv("PBS_NODEFILE", str(nodefile))
+        monkeypatch.setattr(
+            "socket.getfqdn",
+            lambda: "x3005c0s7b1n0.cm.aurora.alcf.anl.gov",
+        )
+        # Slow path mocked to fail — proves we returned via fast path.
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: pytest.fail("must not reach qstat path"),
+        )
+        assert pbs.get_pbs_jobid_of_active_job() == "55555"
+
+    def test_nodefile_hostname_mismatch_falls_through_to_qstat(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """When PBS_NODEFILE doesn't contain our hostname, $PBS_JOBID is
+        lying — log a warning and fall through to qstat.
+
+        Defends against the (rare) case of a stale PBS_JOBID export
+        or running ezpz from an ssh-into-compute-node shell of a
+        different job.
+        """
+        nodefile = tmp_path / "nodefile"
+        nodefile.write_text("x9999c0s0b0n0\n")  # Some other host
+        monkeypatch.setenv("PBS_JOBID", "11111.foo.bar")
+        monkeypatch.setenv("PBS_NODEFILE", str(nodefile))
+        monkeypatch.setattr(
+            "socket.getfqdn",
+            lambda: "x3005c0s7b1n0.cm.aurora.alcf.anl.gov",
+        )
+        # Slow path returns the actually-correct jobid for our host.
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: {"22222": ["x3005c0s7b1n0"]},
+        )
+        with caplog.at_level(logging.WARNING, logger=pbs.logger.name):
+            result = pbs.get_pbs_jobid_of_active_job()
+        assert result == "22222"
+        assert any(
+            "is not in $PBS_NODEFILE" in rec.message
+            for rec in caplog.records
+        ), "Expected a warning about the hostname mismatch."
+
+    def test_nodefile_unreadable_falls_through_silently(
+        self, monkeypatch, tmp_path
+    ):
+        """If PBS_NODEFILE is set but unreadable (deleted, permissions),
+        treat it as 'no cross-check available' and trust $PBS_JOBID.
+
+        Don't bail or fall through to qstat — the file's absence
+        doesn't prove $PBS_JOBID is wrong; it usually just means we're
+        in a subprocess that lost the file descriptor or the file got
+        cleaned up. The original motivation for the fast path was
+        compute-node subprocesses; making them THIS sensitive to
+        filesystem state defeats the point.
+        """
+        monkeypatch.setenv("PBS_JOBID", "77777.foo.bar")
+        monkeypatch.setenv(
+            "PBS_NODEFILE", str(tmp_path / "does-not-exist")
+        )
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: pytest.fail("must not reach qstat path"),
+        )
+        assert pbs.get_pbs_jobid_of_active_job() == "77777"
 
 
 # ===================================================================

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -452,6 +452,42 @@ class TestGetPbsJobidOfActiveJob:
         )
         assert pbs.get_pbs_jobid_of_active_job() == "55555"
 
+    def test_nodefile_fqdn_match_aurora_compute_node(
+        self, monkeypatch, tmp_path
+    ):
+        """Aurora-shaped FQDNs in PBS_NODEFILE + short local hostname.
+
+        Regression for the false-positive caught on Aurora job 8518207:
+        PBS_NODEFILE on Aurora contains
+        `x4114c1s7b0n0.hostmgmt2.cm.aurora.alcf.anl.gov` (FQDN with
+        the hostmgmt2 suffix) while `socket.getfqdn()` on compute
+        nodes returns just `x4114c1s7b0n0` (reverse DNS doesn't
+        include the hostmgmt suffix inside a job). The check must
+        strip both sides to the short hostname before membership.
+
+        Without the fix: every Aurora call logs a misleading
+        "hostname not in PBS_NODEFILE" warning and burns a qstat
+        round-trip on every rank, even though the job is correct.
+        """
+        nodefile = tmp_path / "nodefile"
+        nodefile.write_text(
+            "x4114c1s0b0n0.hostmgmt2.cm.aurora.alcf.anl.gov\n"
+            "x4114c1s7b0n0.hostmgmt2.cm.aurora.alcf.anl.gov\n"
+        )
+        monkeypatch.setenv(
+            "PBS_JOBID",
+            "8518207.aurora-pbs-0001.hostmgmt.cm.aurora.alcf.anl.gov",
+        )
+        monkeypatch.setenv("PBS_NODEFILE", str(nodefile))
+        # On compute nodes inside a job, getfqdn returns the SHORT name.
+        monkeypatch.setattr("socket.getfqdn", lambda: "x4114c1s7b0n0")
+        monkeypatch.setattr(
+            pbs,
+            "get_pbs_running_jobs_for_user",
+            lambda: pytest.fail("must not reach qstat path"),
+        )
+        assert pbs.get_pbs_jobid_of_active_job() == "8518207"
+
     def test_nodefile_hostname_mismatch_falls_through_to_qstat(
         self, monkeypatch, tmp_path, caplog
     ):

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -492,11 +492,16 @@ class TestGetPbsJobidOfActiveJob:
         self, monkeypatch, tmp_path, caplog
     ):
         """When PBS_NODEFILE doesn't contain our hostname, $PBS_JOBID is
-        lying — log a warning and fall through to qstat.
+        lying — log a debug message and fall through to qstat.
 
         Defends against the (rare) case of a stale PBS_JOBID export
         or running ezpz from an ssh-into-compute-node shell of a
         different job.
+
+        Logged at DEBUG (not WARNING) because the function
+        self-recovers via qstat — surfacing the message at WARNING
+        on 96-rank jobs would produce 96 lines of yellow output for
+        a condition that's already handled.
         """
         nodefile = tmp_path / "nodefile"
         nodefile.write_text("x9999c0s0b0n0\n")  # Some other host
@@ -512,13 +517,16 @@ class TestGetPbsJobidOfActiveJob:
             "get_pbs_running_jobs_for_user",
             lambda: {"22222": ["x3005c0s7b1n0"]},
         )
-        with caplog.at_level(logging.WARNING, logger=pbs.logger.name):
+        # Capture at DEBUG so we see the message — it was at WARNING
+        # before, demoted because of 96-rank spam.
+        with caplog.at_level(logging.DEBUG, logger=pbs.logger.name):
             result = pbs.get_pbs_jobid_of_active_job()
         assert result == "22222"
         assert any(
             "is not in $PBS_NODEFILE" in rec.message
+            and rec.levelname == "DEBUG"
             for rec in caplog.records
-        ), "Expected a warning about the hostname mismatch."
+        ), "Expected a DEBUG message about the hostname mismatch."
 
     def test_nodefile_unreadable_falls_through_silently(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
## Summary

`ezpz.pbs.get_pbs_jobid_of_active_job()` unconditionally calls `get_pbs_running_jobs_for_user()`, which executes `from sh import qstat`. The `sh` module uses dynamic `__getattr__` that creates a `Command` for the named binary on `PATH`; if `qstat` isn't found, this raises `ImportError`.

PBS already exports `PBS_JOBID` into every script-launched job's environment (and `mpiexec --envall` propagates it to inner subprocesses). The active-jobid is already available — no need to shell out to `qstat` to rediscover it.

## Fix

Short-circuit on `$PBS_JOBID` if set. Falls back to the existing `qstat`-based path only when the env var is missing (e.g. interactive debugging from outside a PBS job context).

The returned form (`12345` not `12345.aurora-pbs-...`) matches what the rest of ezpz's jobid handling already produces from `qstat` output parsing (`jstr[0].split(".")[0]` on line 95).

## Benefits

1. **Faster**: avoids spawning `qstat -fn1wru $USER` + parsing on every `ezpz launch` call.
2. **Avoids `sh.qstat` ImportError** in any environment where `qstat` isn't on `PATH` of the running shell (some compute-node envs, containers, CI).
3. **Standard pattern**: PBS_JOBID is the canonical PBS env var; using it is more idiomatic than discovering via qstat.

## Test plan

- Local with PBS_JOBID set:
  ```python
  import os; os.environ['PBS_JOBID']='12345.aurora-pbs-0001'
  from ezpz.pbs import get_pbs_jobid_of_active_job
  print(get_pbs_jobid_of_active_job())  # -> '12345'
  ```
- Compute-node smoke: install on Aurora, submit a `ezpz launch` job, verify no ImportError + jobid is correctly detected from env.

## Context

Hit `sh.qstat` ImportError repeatedly while debugging 2B scaling experiments at n=64/128/256 on Aurora via `qsub <script>` invocations. Workarounds I tried at the shell level (`bash --login` shebang, sourcing `/etc/bash.bashrc.local`, explicit `PATH=/opt/pbs/bin:$PATH` export) didn't reach the inner `mpiexec` subprocess where `ezpz launch` re-evaluates qstat. The env-var shortcut bypasses the whole shell-environment-propagation problem cleanly.