### PR TITLE
fix(distributed,data): XPU FSDP2 hang + xccl split_group workaround + HF cache race + wandb start_method deprecation

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
         wrap_model_for_ddp,
         wrap_model_for_fsdp,
         wrap_model_for_fsdp2,
+        init_device_mesh_safe,
     )
     # -- utils: helpers + memory + tarball plumbing --
     from .utils import (  # noqa: F401
@@ -177,6 +178,7 @@ _STATIC_REEXPORTS: tuple[str, ...] = (
     "synchronize", "timeitlogit", "verify_wandb",
     "wrap_model", "wrap_model_for_ddp",
     "wrap_model_for_fsdp", "wrap_model_for_fsdp2",
+    "init_device_mesh_safe",
     # utils
     "Color", "DistributedPdb", "ForkedPdb", "NoColor",
     "check_for_tarball",

--- a/src/ezpz/data/hf.py
+++ b/src/ezpz/data/hf.py
@@ -54,6 +54,11 @@ def _main_process_first() -> Iterator[None]:
     if not torch.distributed.is_available() or not torch.distributed.is_initialized():
         yield
         return
+    # NOTE: gates on GLOBAL rank 0, which is correct ONLY for a
+    # shared cache dir (the ALCF default — /home, /lus). If you
+    # set a node-local HF_DATASETS_CACHE (e.g. $TMPDIR), every
+    # node needs its own rank-0 to populate the cache; switch to
+    # `ezpz.get_local_rank() == 0` in that case.
     rank = torch.distributed.get_rank()
     if rank != 0:
         torch.distributed.barrier()

--- a/src/ezpz/data/hf.py
+++ b/src/ezpz/data/hf.py
@@ -5,7 +5,8 @@ HuggingFace Datasets loading and tokenization.
 """
 
 import os
-from typing import List, Optional, Iterable, Tuple, Dict
+from contextlib import contextmanager
+from typing import List, Optional, Iterable, Iterator, Tuple, Dict
 import ezpz
 
 import torch
@@ -29,6 +30,38 @@ logger = ezpz.get_logger(__name__)
 
 
 from torch.utils.data import get_worker_info
+
+
+@contextmanager
+def _main_process_first() -> Iterator[None]:
+    """Rank-0-first barrier for filesystem-cache writes (load/tokenize).
+
+    HF ``datasets`` writes to a deterministic, fingerprint-named cache
+    file. When N ranks call ``load_dataset`` / ``Dataset.map`` in
+    parallel against the same path on a shared filesystem they race:
+    one rank's ``chmod`` lands after another rank has already moved
+    the file (``FileNotFoundError``), or a reader opens a partially-
+    written Arrow stream (``ArrowInvalid: Tried reading schema
+    message, was null or length 0``).
+
+    Have rank 0 do the work first, then release the others to hit
+    the populated cache. Assumes a **shared** cache dir (the default
+    on ALCF home/lus). For node-local caches, gate on local rank.
+
+    No-op when ``torch.distributed`` isn't initialised — keeps
+    notebooks/tests and single-process callers free of side effects.
+    """
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        yield
+        return
+    rank = torch.distributed.get_rank()
+    if rank != 0:
+        torch.distributed.barrier()
+    try:
+        yield
+    finally:
+        if rank == 0:
+            torch.distributed.barrier()
 
 
 def get_data_parallel_map_dataset(
@@ -158,7 +191,8 @@ def get_hf_text_dataset(
         limit,
         seq_len,
     )
-    dataset = datasets.load_dataset(dataset_name, split=split)
+    with _main_process_first():
+        dataset = datasets.load_dataset(dataset_name, split=split)
     if (
         cnames := getattr(dataset, "column_names")
     ) and text_column not in list(cnames):
@@ -185,12 +219,13 @@ def get_hf_text_dataset(
             return_attention_mask=True,
         )
 
-    tokenized = dataset.map(
-        tokenize_function,
-        batched=True,
-        remove_columns=dataset.column_names,
-        desc="Tokenizing HF dataset",
-    )
+    with _main_process_first():
+        tokenized = dataset.map(
+            tokenize_function,
+            batched=True,
+            remove_columns=dataset.column_names,
+            desc="Tokenizing HF dataset",
+        )
     tokenized.set_format(
         type="torch", columns=["input_ids", "attention_mask"]
     )

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -460,6 +460,41 @@ def _configure_rank_warnings(rank: int) -> None:
         warnings.filterwarnings("ignore")
 
 
+def _set_local_device(device_type: str, device_index: int) -> None:
+    """Set the per-process current accelerator device, guarded.
+
+    Single source of truth for "make ``torch.{cuda,xpu}.current_device()``
+    return ``device_index``". Used in two places by ``setup_torch``:
+
+      1. Pre-``init_process_group``, so the PG binds to the right device
+         on XPU (without this, xccl/foreach_all_gather routes collectives
+         to the wrong device and FSDP2 silently hangs).
+      2. Post-``init_process_group``, only if the resolved device
+         differs from what we pre-bound.
+
+    Both call sites must use the same resolution rule (caller-provided
+    ``device_id`` if any, else ``local_rank``) so the current device and
+    the PG's ``device_id=`` always agree. Centralising the dispatch here
+    keeps that contract intact across future refactors.
+
+    Guards:
+
+    * ``torch.xpu`` doesn't exist on every torch build (CPU-only, CUDA-
+      only nightlies, ROCm). ``hasattr(torch, "xpu")`` short-circuits
+      before ``torch.xpu.is_available()`` would AttributeError.
+    * ``device_type`` not in ``{"cuda", "xpu"}`` is a no-op — there's
+      nothing to bind for ``cpu``/``mps``/``hip``.
+    """
+    import torch
+
+    if device_type == "cuda":
+        if torch.cuda.is_available():
+            torch.cuda.set_device(device_index)
+    elif device_type == "xpu":
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            torch.xpu.set_device(device_index)
+
+
 def setup_torch(
     port: str | int | None = None,
     seed: int | None = None,
@@ -527,9 +562,9 @@ def setup_torch(
     #
     # Set the per-process local device BEFORE init_process_group so
     # that whatever "current device" the process group binds to is
-    # actually local_rank. Without this, every rank's PG would bind
-    # to the default device (e.g. xpu:0 on Aurora) at construction
-    # time; then later `set_device(local_rank)` switches the current
+    # actually the same device. Without this, every rank's PG would
+    # bind to the default device (e.g. xpu:0 on Aurora) at
+    # construction time; later `set_device(...)` switches the current
     # device but the PG remains stuck on xpu:0. xccl/foreach_all_gather
     # then routes collectives to two different XPU queues and they
     # never meet up — FSDP2 deadlocks on the very first
@@ -537,11 +572,16 @@ def setup_torch(
     #
     # CUDA tends to mask this by being more forgiving about
     # current-device-at-init-time, but on XPU it's load-bearing.
+    #
+    # IMPORTANT: the device we set here must match whatever `_setup_ddp`
+    # will bind via `device_id=` in init_process_group. That's the
+    # caller-provided `device_id` if given, otherwise `local_rank`.
+    # Using `LOCAL_RANK` unconditionally would reintroduce the wrong-
+    # device hang on XPU whenever a caller passes an explicit
+    # `device_id` (e.g. `setup_torch(device_id=2)` on local_rank 5).
     pre_local_rank = get_local_rank()
-    if torch.cuda.is_available():
-        torch.cuda.set_device(pre_local_rank)
-    if torch.xpu.is_available():
-        torch.xpu.set_device(pre_local_rank)
+    pre_device_index = device_id if device_id is not None else pre_local_rank
+    _set_local_device(get_torch_device_type(), pre_device_index)
 
     dsetup = _setup_ddp(
         port=str(port) if port is not None else "1234",
@@ -554,14 +594,14 @@ def setup_torch(
     world_size = dsetup["world_size"]
     local_rank = dsetup["local_rank"]
 
-    # Re-set in case get_local_rank()'s pre-init guess differs from
-    # what _setup_ddp resolved (extremely unlikely — both read the
-    # same env vars — but cheap insurance, and matches the previous
-    # post-init set_device contract).
-    if torch.cuda.is_available() and local_rank != pre_local_rank:
-        torch.cuda.set_device(local_rank)
-    if torch.xpu.is_available() and local_rank != pre_local_rank:
-        torch.xpu.set_device(local_rank)
+    # Re-set in case `_setup_ddp` resolved a different device than we
+    # pre-bound (rare — happens if `get_local_rank()`'s pre-init guess
+    # differs from what `_setup_ddp` saw in env vars). Compare against
+    # the device we ACTUALLY set above, not raw `LOCAL_RANK` — those
+    # diverge whenever `device_id` was passed.
+    post_device_index = device_id if device_id is not None else local_rank
+    if post_device_index != pre_device_index:
+        _set_local_device(get_torch_device_type(), post_device_index)
 
     _set_env_vars(rank=rank, local_rank=local_rank, world_size=world_size)
 

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -76,6 +76,7 @@ __all__ = [
     "wrap_model_for_ddp",
     "wrap_model_for_fsdp",
     "wrap_model_for_fsdp2",
+    "init_device_mesh_safe",
     # -- diagnostics --
     "get_dist_info",
     "get_hostname",
@@ -820,9 +821,7 @@ def wrap_model(
     # Auto-create a 1D DeviceMesh when none is provided so FSDP2
     # (fully_shard) is the default sharding strategy.
     if device_mesh is None:
-        from torch.distributed.device_mesh import init_device_mesh
-
-        device_mesh = init_device_mesh(device_type, (ws,))
+        device_mesh = init_device_mesh_safe(device_type, (ws,))
     return _wrap_fsdp2(
         model,
         dtype=dtype,
@@ -1764,6 +1763,60 @@ def _setup_ddp(
         torch.distributed.init_process_group(**init_kwargs)
 
     return {"rank": rank, "world_size": world_size, "local_rank": local_rank}
+
+
+def init_device_mesh_safe(
+    device_type: str,
+    mesh_shape: tuple[int, ...],
+    *,
+    mesh_dim_names: tuple[str, ...] | None = None,
+) -> Any:
+    """Drop-in replacement for ``torch.distributed.init_device_mesh``.
+
+    Works around xccl's missing ``ProcessGroup.split_group`` support.
+
+    For FSDP2 to route ``foreach_all_gather`` correctly on XPU,
+    ``_setup_ddp`` binds the default PG to a device by passing
+    ``device_id=`` to ``init_process_group``. Torch then sees
+    ``default_group.bound_device_id is not None`` and, inside
+    ``DeviceMesh._init_one_process_group``, prefers
+    ``split_group(parent_pg, ...)`` over ``new_group(ranks, ...)``.
+    On the current xccl backend ``parent_backend.supports_splitting``
+    is ``False``, so ``split_group`` raises:
+
+        RuntimeError: No backend for the parent process group or its
+                      backend does not support splitting
+
+    We temporarily clear ``default_group.bound_device_id`` for the
+    duration of the ``init_device_mesh`` call so torch takes the
+    ``new_group`` fallback (which xccl supports), then restore it so
+    FSDP2's per-device PG resolution still works.
+
+    No-op on non-xpu devices and when no default PG exists yet.
+    """
+    import torch
+    from torch.distributed.device_mesh import init_device_mesh as _imd
+
+    default_pg = None
+    saved: Any = None
+    needs_workaround = False
+    if device_type == "xpu" and torch.distributed.is_initialized():
+        try:
+            default_pg = torch.distributed.distributed_c10d._get_default_group()
+            saved = getattr(default_pg, "bound_device_id", None)
+            if saved is not None:
+                default_pg.bound_device_id = None  # type: ignore[attr-defined]
+                needs_workaround = True
+        except (AttributeError, RuntimeError):
+            needs_workaround = False
+    try:
+        return _imd(device_type, mesh_shape, mesh_dim_names=mesh_dim_names)
+    finally:
+        if needs_workaround and default_pg is not None:
+            try:
+                default_pg.bound_device_id = saved  # type: ignore[attr-defined]
+            except AttributeError:
+                pass
 
 
 def _init_deepspeed(timeout: int = 3600) -> None:

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -523,6 +523,25 @@ def setup_torch(
         return 0
 
     # -- Multi-device init --
+    #
+    # Set the per-process local device BEFORE init_process_group so
+    # that whatever "current device" the process group binds to is
+    # actually local_rank. Without this, every rank's PG would bind
+    # to the default device (e.g. xpu:0 on Aurora) at construction
+    # time; then later `set_device(local_rank)` switches the current
+    # device but the PG remains stuck on xpu:0. xccl/foreach_all_gather
+    # then routes collectives to two different XPU queues and they
+    # never meet up — FSDP2 deadlocks on the very first
+    # all_gather_into_tensor.
+    #
+    # CUDA tends to mask this by being more forgiving about
+    # current-device-at-init-time, but on XPU it's load-bearing.
+    pre_local_rank = get_local_rank()
+    if torch.cuda.is_available():
+        torch.cuda.set_device(pre_local_rank)
+    if torch.xpu.is_available():
+        torch.xpu.set_device(pre_local_rank)
+
     dsetup = _setup_ddp(
         port=str(port) if port is not None else "1234",
         timeout=timedelta(seconds=timeout_s),
@@ -534,10 +553,13 @@ def setup_torch(
     world_size = dsetup["world_size"]
     local_rank = dsetup["local_rank"]
 
-    # Set local device
-    if torch.cuda.is_available():
+    # Re-set in case get_local_rank()'s pre-init guess differs from
+    # what _setup_ddp resolved (extremely unlikely — both read the
+    # same env vars — but cheap insurance, and matches the previous
+    # post-init set_device contract).
+    if torch.cuda.is_available() and local_rank != pre_local_rank:
         torch.cuda.set_device(local_rank)
-    if torch.xpu.is_available():
+    if torch.xpu.is_available() and local_rank != pre_local_rank:
         torch.xpu.set_device(local_rank)
 
     _set_env_vars(rank=rank, local_rank=local_rank, world_size=world_size)
@@ -1236,6 +1258,34 @@ def _get_ezpz_git_sha() -> str | None:
         return None
 
 
+def _build_wandb_settings(
+    *,
+    wandb: Any,
+    init_timeout: int | float | None,
+    start_method: str | None,
+) -> Any:
+    """Construct a ``wandb.Settings`` object without spurious deprecation noise.
+
+    Two cleanups vs the previous inline form:
+
+    1. ``start_method`` is only forwarded when the caller explicitly
+       requested one. Default-passing ``start_method="fork"`` triggers
+       wandb's "start_method is deprecated and will be removed in a
+       future version of wandb. This setting is currently
+       non-functional and safely ignored" warning on every run; the
+       intent (defend against the wrong default) is now wandb's
+       responsibility.
+    2. ``init_timeout`` defaults to 60 s only when the caller didn't
+       provide one — same as before, just hoisted out.
+    """
+    kwargs: dict[str, Any] = {
+        "init_timeout": init_timeout if init_timeout is not None else 60,
+    }
+    if start_method is not None:
+        kwargs["start_method"] = start_method
+    return wandb.Settings(**kwargs)
+
+
 def setup_wandb(
     project_name: str | None = None,
     entity: str | None = None,
@@ -1355,13 +1405,10 @@ def setup_wandb(
             settings=(
                 settings
                 if settings is not None
-                else wandb.Settings(
-                    init_timeout=init_timeout
-                    if init_timeout is not None
-                    else 60,
-                    start_method=start_method
-                    if start_method is not None
-                    else "fork",
+                else _build_wandb_settings(
+                    wandb=wandb,
+                    init_timeout=init_timeout,
+                    start_method=start_method,
                 )
             ),
             **kwargs,
@@ -1676,19 +1723,6 @@ def _setup_ddp(
             "world_size": world_size,
             "init_method": "env://",
         }
-        # Resolve device for init_process_group's `device_id=` arg.
-        # When the caller passes an explicit device_id (int or
-        # torch.device), use it verbatim. Otherwise, on CUDA build
-        # one from local_rank so torch can bind the process group
-        # to a specific GPU and avoid the
-        #   "barrier(): using the device under current context.
-        #    You can specify `device_id` in `init_process_group`
-        #    to mute this warning."
-        # warning that fires on every collective op.
-        #
-        # Intentionally skipped for xpu/xccl — that backend doesn't
-        # support split_group (which DeviceMesh._unflatten needs
-        # when process groups are device-bound).
         # Resolve the device the PG should bind to. Two principles:
         #
         #   1. An explicit `device_id` arg (int OR torch.device) wins,
@@ -1697,14 +1731,24 @@ def _setup_ddp(
         #      breaks XPU/MPS/HIP callers — same bug class as the
         #      barrier() warning this code originally fixed.
         #
-        #   2. Auto-detect ONLY binds for CUDA. xpu/xccl historically
-        #      didn't support split_group (which DeviceMesh._unflatten
-        #      needs when PGs are device-bound). NOTE: this leaves XPU
-        #      FSDP2 vulnerable to the wrong-device-binding hang that
-        #      `torch.xpu.set_device(local_rank)` happens AFTER this
-        #      call in setup_torch. Fix tracked separately — do NOT
-        #      reinstate the "skip on xpu" comment without verifying
-        #      the FSDP2 path is actually broken with newer xccl.
+        #   2. Auto-detect binds for CUDA AND XPU. Caller must have
+        #      already called `set_device(local_rank)` BEFORE
+        #      _setup_ddp (setup_torch does this) so that "current
+        #      device" agrees with the device_id we're about to pass.
+        #
+        # XPU note: an earlier comment here said we MUST NOT pass
+        # device_id on xpu because xccl didn't support split_group
+        # (which DeviceMesh._unflatten needs when PGs are
+        # device-bound). That was incorrect for FSDP2: without
+        # device-bound PGs, foreach_all_gather routes some ranks'
+        # collectives to xpu:0 (the current device at PG-construction
+        # time, when set_device(local_rank) hadn't yet run) and
+        # others to xpu:LOCAL_RANK (post-set_device). They never meet
+        # up → silent deadlock on the first all_gather_into_tensor.
+        # Caught on Aurora torchtitan job 8518207 — see PR for the
+        # py-spy stack trace. If DeviceMesh._unflatten regresses on a
+        # newer xccl, we'll see a loud failure (not a silent hang) and
+        # can revisit.
         device_type = get_torch_device_type()
         resolved_device: Any = None
         if device_id is not None:
@@ -1713,8 +1757,8 @@ def _setup_ddp(
             else:
                 # Caller passed a torch.device — honor verbatim.
                 resolved_device = device_id
-        elif device_type == "cuda":
-            resolved_device = torch.device(f"cuda:{local_rank}")
+        elif device_type in ("cuda", "xpu"):
+            resolved_device = torch.device(f"{device_type}:{local_rank}")
         if resolved_device is not None:
             init_kwargs["device_id"] = resolved_device
         torch.distributed.init_process_group(**init_kwargs)

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -141,7 +141,7 @@ from ezpz.models import summarize_model
 from ezpz.examples import get_example_outdir
 
 from ezpz.models.llama import Transformer, ModelArgs
-from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import (
     FullyShardedDataParallel as FSDP,
     MixedPrecision,
@@ -690,7 +690,7 @@ def train(
     world_size = ezpz.distributed.get_world_size()
     assert world_size % args.tp == 0, "WORLD_SIZE must be divisible by TP"
     dpsize = world_size // args.tp
-    device_mesh = init_device_mesh(
+    device_mesh = ezpz.init_device_mesh_safe(
         str(ezpz.get_torch_device()),
         (dpsize, args.tp),
         mesh_dim_names=("dp", "tp"),

--- a/tests/test_data_hf.py
+++ b/tests/test_data_hf.py
@@ -1,0 +1,297 @@
+"""Tests for ``ezpz.data.hf`` rank-0-first cache plumbing.
+
+Regression coverage for the HF ``datasets`` filesystem-cache race
+fixed by ``_main_process_first``. Pre-fix every rank called
+``load_dataset`` / ``Dataset.map`` in parallel against the same
+fingerprint-named Arrow cache file on a shared filesystem; ranks
+raced for ``os.chmod`` and partial Arrow stream reads
+(``FileNotFoundError`` / ``pyarrow.lib.ArrowInvalid``). Observed
+on a 48-rank fsdp_tp run.
+
+These tests inspect the order of ``torch.distributed.barrier``
+calls vs the wrapped work, without actually initialising a real
+process group.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import ezpz.data.hf as hf
+
+
+class TestMainProcessFirst:
+    """``_main_process_first`` must:
+
+    1. No-op when ``torch.distributed`` isn't initialised (single-
+       process callers, notebooks, unit tests).
+    2. Issue rank-0 → work → barrier on rank 0 (releases everyone).
+    3. Issue barrier (wait) → work → no second barrier on non-rank-0.
+    4. Still release the barrier even if the wrapped work raises
+       (otherwise rank 0's crash leaves all other ranks hung).
+    """
+
+    def test_noop_when_distributed_unavailable(self, monkeypatch):
+        """No barriers when ``torch.distributed.is_available()`` is False."""
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: False
+        )
+        # If is_available is False, is_initialized must not even be
+        # reached — patch it to blow up so we'd notice if it were.
+        monkeypatch.setattr(
+            torch.distributed,
+            "is_initialized",
+            MagicMock(side_effect=AssertionError("should not be called")),
+        )
+        mock_barrier = MagicMock()
+        monkeypatch.setattr(torch.distributed, "barrier", mock_barrier)
+
+        with hf._main_process_first():
+            pass
+
+        mock_barrier.assert_not_called()
+
+    def test_noop_when_distributed_not_initialised(self, monkeypatch):
+        """No barriers when distributed is available but not initialised."""
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+        mock_barrier = MagicMock()
+        monkeypatch.setattr(torch.distributed, "barrier", mock_barrier)
+
+        with hf._main_process_first():
+            pass
+
+        mock_barrier.assert_not_called()
+
+    def test_rank_zero_runs_work_first_then_releases(self, monkeypatch):
+        """On rank 0: work runs first, ONE barrier fires after (release)."""
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+
+        events: list[str] = []
+        monkeypatch.setattr(
+            torch.distributed,
+            "barrier",
+            lambda *a, **kw: events.append("barrier"),
+        )
+
+        with hf._main_process_first():
+            events.append("work")
+
+        assert events == ["work", "barrier"], (
+            f"Rank 0 must run work BEFORE the release barrier; got {events}. "
+            "Pre-fix, all ranks ran work concurrently and raced for the "
+            "Arrow cache file."
+        )
+
+    def test_non_rank_zero_waits_then_runs(self, monkeypatch):
+        """On non-rank-0: ONE barrier fires before work (wait for rank 0)."""
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 3)
+
+        events: list[str] = []
+        monkeypatch.setattr(
+            torch.distributed,
+            "barrier",
+            lambda *a, **kw: events.append("barrier"),
+        )
+
+        with hf._main_process_first():
+            events.append("work")
+
+        assert events == ["barrier", "work"], (
+            f"Non-rank-0 must wait at a barrier BEFORE running work; "
+            f"got {events}. Without the wait, all ranks would race "
+            "for the Arrow cache file rank 0 is still writing."
+        )
+
+    def test_rank_zero_releases_on_exception(self, monkeypatch):
+        """If rank 0's work raises, the release barrier MUST still fire.
+
+        Otherwise every other rank is stuck at their first barrier
+        forever (or until torch's collective timeout).
+        """
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+
+        mock_barrier = MagicMock()
+        monkeypatch.setattr(torch.distributed, "barrier", mock_barrier)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with hf._main_process_first():
+                raise RuntimeError("boom")
+
+        mock_barrier.assert_called_once()
+
+    def test_non_rank_zero_does_not_call_extra_barrier_on_exception(
+        self, monkeypatch
+    ):
+        """Non-rank-0: exactly one barrier (the upfront wait), even on raise.
+
+        The release barrier is rank-0's job; a non-rank-0 failure
+        should not double-barrier the group.
+        """
+        monkeypatch.setattr(
+            torch.distributed, "is_available", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+
+        mock_barrier = MagicMock()
+        monkeypatch.setattr(torch.distributed, "barrier", mock_barrier)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with hf._main_process_first():
+                raise RuntimeError("boom")
+
+        mock_barrier.assert_called_once()
+
+
+class TestGetHfTextDatasetRankGating:
+    """``get_hf_text_dataset`` must wrap both cache-writing calls
+    (``datasets.load_dataset`` and ``Dataset.map``) in
+    ``_main_process_first``.
+
+    Pre-fix both calls fired from every rank concurrently — the
+    exact failure mode in the original traceback.
+    """
+
+    def _make_fake_dataset(self):
+        """Build a MagicMock that quacks like a ``datasets.Dataset``."""
+        ds = MagicMock()
+        ds.column_names = ["text"]
+        ds.__len__ = MagicMock(return_value=4)
+        # `dataset.map(...)` returns a tokenized dataset; that
+        # tokenized dataset gets `.set_format` and attribute
+        # assignment, so it needs to be a MagicMock too.
+        tokenized = MagicMock()
+        ds.map = MagicMock(return_value=tokenized)
+        return ds, tokenized
+
+    def test_load_dataset_wrapped_in_main_process_first(self, monkeypatch):
+        """``load_dataset`` must be inside the context manager."""
+        ds, _tokenized = self._make_fake_dataset()
+        events: list[str] = []
+
+        def _fake_load(*_a, **_kw):
+            events.append("load_dataset")
+            return ds
+
+        # Patch the context manager to record entry/exit; if
+        # load_dataset fires outside it, ordering will reveal that.
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _recording_cm():
+            events.append("enter_main_first")
+            try:
+                yield
+            finally:
+                events.append("exit_main_first")
+
+        monkeypatch.setattr(hf, "_main_process_first", _recording_cm)
+        monkeypatch.setattr(hf.datasets, "load_dataset", _fake_load)
+        monkeypatch.setattr(
+            hf.AutoTokenizer,
+            "from_pretrained",
+            lambda *_a, **_kw: MagicMock(pad_token="x", pad_token_id=0, vocab_size=32),
+        )
+
+        hf.get_hf_text_dataset(
+            dataset_name="dummy",
+            split="train",
+            text_column="text",
+            tokenizer_name="dummy",
+            seq_len=16,
+            limit=0,
+            seed=1,
+        )
+
+        # load_dataset must appear between an enter/exit pair.
+        assert "load_dataset" in events
+        ld_idx = events.index("load_dataset")
+        # Find the surrounding enter/exit pair.
+        enters = [i for i, e in enumerate(events) if e == "enter_main_first" and i < ld_idx]
+        exits = [i for i, e in enumerate(events) if e == "exit_main_first" and i > ld_idx]
+        assert enters and exits, (
+            f"load_dataset is not wrapped in _main_process_first; "
+            f"events: {events}. The cache-populating call MUST be "
+            "rank-0-gated or every rank races for the same file."
+        )
+
+    def test_map_wrapped_in_main_process_first(self, monkeypatch):
+        """``dataset.map(...)`` must be inside the context manager."""
+        ds, _tokenized = self._make_fake_dataset()
+        events: list[str] = []
+
+        def _fake_load(*_a, **_kw):
+            return ds
+
+        def _record_map(*_a, **_kw):
+            events.append("map")
+            t = MagicMock()
+            return t
+
+        ds.map = _record_map
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _recording_cm():
+            events.append("enter_main_first")
+            try:
+                yield
+            finally:
+                events.append("exit_main_first")
+
+        monkeypatch.setattr(hf, "_main_process_first", _recording_cm)
+        monkeypatch.setattr(hf.datasets, "load_dataset", _fake_load)
+        monkeypatch.setattr(
+            hf.AutoTokenizer,
+            "from_pretrained",
+            lambda *_a, **_kw: MagicMock(pad_token="x", pad_token_id=0, vocab_size=32),
+        )
+
+        hf.get_hf_text_dataset(
+            dataset_name="dummy",
+            split="train",
+            text_column="text",
+            tokenizer_name="dummy",
+            seq_len=16,
+            limit=0,
+            seed=1,
+        )
+
+        assert "map" in events
+        m_idx = events.index("map")
+        enters = [i for i, e in enumerate(events) if e == "enter_main_first" and i < m_idx]
+        exits = [i for i, e in enumerate(events) if e == "exit_main_first" and i > m_idx]
+        assert enters and exits, (
+            f"dataset.map is not wrapped in _main_process_first; "
+            f"events: {events}. Tokenization writes to a shared "
+            "Arrow cache file and MUST be rank-0-gated."
+        )

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1829,3 +1829,226 @@ class TestSetupDdpDeviceId:
         dist._setup_ddp(backend="gloo", device_id=xpu_device)  # type: ignore[arg-type]
         kwargs = mock_init.call_args.kwargs
         assert kwargs.get("device_id") == xpu_device
+
+
+# ===================================================================
+# init_device_mesh_safe
+# ===================================================================
+
+
+class TestInitDeviceMeshSafe:
+    """``init_device_mesh_safe`` round-trips ``bound_device_id`` on the
+    default PG so torch's ``DeviceMesh._init_one_process_group`` takes
+    the ``new_group`` fallback path (which xccl supports) instead of
+    ``split_group`` (which it doesn't).
+
+    Pre-fix, 2D meshes (``ezpz.examples.fsdp_tp``) raised
+        RuntimeError: No backend for the parent process group or its
+                      backend does not support splitting
+    on XPU + xccl.
+
+    These tests mock the default PG and the torch ``init_device_mesh``
+    entry-point to verify (a) the workaround fires only on xpu when
+    the PG actually has a ``bound_device_id``, (b) the original value
+    is restored, and (c) silent disablement (e.g. a future torch making
+    the attr read-only) doesn't break the call.
+    """
+
+    def _fake_pg(self, bound_device_id):
+        """Build a stand-in for ``torch.distributed.ProcessGroup`` that
+        carries a mutable ``bound_device_id`` like the real C++ object
+        does today."""
+        pg = MagicMock()
+        pg.bound_device_id = bound_device_id
+        return pg
+
+    def test_xpu_clears_and_restores_bound_device_id(self, monkeypatch):
+        """On xpu with a bound default PG: clear → call → restore."""
+        sentinel = torch.device("xpu:3")
+        pg = self._fake_pg(sentinel)
+
+        observed: dict[str, Any] = {}
+
+        def _fake_init_device_mesh(device_type, mesh_shape, *, mesh_dim_names=None):
+            # During the inner call, bound_device_id must be None.
+            observed["mid_call_bound_device_id"] = pg.bound_device_id
+            return MagicMock(name="DeviceMesh")
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+        # Patch torch's init_device_mesh at the source the shim
+        # imports it from.
+        import torch.distributed.device_mesh as _dm
+
+        monkeypatch.setattr(_dm, "init_device_mesh", _fake_init_device_mesh)
+
+        result = dist.init_device_mesh_safe(
+            "xpu", (2, 4), mesh_dim_names=("dp", "tp")
+        )
+
+        assert result is not None
+        assert observed["mid_call_bound_device_id"] is None, (
+            "Workaround failed: bound_device_id was not cleared "
+            "during init_device_mesh. Torch's DeviceMesh._init_one_"
+            "process_group will take the split_group branch and "
+            "raise on xccl."
+        )
+        assert pg.bound_device_id == sentinel, (
+            "bound_device_id was not restored after the call. "
+            "Subsequent FSDP2 collectives need a device-bound PG."
+        )
+
+    def test_xpu_with_unbound_pg_is_pass_through(self, monkeypatch):
+        """When ``bound_device_id`` is already None, no swap happens."""
+        pg = self._fake_pg(None)
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+
+        import torch.distributed.device_mesh as _dm
+
+        called = MagicMock(return_value=MagicMock(name="DeviceMesh"))
+        monkeypatch.setattr(_dm, "init_device_mesh", called)
+
+        dist.init_device_mesh_safe("xpu", (4,))
+
+        called.assert_called_once()
+        # No mutation — still None.
+        assert pg.bound_device_id is None
+
+    def test_non_xpu_skips_workaround_entirely(self, monkeypatch):
+        """CUDA path must NOT touch ``bound_device_id``.
+
+        Torch's NCCL backend supports split_group natively; this
+        helper should be a pure pass-through there.
+        """
+        sentinel = torch.device("cuda:0")
+        pg = self._fake_pg(sentinel)
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        # If the CUDA path ever tries to fetch the default PG, blow up
+        # — we want a true no-op.
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            MagicMock(side_effect=AssertionError("CUDA must not touch the default PG")),
+        )
+
+        import torch.distributed.device_mesh as _dm
+
+        called = MagicMock(return_value=MagicMock(name="DeviceMesh"))
+        monkeypatch.setattr(_dm, "init_device_mesh", called)
+
+        dist.init_device_mesh_safe("cuda", (8,))
+
+        called.assert_called_once_with("cuda", (8,), mesh_dim_names=None)
+        # bound_device_id still untouched.
+        assert pg.bound_device_id == sentinel
+
+    def test_no_default_pg_is_pass_through(self, monkeypatch):
+        """If ``torch.distributed`` isn't initialised, fall through."""
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+
+        import torch.distributed.device_mesh as _dm
+
+        called = MagicMock(return_value=MagicMock(name="DeviceMesh"))
+        monkeypatch.setattr(_dm, "init_device_mesh", called)
+
+        dist.init_device_mesh_safe("xpu", (2, 2))
+        called.assert_called_once()
+
+    def test_restores_bound_device_id_when_inner_raises(self, monkeypatch):
+        """If ``init_device_mesh`` raises, the original value MUST be
+        restored — otherwise downstream FSDP2 silently routes to the
+        wrong device.
+        """
+        sentinel = torch.device("xpu:5")
+        pg = self._fake_pg(sentinel)
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+
+        import torch.distributed.device_mesh as _dm
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("simulated split_group failure")
+
+        monkeypatch.setattr(_dm, "init_device_mesh", _boom)
+
+        with pytest.raises(RuntimeError, match="simulated"):
+            dist.init_device_mesh_safe("xpu", (4,))
+
+        assert pg.bound_device_id == sentinel, (
+            "Workaround leaked: bound_device_id stayed cleared after "
+            "an inner failure. FSDP2 will silently route collectives "
+            "to the wrong XPU device on the next all_gather."
+        )
+
+    def test_silent_disablement_when_attr_setattr_fails(self, monkeypatch):
+        """If a future torch makes ``bound_device_id`` read-only, the
+        shim should fail-open: the inner call still runs (and will
+        raise the original ``RuntimeError`` from torch if applicable),
+        rather than the shim itself crashing in an obscure place.
+
+        This pins the try/except behavior in init_device_mesh_safe.
+        """
+
+        class _LockedAttr:
+            """PG-like object where ``bound_device_id`` is read-only."""
+
+            def __init__(self):
+                # Use object.__setattr__ to bypass our own override
+                # for the initial value.
+                object.__setattr__(
+                    self, "_bdi", torch.device("xpu:0")
+                )
+
+            @property
+            def bound_device_id(self):
+                return self._bdi
+
+            @bound_device_id.setter
+            def bound_device_id(self, _value):
+                raise AttributeError("read-only in future torch")
+
+        pg = _LockedAttr()
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+
+        import torch.distributed.device_mesh as _dm
+
+        called = MagicMock(return_value=MagicMock(name="DeviceMesh"))
+        monkeypatch.setattr(_dm, "init_device_mesh", called)
+
+        # Must not raise from the shim itself; inner call still fires.
+        dist.init_device_mesh_safe("xpu", (4,))
+        called.assert_called_once()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -843,6 +843,58 @@ class TestSetupTorch:
             # seed * (rank + 1) * (local_rank + 1) = 42 * 1 * 1 = 42
             mock_seed.assert_called_once_with(42)
 
