### PR TITLE
chore(utils): make ezpz_check_working_dir actually fail-capable

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -3150,19 +3150,24 @@ ezpz_check_working_dir_slurm() {
 }
 
 ezpz_check_working_dir() {
-	WORKING_DIR=$(ezpz_get_working_dir)
-	export WORKING_DIR="${WORKING_DIR}"
-
 	# The function's invariant: WORKING_DIR is set and non-empty on
 	# success. ezpz_get_working_dir shells out to python3, which can
 	# fail silently in a stripped environment (python3 not on PATH,
 	# import error, etc.) — the command substitution returns empty
-	# without raising. Catch that here so callers can `|| log_message
-	# ERROR ...` and not be lied to.
-	if [[ -z "${WORKING_DIR}" ]]; then
+	# without raising. Catch that BEFORE we export so we never leak
+	# WORKING_DIR="" into the parent shell's env: a downstream caller
+	# that does `[[ -n "$WORKING_DIR" ]] && skip-recompute` would see
+	# "the variable is set" and skip the real resolution, masking the
+	# failure in a way that pre-fix behavior never did.
+	local _resolved
+	_resolved=$(ezpz_get_working_dir)
+	if [[ -z "${_resolved}" ]]; then
+		unset WORKING_DIR
 		log_message ERROR "Unable to determine WORKING_DIR (ezpz_get_working_dir returned empty)."
 		return 1
 	fi
+	WORKING_DIR="${_resolved}"
+	export WORKING_DIR
 
 	if [[ -d .git ]]; then
 		GIT_COMMIT_HASH=$(git rev-parse HEAD) && export GIT_COMMIT_HASH

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -2639,11 +2639,14 @@ ezpz_setup_job() {
 	mn="$(ezpz_get_machine_name)"
 	local hn
 	hn="$(hostname)"
+
 	log_message INFO "[${YELLOW}JOB${RESET}]"
 	log_message INFO "  - Parsing job env for ${YELLOW}${USER}${RESET}"
 	log_message INFO "  - Detected ${YELLOW}${scheduler_type}${RESET} scheduler"
 	log_message INFO "  - Machine: ${YELLOW}${mn}${RESET}"
 	log_message INFO "  - Hostname: ${YELLOW}${hn}${RESET}"
+    ezpz_check_working_dir || log_message ERROR "Failed to set WORKING_DIR. Please check your environment."
+
 	if [[ "${scheduler_type}" == "pbs" ]]; then
 		ezpz_setup_job_alcf "$@"
 		return $?
@@ -3150,6 +3153,17 @@ ezpz_check_working_dir() {
 	WORKING_DIR=$(ezpz_get_working_dir)
 	export WORKING_DIR="${WORKING_DIR}"
 
+	# The function's invariant: WORKING_DIR is set and non-empty on
+	# success. ezpz_get_working_dir shells out to python3, which can
+	# fail silently in a stripped environment (python3 not on PATH,
+	# import error, etc.) — the command substitution returns empty
+	# without raising. Catch that here so callers can `|| log_message
+	# ERROR ...` and not be lied to.
+	if [[ -z "${WORKING_DIR}" ]]; then
+		log_message ERROR "Unable to determine WORKING_DIR (ezpz_get_working_dir returned empty)."
+		return 1
+	fi
+
 	if [[ -d .git ]]; then
 		GIT_COMMIT_HASH=$(git rev-parse HEAD) && export GIT_COMMIT_HASH
 		GIT_BRANCH=$(git branch --show-current) && export GIT_BRANCH
@@ -3157,19 +3171,23 @@ ezpz_check_working_dir() {
 		log_message WARN "No .git directory found in WORKING_DIR (${GREEN}${WORKING_DIR}${RESET}). Skipping Git info export."
 	fi
 
+	local scheduler_rc=0
 	scheduler_type=$(ezpz_get_scheduler_type)
 	if [[ "${scheduler_type}" == "pbs" ]]; then
 		log_message INFO "Detected PBS scheduler environment."
 		ezpz_check_working_dir_pbs
+		scheduler_rc=$?
 	elif [[ "${scheduler_type}" == "slurm" ]]; then
 		log_message INFO "Detected SLURM scheduler environment."
 		ezpz_check_working_dir_slurm
+		scheduler_rc=$?
 	else
 		log_message INFO "No PBS or SLURM scheduler environment detected."
 		log_message INFO "Unable to detect PBS or SLURM working directory info..."
 		log_message INFO "Using current working directory (${GREEN}${WORKING_DIR}${RESET}) as working directory..."
 	fi
 
+	return "${scheduler_rc}"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ezpz_check_working_dir` was advertised in `ezpz_setup_job` as a sanity check that should ERROR-log if `WORKING_DIR` couldn't be resolved:

```bash
ezpz_check_working_dir || log_message ERROR "Failed to set WORKING_DIR. ..."
```

…but the function had **no `return 1` anywhere** — it always fell through to rc=0, so the `||` branch was dead code. `ezpz_get_working_dir` (which the check delegates to) shells out to `python3`, and a command substitution against a missing `python3` returns empty *without* raising — so `WORKING_DIR` could silently become `""` and no warning would surface.

## Changes

**1. `ezpz_check_working_dir` now returns 1** when `ezpz_get_working_dir` returns an empty string, with a clear ERROR log so the caller sees what broke.

**2. Scheduler-specific check propagates its rc.** Previously `ezpz_check_working_dir_pbs` / `_slurm` exit codes were discarded; they now bubble up.

## Verification

Manual functional test (sourced the script in a fresh bash, exercised both paths):

```text
--- test 1: real cwd ---
... [INFO] No PBS or SLURM scheduler environment detected.
... [INFO] Unable to detect PBS or SLURM working directory info...
... [INFO] Using current working directory (/.../ezpz) as working directory...
rc=0 (OK)
WORKING_DIR=/.../ezpz

--- test 2: empty python3 output ---
... [ERROR] Unable to determine WORKING_DIR (ezpz_get_working_dir returned empty).
rc=1 (OK — correctly returned non-zero)
```

`bash -n src/ezpz/bin/utils.sh` clean.

## Label

`release:patch` — bash-only change, no public Python API touched. Behavior change is strictly additive (function can now signal failure where it previously couldn't); callers that ignore the rc see no difference.

## Test plan

- [x] `bash -n src/ezpz/bin/utils.sh` syntax check
- [x] Manual exercise of both happy + failure paths
- [ ] Run `ezpz_setup_job` on Aurora and confirm the new ERROR log fires (or doesn't, in the happy case)

## Summary by Sourcery

Ensure working directory resolution failures are surfaced and propagated from job setup utilities.

Bug Fixes:
- Make ezpz_check_working_dir return a non-zero status and log an error when WORKING_DIR cannot be determined.
- Propagate PBS/SLURM scheduler-specific working directory check exit codes back to the caller instead of discarding them.

Enhancements:
- Invoke ezpz_check_working_dir from ezpz_setup_job so job setup logs an explicit error when WORKING_DIR setup fails.