### PR TITLE
docs(shell-environment): document ezpz_check_working_dir failure semantics (v0.18.4)

### DIFF
--- a/docs/notes/shell-environment.md
+++ b/docs/notes/shell-environment.md
@@ -161,6 +161,9 @@ ezpz_setup_env
 | `ezpz_setup_python`          | Wrapper: `ezpz_setup_conda && ezpz_setup_venv_from_conda`                                 |
 | `ezpz_setup_conda`           | Find and activate the appropriate conda module[^1]                                        |
 | `ezpz_setup_venv_from_conda` | From `${CONDA_NAME}`, build or activate the venv in `venvs/${CONDA_NAME}/`                |
+| `ezpz_get_scheduler_type`    | Echo the active scheduler: `pbs`, `slurm`, or empty when neither is detected              |
+| `ezpz_get_working_dir`       | Echo the current working directory (shells out to `python3 -c 'os.getcwd()'`)             |
+| `ezpz_check_working_dir`     | Resolve and export `WORKING_DIR`; returns non-zero on failure (see below)                 |
 
 ### Shell Variables Exported
 
@@ -175,6 +178,39 @@ After `ezpz_setup_env` completes, the following are available in your shell
 | `HOSTFILE`      | `/var/spool/...` | Path to hostfile                  |
 | `DIST_LAUNCH`   | `mpiexec ...`    | Full launch command prefix        |
 | `JOBENV_FILE`   | `.jobenv`        | Saved job environment file        |
+| `WORKING_DIR`   | `/lus/.../proj`  | Resolved working dir (set by `ezpz_check_working_dir`) |
+
+### `ezpz_check_working_dir` — error semantics
+
+`ezpz_check_working_dir` resolves the current working directory (via
+`ezpz_get_working_dir`, which shells out to `python3 -c 'os.getcwd()'`),
+exports it as `WORKING_DIR`, and dispatches to the scheduler-specific
+check (`ezpz_check_working_dir_pbs` / `_slurm`) that reconciles
+`PBS_O_WORKDIR` / `SLURM_SUBMIT_DIR`.
+
+As of **v0.18.4** the function actually returns a non-zero rc when
+resolution fails:
+
+```bash
+if ! ezpz_check_working_dir; then
+    log_message ERROR "Failed to set WORKING_DIR. Please check your environment."
+fi
+```
+
+Two failure modes the function now signals:
+
+- **Empty resolution** (e.g. `python3` not on PATH, stripped env, import
+  error): logs `ERROR Unable to determine WORKING_DIR (ezpz_get_working_dir returned empty)`,
+  leaves `WORKING_DIR` **unset** (not exported as empty — important so
+  that `[[ -n "$WORKING_DIR" ]] && skip-recompute` patterns in caller
+  scripts don't accept the bad value), and returns `1`.
+- **Scheduler-specific check fails**: the exit code from
+  `ezpz_check_working_dir_pbs` / `_slurm` now propagates up (previously
+  discarded).
+
+Pre-v0.18.4 the function had no `return 1` anywhere, so the
+`|| log_message ERROR ...` branch in `ezpz_setup_job` was unreachable
+and a silent empty `WORKING_DIR` could leak through.
 
 ## Setup Python
 


### PR DESCRIPTION
## Summary

Three additions to `docs/notes/shell-environment.md` covering bash-utility changes from v0.18.4 (PR #150):

1. **Key Functions table** gains three previously-undocumented public helpers from `src/ezpz/bin/utils.sh`:
   - `ezpz_get_scheduler_type` — used heavily but never documented
   - `ezpz_get_working_dir` — building block for `check_working_dir`
   - `ezpz_check_working_dir` — with a forward-link to its new error semantics

2. **Shell Variables Exported table** gains `WORKING_DIR`.

3. **New subsection** `ezpz_check_working_dir — error semantics` documenting the PR #150 behavior change:
   - Function now returns `1` (was always `0`) when `ezpz_get_working_dir` returns empty, with the literal ERROR log fingerprint users will see.
   - Scheduler-specific rc now propagates (was discarded).
   - On failure `WORKING_DIR` is **unset**, not exported as empty — so caller `[[ -n "$WORKING_DIR" ]] && skip-recompute` patterns don't accept the bad value.

Notes the pre-v0.18.4 silent-failure behavior so users debugging older logs can connect the dots.

## Why

The audit on PR #149/#150 found `src/ezpz/bin/utils.sh` has zero reference documentation — ~3200 lines of shell helpers, including ones the `ezpz_setup_env` workflow depends on. This PR doesn't attempt the full reference (that's a much bigger project); it covers exactly what changed in v0.18.4 (PR #150) plus the directly-related helpers (`get_scheduler_type`, `get_working_dir`) so the changed function isn't documented in a vacuum.

## Test plan

- [x] Visual inspection — matches surrounding section style.
- [ ] Render check (mkdocs serve) — confirm `WORKING_DIR` row renders consistently with the rest of the table.

## Followups

The full bash-utils reference (~30 public functions across modules, scheduler helpers, conda setup, hostfile management) is still missing. That's a separate, larger task — not in scope here.

## Summary by Sourcery

Document new and updated shell working-directory helpers and their failure semantics introduced in v0.18.4.

Documentation:
- Extend shell environment notes to document ezpz_get_scheduler_type, ezpz_get_working_dir, and ezpz_check_working_dir.
- Add WORKING_DIR to the list of exported shell variables with its purpose and origin.
- Describe ezpz_check_working_dir error and return-code semantics, including scheduler-specific propagation and behavior before v0.18.4.