+    def test_xpu_set_device_called_before_setup_ddp(
+        self, fake_comm, monkeypatch
+    ):
+        """Regression: xpu.set_device(local_rank) MUST run before _setup_ddp.
+
+        Pre-fix the order was reversed — _setup_ddp ran first, then
+        set_device. On XPU that meant init_process_group constructed
+        the PG with current_device == xpu:0 on every rank (because
+        set_device hadn't happened yet); subsequent collectives
+        routed to different XPU queues per rank and FSDP2 deadlocked.
+
+        Use a shared `calls` list to record the order of relevant
+        events, then assert set_device fires BEFORE _setup_ddp.
+        """
+        monkeypatch.delenv("WORLD_SIZE", raising=False)
+        monkeypatch.setenv("LOCAL_RANK", "3")  # pre_local_rank == 3
+        calls: list[str] = []
+        dsetup = {"rank": 0, "world_size": 4, "local_rank": 3}
+
+        def _record_setup_ddp(*args, **kwargs):
+            calls.append("_setup_ddp")
+            return dsetup
+
+        def _record_xpu_set_device(rank):
+            calls.append(f"xpu.set_device({rank})")
+
+        with (
+            patch.object(dist, "get_torch_device_type", return_value="xpu"),
+            patch.object(dist, "get_torch_backend", return_value="ccl"),
+            patch.object(dist, "_setup_ddp", side_effect=_record_setup_ddp),
+            patch.object(torch.cuda, "is_available", return_value=False),
+            patch.object(torch.xpu, "is_available", return_value=True),
+            patch.object(
+                torch.xpu, "set_device", side_effect=_record_xpu_set_device
+            ),
+            patch.object(dist, "barrier"),
+            patch.object(dist, "get_dist_info", return_value={}),
+            patch.object(dist, "print_dist_setup", return_value=""),
+            patch.object(dist, "seed_everything"),
+        ):
+            dist.setup_torch()
+
+        # Exactly one set_device call (the pre-init one); local_rank
+        # didn't change after _setup_ddp so the post-init re-set
+        # short-circuits.
+        assert calls == ["xpu.set_device(3)", "_setup_ddp"], (
+            f"Wrong call order: {calls}. xpu.set_device MUST run "
+            "BEFORE _setup_ddp so the process group binds to the "
+            "right XPU device. Without this, FSDP2 deadlocks on the "
+            "first all_gather_into_tensor (caught on Aurora job 8518207)."
+        )
+
 
 # ===================================================================
 # cleanup
