### PR TITLE
docs(readme): point XPU multi-dim parallelism users at init_device_mesh_safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ rank = ezpz.setup_torch()           # auto-detects device + backend
 device = ezpz.get_torch_device()
 model = torch.nn.Linear(128, 10).to(device)
 model = ezpz.wrap_model(model)       # FSDP (default)
+
+# Multi-dim parallelism (TP/PP/CP) on XPU? Use ezpz.init_device_mesh_safe
+# instead of torch's init_device_mesh — works around xccl's missing
+# split_group on Aurora/Sunspot. See docs/troubleshooting.md.
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

Two purposes:

1. **Real change**: tiny Quick Start note in README.md flagging that anyone reaching for `torch.distributed.init_device_mesh` on Aurora/Sunspot (TP/PP/CP/EP, 2D/3D meshes) should use `ezpz.init_device_mesh_safe` instead. Links to the troubleshooting page that explains why.

2. **Release trigger**: this PR is labeled `release:patch` so its merge fires the release-on-merge workflow, bundling the three doc-only commits since v0.18.4 (#151, #152, #153) into a v0.18.5 CHANGELOG section.

## Why

The three doc PRs were intentionally labeled `release:skip` so each wouldn't trigger its own patch bump. That left them queued behind whatever fires the next release. This is that fire — small enough to not deserve its own version on its own, big enough to be worth shipping with the doc round.

## What lands in v0.18.5

```
17c2caf docs(readme): point XPU multi-dim parallelism users at init_device_mesh_safe  (this PR)
af3c217 docs(shell-environment): document ezpz_check_working_dir failure semantics    (#153)
2f85efe docs(troubleshooting): XPU FSDP2 first-step hang + custom DeviceMesh + HF cache races  (#152)
f892eb6 docs(distributed): document init_device_mesh_safe + clarify setup_torch device_id  (#151)
```

No code changes, so the package itself is binary-identical to v0.18.4.

## Test plan

- [x] `git diff` shows only a 4-line addition to README.md.
- [ ] After merge: confirm release workflow runs, CHANGELOG gets a v0.18.5 entry with all 4 commits, tag is created.

## Summary by Sourcery

Documentation:
- Add a README note directing XPU multi-dim parallelism users to use ezpz.init_device_mesh_safe instead of torch.distributed.init_device_mesh, with a pointer to troubleshooting details.