### PR TITLE
docs(distributed): document init_device_mesh_safe + clarify setup_torch device_id

### DIFF
--- a/docs/python/Code-Reference/distributed.md
+++ b/docs/python/Code-Reference/distributed.md
@@ -44,7 +44,7 @@ rank = ezpz.setup_torch(
 | `pipeline_parallel_backend`* | `None`    | Backend for PP groups (auto-detected)              |
 | `context_parallel_backend`*  | `None`    | Backend for CP groups (auto-detected)              |
 | `data_parallel_backend`*     | `None`    | Backend for DP groups (auto-detected)              |
-| `device_id`*                 | `None`    | Override local device index                        |
+| `device_id`*                 | `None`    | Override the per-rank device index. Defaults to `LOCAL_RANK`. When set, this is the device the process group binds to (`init_process_group(device_id=...)`) AND the device `setup_torch` activates before init. On XPU this binding is load-bearing — see [Multi-dimensional DeviceMesh](#multi-dimensional-devicemesh-xpu-safe) for why. |
 
 Parameters marked with `*` are keyword-only.
 
@@ -88,6 +88,43 @@ model = ezpz.wrap_model_for_fsdp2(
     device_mesh=my_mesh,  # optional DeviceMesh for multi-dim parallelism
 )
 ```
+
+## Multi-dimensional DeviceMesh (XPU-safe)
+
+Building a `DeviceMesh` directly on Aurora/Sunspot (xccl) requires a small
+workaround — torch's `DeviceMesh._init_one_process_group` prefers the
+`split_group` path when the default PG is device-bound, but the current
+xccl backend reports `supports_splitting=False` and raises:
+
+```
+RuntimeError: No backend for the parent process group or its backend
+              does not support splitting
+```
+
+`ezpz.init_device_mesh_safe()` is a drop-in for `torch.distributed.init_device_mesh`
+that round-trips `bound_device_id` around the call so torch takes the
+`new_group(ranks, ...)` fallback (which xccl supports), then restores the
+binding so FSDP2's per-device PG resolution still works. No-op on CUDA/NCCL
+(which supports `split_group` natively).
+
+```python
+import ezpz
+
+# 1D mesh
+mesh = ezpz.init_device_mesh_safe("xpu", (world_size,))
+
+# 2D (dp, tp) mesh — see ezpz.examples.fsdp_tp
+mesh = ezpz.init_device_mesh_safe(
+    str(ezpz.get_torch_device()),
+    (dp_size, tp_size),
+    mesh_dim_names=("dp", "tp"),
+)
+```
+
+`ezpz.wrap_model`'s auto-created 1D mesh and `ezpz.examples.fsdp_tp` both
+route through this helper, so callers using those paths get the workaround
+for free. Reach for `init_device_mesh_safe` directly when you're building
+your own mesh (TP, PP, CP, EP, 2D/3D combinations).
 
 ## Hostfile Helpers
 


### PR DESCRIPTION
## Summary

- Adds a **Multi-dimensional DeviceMesh (XPU-safe)** section to `docs/python/Code-Reference/distributed.md` covering `ezpz.init_device_mesh_safe` — the symbol shipped in v0.18.4 (PR #149) that wasn't in the reference.
- Expands the `device_id` row in the `setup_torch` parameter table from one phrase to a real explanation, with a link to the new section explaining the XPU rationale.

## Why

The audit on PR #149 found that `init_device_mesh_safe` is a new public symbol but only discoverable by grepping the source or reading its docstring — it's not in the reference page. Anyone building a custom 2D/3D DeviceMesh on Aurora/Sunspot today will hit the xccl `split_group` `RuntimeError` and have no doc telling them what to do.

The `setup_torch(device_id=...)` row also got beefed up since the PR #149 fix made its behavior more load-bearing on XPU (it now drives the pre-init `set_device` call too, not just `_setup_ddp`'s PG binding).

## Test plan

- [x] `wc -l` and visual inspection — formatting matches surrounding sections.
- [ ] Render check (mkdocs serve) — would prefer if a maintainer with the docs env confirms the anchor `#multi-dimensional-devicemesh-xpu-safe` resolves correctly.

## Summary by Sourcery

Document XPU-safe multi-dimensional DeviceMesh usage and clarify device binding behavior in distributed setup documentation.

Documentation:
- Expand the `device_id` parameter description in `setup_torch` to explain its default, device binding behavior, and XPU-specific implications.
- Add a new "Multi-dimensional DeviceMesh (XPU-safe)" section documenting `ezpz.init_device_mesh_safe`, its rationale, and usage examples for 1D and 2D meshes.