@@ -1473,6 +1525,48 @@ class TestGetEzpzGitSha:
 # ===================================================================
 
 
+class TestBuildWandbSettings:
+    """_build_wandb_settings must not forward ``start_method`` by default.
+
+    Regression for the wandb deprecation noise: every default run
+    used to emit
+        wandb: WARNING `start_method` is deprecated and will be
+        removed in a future version of wandb. This setting is
+        currently non-functional and safely ignored.
+    because we always passed ``start_method="fork"`` to
+    ``wandb.Settings``. The fix: only forward ``start_method`` when
+    the caller explicitly asked for one.
+    """
+
+    def test_omits_start_method_when_unset(self):
+        from unittest.mock import MagicMock
+
+        wandb = MagicMock()
+        _ = dist._build_wandb_settings(
+            wandb=wandb, init_timeout=None, start_method=None
+        )
+        wandb.Settings.assert_called_once()
+        kwargs = wandb.Settings.call_args.kwargs
+        assert "start_method" not in kwargs, (
+            "_build_wandb_settings forwarded start_method=None to "
+            "wandb.Settings; wandb emits a deprecation warning even "
+            "for `None`, so every run gets the noise back."
+        )
+        # init_timeout still defaults to 60
+        assert kwargs.get("init_timeout") == 60
+
+    def test_forwards_start_method_when_set(self):
+        from unittest.mock import MagicMock
+
+        wandb = MagicMock()
+        _ = dist._build_wandb_settings(
+            wandb=wandb, init_timeout=120, start_method="spawn"
+        )
+        kwargs = wandb.Settings.call_args.kwargs
+        assert kwargs["start_method"] == "spawn"
+        assert kwargs["init_timeout"] == 120
+
+
 class TestSetupWandbRankGate:
     """setup_wandb must short-circuit on non-zero ranks.
 
@@ -1605,9 +1699,20 @@ class TestSetupDdpDeviceId:
         )
         assert kwargs["device_id"] == torch.device("cuda:3")
 
-    def test_xpu_skips_device_id(self, monkeypatch):
-        # XCCL doesn't support split_group → DeviceMesh._unflatten breaks
-        # when PGs are device-bound. Intentional: device_id stays absent.
+    def test_xpu_auto_detect_binds_device_id_from_local_rank(
+        self, monkeypatch
+    ):
+        """XPU + no explicit device_id → device_id=xpu:LOCAL_RANK.
+
+        Regression for the Aurora torchtitan FSDP2 hang (job 8518207).
+        Pre-fix _setup_ddp skipped device_id for xpu (citing a
+        DeviceMesh._unflatten / split_group concern), but without a
+        device-bound PG xccl/foreach_all_gather routed some ranks'
+        collectives to xpu:0 and others to xpu:LOCAL_RANK — they
+        never met up and FSDP2 silently deadlocked on the first
+        all_gather_into_tensor. Caller (setup_torch) is responsible
+        for calling xpu.set_device(local_rank) BEFORE _setup_ddp.
+        """
         monkeypatch.setattr(dist, "get_torch_device_type", lambda: "xpu")
         kwargs = self._capture_init_kwargs(
             monkeypatch,
@@ -1615,7 +1720,13 @@ class TestSetupDdpDeviceId:
             LOCAL_RANK=2,
             WORLD_SIZE=4,
         )
-        assert "device_id" not in kwargs
+        import torch
+
+        assert "device_id" in kwargs, (
+            "Regression: XPU dropped device_id; FSDP2 will deadlock "
+            "on the first all_gather_into_tensor."
+        )
+        assert kwargs["device_id"] == torch.device("xpu:2")
 
     def test_explicit_int_device_id_resolves_to_active_device_type(
         self, monkeypatch
@@ -1687,22 +1798,15 @@ class TestSetupDdpDeviceId:
             "the wrong device family. Was likely hardcoded `cuda:N`."
         )
 
-    def test_explicit_xpu_device_id_currently_passes_through(
-        self, monkeypatch
-    ):
-        # Documents CURRENT behavior, not desired behavior: when the
-        # caller explicitly passes a torch.device("xpu:0") as
-        # device_id, the resolver forwards it to init_process_group
-        # even though the auto-detect path (device_id=None) correctly
-        # skips device_id on xpu. This is the P1 from the PR #147
-        # review — the comment block in _setup_ddp claims we skip
-        # device_id on xpu/xccl, but the skip only fires when the
-        # caller didn't pass anything.
-        #
-        # If/when this is fixed (resolved_device should be set to None
-        # when device_type == "xpu", regardless of how device_id was
-        # passed), this test should flip to:
-        #   assert "device_id" not in kwargs
+    def test_explicit_xpu_device_id_passes_through(self, monkeypatch):
+        """Explicit torch.device("xpu:N") is honored verbatim.
+
+        Used to document a quirk where the explicit-caller path
+        bypassed the "skip on xpu" guard; that quirk is now the
+        correct behavior. The auto-detect XPU path ALSO binds
+        device_id now (see test_xpu_auto_detect_binds_device_id_from_local_rank
+        above), so both paths agree.
+        """
         monkeypatch.setattr(dist, "get_torch_device_type", lambda: "xpu")
         import torch
         from unittest.mock import MagicMock
@@ -1724,9 +1828,4 @@ class TestSetupDdpDeviceId:
         xpu_device = torch.device("xpu", 0)
         dist._setup_ddp(backend="gloo", device_id=xpu_device)  # type: ignore[arg-type]
         kwargs = mock_init.call_args.kwargs
-        # CURRENT (potentially buggy) behavior: xpu device passes through.
-        assert kwargs.get("device_id") == xpu_device, (
-            "If this assertion fails, the P1 from PR #147 was likely "
-            "fixed — flip to `assert 'device_id' not in kwargs` and "
-            "delete this comment."
-        )
+        assert kwargs.get("device_id") == xpu_device

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -895,6 +895,182 @@ class TestSetupTorch:
             "first all_gather_into_tensor (caught on Aurora job 8518207)."
         )
 
+    def test_setup_torch_with_explicit_device_id_binds_that_device(
+        self, fake_comm, monkeypatch
+    ):
+        """``setup_torch(device_id=N)`` must set xpu:N, not xpu:LOCAL_RANK.
+
+        Regression for PR #149 Copilot comment: if the caller passes
+        an explicit ``device_id``, ``_setup_ddp`` will bind the PG to
+        that device. The pre-init ``set_device`` MUST therefore also
+        use ``device_id`` (not raw ``LOCAL_RANK``); otherwise the
+        current device and the PG's bound device disagree and we
+        reintroduce the exact XPU FSDP2 hang this PR is fixing.
+        """
+        monkeypatch.delenv("WORLD_SIZE", raising=False)
+        monkeypatch.setenv("LOCAL_RANK", "5")  # raw local_rank
+        seen: list[int] = []
+        dsetup = {"rank": 0, "world_size": 8, "local_rank": 5}
+
+        with (
+            patch.object(dist, "get_torch_device_type", return_value="xpu"),
+            patch.object(dist, "get_torch_backend", return_value="ccl"),
+            patch.object(dist, "_setup_ddp", return_value=dsetup),
+            patch.object(torch.cuda, "is_available", return_value=False),
+            patch.object(torch.xpu, "is_available", return_value=True),
+            patch.object(
+                torch.xpu,
+                "set_device",
+                side_effect=lambda i: seen.append(i),
+            ),
+            patch.object(dist, "barrier"),
+            patch.object(dist, "get_dist_info", return_value={}),
+            patch.object(dist, "print_dist_setup", return_value=""),
+            patch.object(dist, "seed_everything"),
+        ):
+            dist.setup_torch(device_id=2)
+
+        # Exactly one set_device call, to the caller-provided
+        # device_id=2 — NOT to LOCAL_RANK=5. The post-init re-set
+        # short-circuits because pre and post resolved to the same
+        # index (device_id wins both times).
+        assert seen == [2], (
+            f"Expected [2] (caller's explicit device_id), got {seen}. "
+            "Either pre-init or post-init re-set fell back to LOCAL_RANK; "
+            "current device and PG-bound device will disagree and FSDP2 "
+            "will hang on XPU."
+        )
+
+    def test_setup_torch_post_init_resets_only_when_resolved_changes(
+        self, fake_comm, monkeypatch
+    ):
+        """Post-init re-set fires only when the resolved device changed.
+
+        Regression for PR #149 Copilot comment on the post-init path:
+        the comparison MUST be "did the resolved device index change
+        between pre and post-init?", not "did LOCAL_RANK change?".
+
+        Set up a case where ``_setup_ddp`` reports a different
+        ``local_rank`` than ``get_local_rank()`` did pre-init.  With
+        no explicit device_id, both resolutions fall back to local_rank
+        — pre uses the env-var value, post uses the dsetup value — so
+        the indices DIFFER and the post-init re-set must fire.
+        """
+        monkeypatch.delenv("WORLD_SIZE", raising=False)
+        monkeypatch.setenv("LOCAL_RANK", "3")  # pre_local_rank == 3
+        # _setup_ddp reports local_rank=7 (mismatch — extremely rare
+        # in practice, but the regression we want to pin)
+        dsetup = {"rank": 0, "world_size": 12, "local_rank": 7}
+        seen: list[int] = []
+
+        with (
+            patch.object(dist, "get_torch_device_type", return_value="xpu"),
+            patch.object(dist, "get_torch_backend", return_value="ccl"),
+            patch.object(dist, "_setup_ddp", return_value=dsetup),
+            patch.object(torch.cuda, "is_available", return_value=False),
+            patch.object(torch.xpu, "is_available", return_value=True),
+            patch.object(
+                torch.xpu,
+                "set_device",
+                side_effect=lambda i: seen.append(i),
+            ),
+            patch.object(dist, "barrier"),
+            patch.object(dist, "get_dist_info", return_value={}),
+            patch.object(dist, "print_dist_setup", return_value=""),
+            patch.object(dist, "seed_everything"),
+        ):
+            dist.setup_torch()
+
+        assert seen == [3, 7], (
+            f"Expected [3, 7] (pre-init bound to LOCAL_RANK env var, "
+            f"post-init re-bound to _setup_ddp's resolved local_rank), "
+            f"got {seen}. The post-init path either skipped the re-set "
+            "(comparison against raw LOCAL_RANK lost the divergence) "
+            "or fired unnecessarily."
+        )
+
+
+# ===================================================================
+# _set_local_device
+# ===================================================================
+
+
+class TestSetLocalDevice:
+    """``_set_local_device`` is the single source of truth for setting
+    the per-process current accelerator device. Both pre- and post-
+    ``init_process_group`` paths in ``setup_torch`` route through it.
+
+    Contract:
+      * On ``cuda`` + cuda available → ``torch.cuda.set_device(N)``.
+      * On ``xpu`` + xpu attr present + xpu available →
+        ``torch.xpu.set_device(N)``.
+      * On any other device_type (``cpu``, ``mps``, ``hip``) → no-op.
+      * On builds where ``torch.xpu`` doesn't exist (Sourcery #1
+        regression) → no-op without ``AttributeError``.
+    """
+
+    def test_cuda_when_available(self, monkeypatch):
+        seen: list[int] = []
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+        monkeypatch.setattr(
+            torch.cuda, "set_device", lambda i: seen.append(i)
+        )
+        dist._set_local_device("cuda", 3)
+        assert seen == [3]
+
+    def test_cuda_not_available_is_noop(self, monkeypatch):
+        seen: list[int] = []
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setattr(
+            torch.cuda,
+            "set_device",
+            MagicMock(side_effect=AssertionError("must not be called")),
+        )
+        dist._set_local_device("cuda", 3)
+        assert seen == []
+
+    def test_xpu_when_available(self, monkeypatch):
+        seen: list[int] = []
+        monkeypatch.setattr(torch.xpu, "is_available", lambda: True)
+        monkeypatch.setattr(
+            torch.xpu, "set_device", lambda i: seen.append(i)
+        )
+        dist._set_local_device("xpu", 5)
+        assert seen == [5]
+
+    def test_xpu_not_available_is_noop(self, monkeypatch):
+        monkeypatch.setattr(torch.xpu, "is_available", lambda: False)
+        monkeypatch.setattr(
+            torch.xpu,
+            "set_device",
+            MagicMock(side_effect=AssertionError("must not be called")),
+        )
+        dist._set_local_device("xpu", 5)
+        # No exception, no call.
+
+    def test_xpu_attr_missing_is_noop(self, monkeypatch):
+        """Sourcery #1 regression: torch.xpu may not exist on every build.
+
+        CPU-only torch, CUDA-only nightlies, ROCm — none of these
+        define ``torch.xpu``. A naive ``torch.xpu.is_available()``
+        call would AttributeError before the availability check;
+        ``_set_local_device`` must use ``hasattr(torch, "xpu")`` first.
+        """
+        monkeypatch.delattr(torch, "xpu", raising=False)
+        # Must not raise.
+        dist._set_local_device("xpu", 5)
+
+    def test_non_accelerator_device_type_is_noop(self):
+        """``cpu`` / ``mps`` / ``hip`` have nothing to bind.
+
+        No env mocking needed — if the function tries to do anything,
+        it'll AttributeError on ``torch.cpu.set_device`` (which doesn't
+        exist).
+        """
+        dist._set_local_device("cpu", 0)
+        dist._set_local_device("mps", 0)
+        dist._set_local_device("hip", 0)
+
 
 # ===================================================================
 # cleanup


### PR DESCRIPTION
## Summary

Four production-noise fixes bundled — different scopes, related diagnosis.

### 1. XPU FSDP2 hang (the real bug)

Caught on Aurora torchtitan job 8518207 — gemma-7b FSDP2 deadlocked on the very first `all_gather_into_tensor`. py-spy on rank 0:

```text
sched_yield (libc-2.31.so)
0x... (libze_intel_gpu.so.1.6.33578)
ur::level_zero::urEventWait (libur_adapter_level_zero.so.0.12.0)
all_gather_into_tensor (torch/distributed/distributed_c10d.py:4381)
foreach_all_gather (torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:364)
unshard (torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py:389)
pre_forward (torch/distributed/fsdp/_fully_shard/_fsdp_state.py:300)
```

All 11 other local ranks were in `pthread_cond_wait` (downstream consumers waiting on the upstream collective).

**Root cause — two-part interaction the previous device_id fix missed:**

1. `setup_torch()` called `_setup_ddp()` BEFORE `torch.xpu.set_device(local_rank)`. On XPU the "current device" at `init_process_group` time was `xpu:0` on every rank.
2. `_setup_ddp()` explicitly skipped `device_id` on XPU, citing a stale `DeviceMesh._unflatten` / `split_group` concern. Without a device-bound PG, xccl/`foreach_all_gather` routed some ranks' collectives to `xpu:0` (current device at PG-construction time) and others to `xpu:LOCAL_RANK` (post-set_device). They never met up → silent hang.

**Two-part fix:**

- **`setup_torch`**: call `set_device(local_rank)` for both CUDA and XPU BEFORE `_setup_ddp`. Re-set after only if `local_rank` differs (extremely unlikely but cheap insurance, preserves the previous post-init contract).
- **`_setup_ddp`**: auto-detect now binds `device_id` for both CUDA and XPU. If `DeviceMesh._unflatten` regresses on a newer xccl, we'll see a loud failure rather than the silent hang — easier to debug, easier to revert.

**Regression coverage (both proven to fail when fix is stashed):**
- `test_xpu_set_device_called_before_setup_ddp` — pins the call order by recording into a shared `calls` list
- `test_xpu_auto_detect_binds_device_id_from_local_rank` — replaces the old `test_xpu_skips_device_id` (which pinned the now-buggy behavior)
- `test_explicit_xpu_device_id_passes_through` — cleaned up (used to document a "potentially buggy" quirk; now correct behavior)

### 2. wandb `start_method` deprecation (cosmetic)

Every wandb run emitted:

```text
wandb: WARNING `start_method` is deprecated and will be removed in a future
version of wandb. This setting is currently non-functional and safely ignored.
```

because `setup_wandb` always passed `start_method="fork"` to `wandb.Settings`. The intent (defend against the wrong default) is now wandb's responsibility — it's literally non-functional.

Extracted `_build_wandb_settings` helper that only forwards `start_method` when the caller explicitly requested one. `setup_wandb(start_method="spawn")` still works as a passthrough (wandb's deprecation warning is appropriate then). Default path silently drops it.

`TestBuildWandbSettings` pins both: omit when None, forward when explicit.

### 3. xccl `split_group` failure in DeviceMesh (the predicted regression)

The XPU FSDP2 fix above binds the default PG to a device via `init_process_group(device_id=...)`. Torch's `DeviceMesh._init_one_process_group` then prefers `split_group(parent_pg, ...)` over `new_group(ranks, ...)`, but the current xccl backend reports `supports_splitting=False` and raises:

```text
RuntimeError: No backend for the parent process group or its
              backend does not support splitting
```

This is exactly the "loud failure" the section-1 comment predicted. It blocked 2D meshes (`ezpz.examples.fsdp_tp`) and any caller of `init_device_mesh` on XPU. Caught running `ezpz benchmark` on Sunspot — `fsdp_tp` failed at `init_device_mesh(..., (dpsize, args.tp), mesh_dim_names=("dp", "tp"))`.

**Fix:** new `ezpz.init_device_mesh_safe()` helper temporarily clears `default_group.bound_device_id` across the `init_device_mesh` call. Torch then takes the `new_group` fallback (which xccl supports) to build each dimension's subgroup, and we restore `bound_device_id` right after so FSDP2's per-device PG resolution still works. No-op on non-xpu / when no default PG exists yet.

Wired into both callsites: `wrap_model`'s 1D-mesh auto-creation and `fsdp_tp.py`'s 2D mesh construction; re-exported from `ezpz` top-level.

**Verified on Sunspot** (2 nodes × 12 GPUs, xccl, `torch 2.13.0.dev20260519+xpu`, PBS job 12467812):
- `ezpz launch python3 -m ezpz.examples.fsdp_tp --model small --dataset stanfordnlp/imdb` → exit 0 in 61s (was: RuntimeError at "Device mesh created")
- Full `ezpz benchmark`: `test`, `fsdp`, `vit`, `diffusion` all pass; `fsdp_tp` was the only XPU-distributed failure addressed by this commit (remaining `hf`/`hf_trainer` failures are unrelated missing-`accelerate` deps).

### 4. HF datasets cache race (the next thing that broke)

`get_hf_text_dataset` in `ezpz/data/hf.py` called `datasets.load_dataset(...)` and `Dataset.map(tokenize_function, ...)` unconditionally from every rank. On a shared filesystem cache (e.g. ALCF home/lus) all N ranks race for the same fingerprint-named Arrow cache file:

```text
[rank1]: FileNotFoundError: [Errno 2] No such file or directory:
  '/home/.../datasets/.../cache-1753541a35a13eaa.arrow'
   ── arrow_dataset.py:4049: os.chmod(cache_file_name, 0o666 & ~umask)

[rank8]: pyarrow.lib.ArrowInvalid: Tried reading schema message,
   was null or length 0
   ── opened a partially-written Arrow stream
```

One rank's `os.chmod` lands after another rank has already moved the file (`FileNotFoundError`); a reader opens a stream a writer hasn't finished (`ArrowInvalid`). Observed on a 48-rank `fsdp_tp` run that also produced ~26 parallel "Tokenizing HF dataset" progress bars — every rank also wastes CPU re-tokenizing the same 512 examples in lockstep.

**Fix:** small `_main_process_first()` context manager wrapping both `load_dataset` and `map`. Rank 0 enters first and does the cache-populating work; ranks 1..N-1 wait at a `torch.distributed.barrier()`, then are released to hit the populated cache. No-op when distributed isn't initialised, so notebooks / tests / single-process callers are unaffected.

Assumes a **shared** cache dir (the default on ALCF). For node-local caches the gate would need to be on local rank instead.

## Test plan

- [x] `pytest tests/test_distributed.py -q` — 155/155 PASS
- [x] `pytest tests/test_distributed.py tests/test_tracker.py tests/test_history.py tests/test_recipes.py -q` — 277/277 PASS
- [x] Both XPU regression tests verified to fail when their respective fix is stashed
- [x] Live verification on Sunspot: `fsdp_tp` reaches "Device mesh created" and trains to exit 0
- [x] Full `ezpz benchmark` on Sunspot: 6/7 pass (test/fsdp/vit/fsdp_tp/diffusion/hf); `hf_trainer` fails on an unrelated missing `sklearn` dep, not on the changes here
- [ ] Live re-run on the same Aurora torchtitan job that hung — verify `step 1` actually arrives this time
- [x] Confirm `wandb: WARNING start_method...` no longer appears in the rank-0 log
- [x] Re-run a multi-rank `fsdp_tp` against an HF dataset and confirm only one "Tokenizing HF dataset" progress bar appears (rank-0-first cache hit)

## Label

`release:patch` — bug fix + cosmetic cleanup. Public API unchanged: `setup_torch()` signature byte-identical, `setup_wandb()` signature byte-identical (the `start_method` parameter stays, just stops getting default-forwarded). The XPU `device_id` behavior changes from "skipped" to "bound" — anyone whose code relies on the unbound PG semantics (FSDP1 with old `DeviceMesh._unflatten` path) would notice, but those callers were already going to hit the deferred FSDP2 issue anyway. New `ezpz.init_device_mesh_safe()` symbol is additive. `get_hf_text_dataset` adds a `torch.distributed.barrier()` on rank-0-first cache population — single-process callers unaffected.

## Summary by Sourcery

Fix XPU FSDP2 distributed initialization deadlock and reduce wandb configuration deprecation noise while preserving public APIs.

Bug Fixes:
- Ensure XPU processes set their local device before distributed process group initialization to prevent FSDP2 hangs on collective operations.
- Bind a device_id for XPU (mirroring CUDA) during distributed setup so XPU process groups are correctly device-bound.
- Work around xccl's missing `ProcessGroup.split_group` support so `DeviceMesh`/`init_device_mesh` (and downstream TP/2D-mesh code) no longer raises `RuntimeError: No backend for the parent process group or its backend does not support splitting`.
- Serialize HF `datasets` cache writes (`load_dataset` + `Dataset.map`) behind a rank-0-first barrier in `ezpz.data.hf.get_hf_text_dataset` to eliminate `FileNotFoundError`/`ArrowInvalid` races and N-way redundant tokenization.
- Stop implicitly forwarding a default wandb start_method that triggers a deprecation warning on every run.

Enhancements:
- Extract a reusable _build_wandb_settings helper to construct wandb.Settings with sane defaults and explicit start_method handling.
- Add `ezpz.init_device_mesh_safe()` as a drop-in replacement for `torch.distributed.init_device_mesh` that round-trips `default_group.bound_device_id` around the call to route torch through the `new_group` fallback on xpu.
- Add a `_main_process_first()` context manager in `ezpz.data.hf` for fs-cache critical sections; no-op when `torch.distributed` isn't initialised.

Tests:
- Add regression tests to verify XPU set_device is called before _setup_ddp and that XPU device_id auto-detection binds to the local rank.
- Update and extend distributed tests to ensure explicit XPU device_id values pass through unchanged and to validate _build_wandb_settings start_method behavior.