### PR TITLE
docs: nav fix + version footers + restructured example pages + README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ model = ezpz.wrap_model(model)       # FSDP (default)
 
 # Multi-dim parallelism (TP/PP/CP) on XPU? Use ezpz.init_device_mesh_safe
 # instead of torch's init_device_mesh — works around xccl's missing
-# split_group on Aurora/Sunspot. See docs/troubleshooting.md.
+# split_group on Aurora/Sunspot. See https://ezpz.cool/troubleshooting/.
 ```
 
 ```bash
@@ -45,14 +45,40 @@ model = ezpz.wrap_model(model)       # FSDP (default)
 ezpz launch python3 train.py
 ```
 
+For a side-by-side diff against the equivalent raw-torch boilerplate, see
+the [API Cheat Sheet](https://ezpz.cool/quickstart/#api-cheat-sheet).
+
 ## CLI
 
 ```bash
 ezpz launch python3 train.py    # launch distributed training
+ezpz submit -N 2 -q debug -- python3 train.py   # submit batch job to PBS/SLURM
 ezpz test                       # smoke-test your setup
+ezpz benchmark                  # run + compare example benchmarks
 ezpz doctor                     # diagnose environment issues
 ```
+
+## Why ezpz?
+
+Compared to the alternatives:
+
+- **vs raw `torchrun` / `mpirun` / `srun`**: one launcher that detects your
+  scheduler, builds the right command, and works on a laptop too.
+- **vs `accelerate`**: lower surface area, no config files, designed for
+  HPC schedulers from the ground up rather than retrofitted.
+- **vs `DeepSpeed`**: not an alternative — `ezpz` wraps your distributed
+  init so you can still use DeepSpeed (or anything else) underneath.
+
+See the [full comparison](https://ezpz.cool/compare/) for details.
 
 ## Documentation
 
 Full documentation is available at [**ezpz.cool**](https://ezpz.cool).
+
+Useful entry points:
+
+- 🏃‍♂️ [Quickstart](https://ezpz.cool/quickstart/) — install → script → launch in 5 minutes
+- 🎓 [Distributed Training Tutorial](https://ezpz.cool/guides/distributed-training/) — progressive hello-world → FSDP+TP
+- 🍳 [Recipes](https://ezpz.cool/recipes/) — copy-pasteable patterns (checkpointing, gradient accumulation, MFU tracking)
+- 🔧 [Troubleshooting](https://ezpz.cool/troubleshooting/) — XPU FSDP2 hangs, NCCL/CCL errors, scheduler issues
+- 📝 [Examples](https://ezpz.cool/examples/) — runnable end-to-end (FSDP, ViT, Diffusion, HF Trainer)

--- a/docs/examples/diffusion.md
+++ b/docs/examples/diffusion.md
@@ -21,15 +21,61 @@ See:
 ezpz launch python3 -m ezpz.examples.diffusion --batch_size 1 --hf_dataset stanfordnlp/imdb
 ```
 
-## Source
+## What this example demonstrates
 
-<details closed><summary><code>src/ezpz/examples/diffusion.py</code></summary>
+- The full DDPM training recipe in one file — `DiffusionSchedule` precomputes
+  betas/alphas, `add_noise` runs the forward (`q`) process, and `p_sample`
+  implements the reverse step used by `generate_text` for sampling.
+- Building a tiny transformer denoiser (`DiffusionTextModel`) on top of a token
+  vocabulary built from the input corpus (`build_vocab`) — so the same script
+  works on either a default text bundle or any HuggingFace dataset slice.
+- Switching between DDP and FSDP via `ezpz.distributed.wrap_model(model, use_fsdp=args.fsdp)`,
+  honoring `--fsdp-sharding-strategy` and `--fsdp-mixed-precision`.
+- Loading text data from HuggingFace with `load_hf_texts(args.hf_dataset, ...)`
+  using `--hf-split`, `--hf-text-column`, and `--hf-limit` to slice the corpus.
+- Periodic text generation during training (`--samples N` controls how many
+  prompts to decode) so you can eyeball quality without an external eval script.
 
-```python title="src/ezpz/examples/diffusion.py"
---8<-- "src/ezpz/examples/diffusion.py"
+## Expected output
+
+After launch, you'll see distributed init, vocabulary build, the model
+summary, and per-step diffusion loss:
+
+```bash
+[I][ezpz/dist:setup_torch] Using device='xpu' with backend='xccl' ...
+[I][ezpz/dist:setup_torch] [...][rank=00/23][local_rank=00/11]
+[I][ezpz/dist:setup_wandb] wandb.run=[...](https://wandb.ai/...)
+[I][examples/diffusion:main] vocab_size=...  seq_len=...  timesteps=...
+[I][examples/diffusion:main]
+=================================================================
+Layer (type:depth-idx)                   Param #
+=================================================================
+DiffusionTextModel                       --
+...
+[I][examples/diffusion:train] step=0  loss=...  dt=...
+[I][examples/diffusion:train] step=1  loss=...  dt=...
 ```
 
-</details>
+Toward the end of the run, decoded samples are logged on rank 0 (look for
+`sample 0: ...` lines in the captured [Output](#output) below).
+
+## Common modifications
+
+- **Pick a model size** — `--model {debug,small,medium,large}` sets `hidden`,
+  `n_layers`, `n_heads`, `seq_len`, `timesteps`, and `batch_size` together.
+  Presets live in `MODEL_PRESETS` near the top of
+  `src/ezpz/examples/diffusion.py`.
+- **Tune the diffusion process** — `--timesteps`, `--seq-len`, `--train-steps`
+  control the noise schedule length, sequence length, and total optimizer
+  steps. Explicit flags override the preset.
+- **Train on a different HF corpus** — `--hf-dataset <id> --hf-split <split>
+  --hf-text-column <col> --hf-limit <n>` plumbs straight into `load_hf_texts()`.
+  Omit `--hf-dataset` to fall back to `get_default_texts()`.
+- **Enable FSDP** — pass `--fsdp` (and optionally `--fsdp-sharding-strategy`
+  and `--fsdp-mixed-precision`). The `ezpz.distributed.wrap_model(...)` call in
+  `train()` toggles between DDP and FSDP for you.
+- **Generate more / fewer samples** — `--samples N` controls how many prompts
+  `generate_text()` decodes at the end of each evaluation pass.
 
 ## Code Walkthrough
 
@@ -1367,6 +1413,16 @@ wandb: Find logs at: ../../../../../../lus/tegu/projects/datascience/foremans/pr
 [2025-12-31 12:11:54,604899][I][ezpz/launch:448:launch] Execution finished with 0.
 [2025-12-31 12:11:54,605300][I][ezpz/launch:449:launch] Executing finished in 78.58 seconds.
 [2025-12-31 12:11:54,605658][I][ezpz/launch:450:launch] Took 78.58 seconds to run. Exiting.
+```
+
+</details>
+
+## Source code
+
+<details closed><summary><code>src/ezpz/examples/diffusion.py</code></summary>
+
+```python title="src/ezpz/examples/diffusion.py"
+--8<-- "src/ezpz/examples/diffusion.py"
 ```
 
 </details>

--- a/docs/examples/fsdp.md
+++ b/docs/examples/fsdp.md
@@ -3,12 +3,18 @@
 Use this example when your model is too large to fit on a single GPU, or you
 want to reduce per-GPU memory usage. FSDP shards model parameters, gradients,
 and optimizer states across ranks — enabling training of larger models with the
-same hardware. Switch from DDP to FSDP with a single flag: `use_fsdp=True`.
+same hardware.
+
+This example calls PyTorch's `FullyShardedDataParallel` directly to show what
+ezpz is doing under the hood. For most user code,
+[`ezpz.wrap_model(model, use_fsdp=True)`][ezpz.distributed.wrap_model] is the
+one-line equivalent.
 
 !!! info "Key API Functions"
 
     - [`setup_torch()`][ezpz.distributed.setup_torch] — Initialize distributed training
-    - [`wrap_model()`][ezpz.distributed.wrap_model] — Wrap model for FSDP (with `use_fsdp=True`)
+    - [`FullyShardedDataParallel`][torch.distributed.fsdp.FullyShardedDataParallel] — Raw FSDP wrap (used here)
+    - [`wrap_model(use_fsdp=True)`][ezpz.distributed.wrap_model] — `ezpz`'s one-line equivalent for production code
     - [`TrainConfig`][ezpz.configs.TrainConfig] — Training configuration
 
 See:
@@ -20,15 +26,60 @@ See:
 ezpz launch python3 -m ezpz.examples.fsdp
 ```
 
-## Source
+## What this example demonstrates
 
-<details closed><summary><code>src/ezpz/examples/fsdp.py</code></summary>
+- Wrapping a CNN with PyTorch's [`FullyShardedDataParallel`][torch.distributed.fsdp.FullyShardedDataParallel]
+  + a `MixedPrecision` policy so parameters, gradients, and optimizer states are
+  sharded across ranks while compute stays in `bf16`/`fp16`.
+- Per-rank dataloader sampling with [`DistributedSampler`][torch.utils.data.DistributedSampler]
+  and `sampler.set_epoch(epoch)` so each rank sees a different shuffle every epoch.
+- Cross-rank metric aggregation with `dist.all_reduce` so every worker reports the
+  same global train/test loss and accuracy.
+- Estimating model FLOPS *before* the FSDP wrap (FlopCounterMode can't see through
+  the wrapper) and using the per-step duration to compute TFLOPS / MFU — see
+  [MFU Tracking](#mfu-tracking) below.
+- A portable rank-0 checkpoint save (`torch.save(model.state_dict(), ...)`) gated
+  on `--save-model`.
 
-```python title="src/ezpz/examples/fsdp.py"
---8<-- "src/ezpz/examples/fsdp.py"
+## Expected output
+
+After `ezpz launch` finishes its launch banner you'll see distributed init,
+a parameter-count table, then per-epoch metric lines from `History.update`:
+
+```bash
+[I][ezpz/dist:setup_torch] Using device='xpu' with backend='xccl' ...
+[I][ezpz/dist:setup_torch] [...][rank=00/23][local_rank=00/11]
+[I][ezpz/dist:setup_wandb] wandb.run=[...](https://wandb.ai/...)
+[I][examples/fsdp:prepare_model_optimizer_and_scheduler]
+=================================================================
+Layer (type:depth-idx)                   Param #
+=================================================================
+Net                                      --
+├─Conv2d: 1-1                            ...
+...
+=================================================================
+[I][examples/fsdp:fsdp_main] epoch=1 dt=...  train_loss=...  test_loss=...  test_acc=...
+[I][examples/fsdp:fsdp_main] epoch=2 dt=...  train_loss=...  test_loss=...  test_acc=...
 ```
 
-</details>
+A full run also prints text-mode `tplot` summaries and writes JSONL metrics +
+plots under `outputs/ezpz-fsdp/<timestamp>/` (see [Output](#output) for the real
+log captured on Sunspot).
+
+## Common modifications
+
+- **Pick a different model size** — pass `--model {debug,small,medium,large}` or
+  override `--conv1-channels / --conv2-channels / --fc-dim` directly. Presets
+  live in `MODEL_PRESETS` near the top of `src/ezpz/examples/fsdp.py`.
+- **Train on a bigger dataset** — `--dataset {MNIST,OpenImages,ImageNet,ImageNet1k}`
+  routes through `get_data()` to dataset-specific loaders in `ezpz.data.vision`.
+- **Switch the FSDP compute dtype** — pass `--dtype {bf16,fp16,fp32}`. The value
+  flows into `MixedPrecision(param_dtype=...)` in
+  `prepare_model_optimizer_and_scheduler()`.
+- **Change the optimizer / LR schedule** — `optim.AdamW` and `StepLR` are wired
+  in the same function; swap them out without touching the rest of the loop.
+- **Save a checkpoint** — pass `--save-model` to write `mnist_cnn.pt` from rank 0
+  after training completes.
 
 ## Code Walkthrough
 
@@ -876,4 +927,13 @@ wandb: Find logs at: ../../../../../../lus/tegu/projects/datascience/foremans/pr
 
 </details>
 
+## Source code
+
+<details closed><summary><code>src/ezpz/examples/fsdp.py</code></summary>
+
+```python title="src/ezpz/examples/fsdp.py"
+--8<-- "src/ezpz/examples/fsdp.py"
+```
+
+</details>
 

--- a/docs/examples/hf.md
+++ b/docs/examples/hf.md
@@ -30,15 +30,63 @@ ezpz launch python3 -m ezpz.examples.hf \
     --output_dir ./output-hf
 ```
 
-## Source
+## What this example demonstrates
 
-<details closed><summary><code>src/ezpz/examples/hf.py</code></summary>
+- Parsing three dataclass groups (`HfModelArguments`, `HfDataTrainingArguments`,
+  `TrainingArguments`) in a single pass with HuggingFace's `HfArgumentParser`,
+  including the `--config_file foo.json` shortcut for batch jobs.
+- Driving an explicit train/eval loop with HuggingFace `accelerate` — you keep
+  full control over forward/backward/optimizer ordering instead of delegating to
+  `Trainer`.
+- Opt-in FSDP via `ACCELERATE_USE_FSDP=true`. When set, the example builds an
+  explicit `FullyShardedDataParallelPlugin` with a bf16 `MixedPrecision` policy
+  (bypassing Accelerate's env-var defaults that can pick up stale config).
+- Separate `train/` and `eval/` metric namespaces so
+  [`History.finalize()`][ezpz.history.History] produces split `train.h5` /
+  `eval.h5` datasets, distinct plot groups, and per-line summaries tagged
+  `[train]` / `[eval]`.
+- Robustness niceties — a `safetensors` → `.bin` fallback for Lustre's
+  "Argument list too long" failure, and an early break out of the epoch loop
+  once `max_steps` is hit.
 
-```python title="src/ezpz/examples/hf.py"
---8<-- "src/ezpz/examples/hf.py"
+## Expected output
+
+After launch, you'll see distributed init, model + tokenizer loading, and
+prefixed per-step training metrics:
+
+```bash
+[I][ezpz/dist:setup_torch] Using device='xpu' with backend='xccl' ...
+[I][ezpz/dist:setup_torch] [...][rank=00/23][local_rank=00/11]
+[I][ezpz/dist:setup_wandb] wandb.run=[...](https://wandb.ai/...)
+[I][examples/hf:main] Loading model gpt2 ...
+[I][examples/hf:main] Loaded dataset wikitext / wikitext-2-raw-v1
+[I][examples/hf:main] [train] step=0  loss=...  perplexity=...  tflops=...  mfu=...
+[I][examples/hf:main] [train] step=1  loss=...  perplexity=...  tflops=...  mfu=...
+...
+[I][examples/hf:main] [eval]  step=...  loss=...  perplexity=...
 ```
 
-</details>
+`[train]` and `[eval]` tags come from the prefix-stripping helper in
+`_strip_metric_prefix`. Final history is written to `--output_dir`.
+
+## Common modifications
+
+- **Switch the model or dataset** — change `--model_name_or_path`,
+  `--dataset_name`, `--dataset_config_name`. `split_dataset()` handles the
+  train/validation split (including a fallback when split-by-percentage syntax
+  isn't supported).
+- **Turn on FSDP** — `export ACCELERATE_USE_FSDP=true` before launching. The
+  explicit plugin is constructed in `main()` around line ~275 of
+  `src/ezpz/examples/hf.py`.
+- **Tune training schedule** — pass any
+  [`TrainingArguments`](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments)
+  flag (`--per_device_train_batch_size`, `--learning_rate`,
+  `--num_train_epochs`, `--max_steps`, `--gradient_accumulation_steps`, ...).
+- **Change the token chunking** — `--block_size` controls how
+  `group_texts()` packs tokens. Default falls back to the tokenizer's
+  `model_max_length`.
+- **Override the W&B project name** — `--wandb_project_name my-experiment` (or
+  unset to use the default derived from the script path).
 
 ## Code Walkthrough
 
@@ -476,6 +524,16 @@ $ python3 -m ezpz.examples.hf --help
 #   --block_size            Token block size for grouping
 #   --wandb_project_name    Custom W&B project name
 # See HfModelArguments and HfDataTrainingArguments for full list.
+```
+
+</details>
+
+## Source code
+
+<details closed><summary><code>src/ezpz/examples/hf.py</code></summary>
+
+```python title="src/ezpz/examples/hf.py"
+--8<-- "src/ezpz/examples/hf.py"
 ```
 
 </details>

--- a/docs/examples/vit.md
+++ b/docs/examples/vit.md
@@ -22,15 +22,63 @@ See:
 ezpz launch python3 -m ezpz.examples.vit --compile # --fsdp
 ```
 
-## Source
+## What this example demonstrates
 
-<details closed><summary><code>src/ezpz/examples/vit.py</code></summary>
+- Building a Vision Transformer from scratch — `PatchEmbed` splits the image into
+  non-overlapping patches via a strided `Conv2d`, then a stack of
+  `AttentionBlock` layers (from `ezpz.models`) plus a class-token classifier head
+  produces logits.
+- Wrapping with `ezpz.distributed.wrap_model(model, use_fsdp=...)` so the same
+  call picks DDP or FSDP based on the `--fsdp` flag (and honors
+  `--fsdp_sharding_strategy`).
+- Mixing in `torch.compile()` for kernel fusion when `--compile` is passed —
+  the first iteration eats the compile cost, every iteration after that benefits.
+- Selecting from pre-baked model presets (`debug / small / medium / large`) via
+  `--model`, with explicit CLI flags always taking precedence over preset values.
+- End-to-end metric tracking via [`ezpz.history.History`][ezpz.history.History]
+  with optional W&B logging, plus MFU computed from the per-step duration (see
+  [MFU Tracking](#mfu-tracking)).
 
-```python title="src/ezpz/examples/vit.py"
---8<-- "src/ezpz/examples/vit.py"
+## Expected output
+
+After launch, you'll see distributed init, a model parameter summary, and
+per-step train metrics:
+
+```bash
+[I][ezpz/dist:setup_torch] Using device='xpu' with backend='xccl' ...
+[I][ezpz/dist:setup_torch] [...][rank=00/23][local_rank=00/11]
+[I][ezpz/dist:setup_wandb] wandb.run=[...](https://wandb.ai/...)
+[I][examples/vit:main] Using AttentionBlock Attention with args.compile=True
+[I][examples/vit:main]
+=================================================================
+Layer (type:depth-idx)                   Param #
+=================================================================
+SimpleVisionTransformer                  --
+├─PatchEmbed: 1-1                        ...
+├─ModuleList: 1-2                        ...
+...
+[I][examples/vit:train_step] iter=0  dt=...  loss=...  dtf=...  dtb=...
+[I][examples/vit:train_step] iter=1  dt=...  loss=...  dtf=...  dtb=...
 ```
 
-</details>
+`torch.compile` makes the first iteration noticeably slower while it
+specializes kernels — subsequent steps drop to the steady-state `dt`. See the
+[Output](#output) section below for a real captured run.
+
+## Common modifications
+
+- **Pick a model size** — pass `--model {debug,small,medium,med,large}`. Presets
+  live in `MODEL_PRESETS` near the top of `src/ezpz/examples/vit.py`; tweak the
+  dict to add your own.
+- **Tune individual architecture knobs** — `--img_size`, `--patch_size`,
+  `--num_heads`, `--head_dim`, `--depth`, `--embed_dim` all override the preset.
+- **Enable FSDP** — pass `--fsdp` (and optionally `--fsdp_sharding_strategy`)
+  to switch from DDP. The call to `ezpz.distributed.wrap_model(..., use_fsdp=...)`
+  in `main()` handles both cases.
+- **Toggle `torch.compile`** — `--compile` enables it. Useful for measuring the
+  fused-kernel speedup vs. eager execution.
+- **Swap the dataset** — `--dataset {mnist,fake}` routes through the helpers
+  in `ezpz.data.vision` (or generates random tensors for quick smoke tests).
 
 ## Code Walkthrough
 
@@ -1140,4 +1188,13 @@ wandb: Find logs at: ../../../../../../lus/tegu/projects/datascience/foremans/pr
 
 </details>
 
+## Source code
+
+<details closed><summary><code>src/ezpz/examples/vit.py</code></summary>
+
+```python title="src/ezpz/examples/vit.py"
+--8<-- "src/ezpz/examples/vit.py"
+```
+
+</details>
 

--- a/docs/python/Code-Reference/distributed.md
+++ b/docs/python/Code-Reference/distributed.md
@@ -91,6 +91,14 @@ model = ezpz.wrap_model_for_fsdp2(
 
 ## Multi-dimensional DeviceMesh (XPU-safe)
 
+!!! info "Since v0.18.4"
+
+    `ezpz.init_device_mesh_safe()` was added in
+    [v0.18.4](https://github.com/saforem2/ezpz/releases/tag/v0.18.4)
+    (PR [#149](https://github.com/saforem2/ezpz/pull/149)) — see
+    [troubleshooting](../../troubleshooting.md#custom-devicemesh-on-xpu)
+    for the underlying xccl `split_group` limitation it works around.
+
 Building a `DeviceMesh` directly on Aurora/Sunspot (xccl) requires a small
 workaround — torch's `DeviceMesh._init_one_process_group` prefers the
 `split_group` path when the default PG is device-bound, but the current

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,6 +68,15 @@ communication problem between ranks.
 
 ### XPU FSDP2 First-Step Hang
 
+!!! info "Fixed in v0.18.4"
+
+    The two-part fix landed in
+    [v0.18.4](https://github.com/saforem2/ezpz/releases/tag/v0.18.4)
+    (PR [#149](https://github.com/saforem2/ezpz/pull/149)): `setup_torch`
+    now calls `set_device(local_rank)` before `_setup_ddp`, and
+    `_setup_ddp` binds `device_id=` for XPU just like CUDA. Upgrade is
+    the recommended action.
+
 **Symptom:** A `fully_shard`-wrapped model deadlocks on the very first
 `all_gather_into_tensor` call inside `pre_forward`. A `py-spy` dump shows
 rank 0 stuck in `sched_yield → ur::level_zero::urEventWait` and every
@@ -92,6 +101,14 @@ see `device_id` *absent* from that log line on XPU, you're on the old
 behavior.
 
 ### Custom DeviceMesh on XPU
+
+!!! info "Helper added in v0.18.4"
+
+    `ezpz.init_device_mesh_safe()` is the drop-in replacement, added in
+    [v0.18.4](https://github.com/saforem2/ezpz/releases/tag/v0.18.4)
+    (PR [#149](https://github.com/saforem2/ezpz/pull/149)). On versions
+    older than this, build the mesh dimensions yourself via
+    `torch.distributed.new_group(ranks=...)`.
 
 **Symptom:** Calling `torch.distributed.init_device_mesh(...)` directly
 on Aurora/Sunspot raises:
@@ -130,6 +147,14 @@ already route through `init_device_mesh_safe`, so users on those paths
 get the workaround for free.
 
 ### Hugging Face Datasets — `ArrowInvalid` / `FileNotFoundError` in multi-rank loading
+
+!!! info "Auto-handled in `get_hf_text_dataset` since v0.18.4"
+
+    The rank-0-first barrier landed in
+    [v0.18.4](https://github.com/saforem2/ezpz/releases/tag/v0.18.4)
+    (PR [#149](https://github.com/saforem2/ezpz/pull/149)). If you're on
+    `ezpz.data.hf.get_hf_text_dataset` you get the fix for free; if
+    you're writing your own data loader, use the pattern below.
 
 **Symptom:** Multi-rank job using `datasets.load_dataset` or
 `Dataset.map` on a shared filesystem (`/home`, `/lus`) crashes with one

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,10 +209,22 @@ nav:
   - 🍋 ezpz: index.md
   - 🏃‍♂️ Quickstart: quickstart.md
 
+  - 📚 Guides:
+      - 🎓 Distributed Training Tutorial: guides/distributed-training.md
+      - 🍳 Recipes: recipes.md
+      - 📒 End-to-End Walkthrough: reference.md
+      - 📈 Experiment Tracking (<code>History</code>): history.md
+      - ⚙️ Configuration: configuration.md
+      - ⚖️ vs. torchrun / Accelerate / DeepSpeed: compare.md
+      - 🏗️ Architecture: architecture.md
+      - 🔧 Troubleshooting: troubleshooting.md
+
   - 🧰 CLI:
       - cli/index.md
       - 🚀 <code>ezpz launch</code>: cli/launch/index.md
+      - 📤 <code>ezpz submit</code>: cli/submit.md
       - 💯 <code>ezpz test</code>: cli/test.md
+      - 📊 <code>ezpz benchmark</code>: cli/benchmark.md
       - 🩺 <code>ezpz doctor</code>: cli/doctor.md
       - 📦 <code>ezpz tar-env</code>: cli/tar-env.md
       - 🚀 <code>ezpz yeet</code>: cli/yeet.md


### PR DESCRIPTION
## Summary

Four documentation improvements from the v0.18.5 audit, bundled here because they're all docs-only and don't conflict.

### 1. mkdocs nav — surface orphaned hub pages

Six hub pages and the troubleshooting page were linked extensively from `index.md` / `quickstart.md` but absent from `mkdocs.yml` nav, so users browsing the sidebar never saw them.

Added a new **📚 Guides** group between Quickstart and CLI containing:

- 🎓 Distributed Training Tutorial (`guides/distributed-training.md`)
- 🍳 Recipes (`recipes.md`)
- 📒 End-to-End Walkthrough (`reference.md`)
- 📈 Experiment Tracking — `History` (`history.md`)
- ⚙️ Configuration (`configuration.md`)
- ⚖️ vs. torchrun / Accelerate / DeepSpeed (`compare.md`)
- 🏗️ Architecture (`architecture.md`)
- 🔧 Troubleshooting (`troubleshooting.md`)

Also added the two missing CLI entries: `📤 ezpz submit` and `📊 ezpz benchmark`.

### 2. Version footers on changed behaviors

Pilot the `!!! info "Since v0.18.4"` admonition pattern on four spots that describe behavior introduced or changed in v0.18.4:

- `init_device_mesh_safe` in `docs/python/Code-Reference/distributed.md`
- XPU FSDP2 first-step hang in `docs/troubleshooting.md`
- Custom DeviceMesh on XPU in `docs/troubleshooting.md`
- HF datasets `ArrowInvalid` / `FileNotFoundError` in `docs/troubleshooting.md`

Each admonition links the release tag + PR #149.

### 3. Restructured example pages

`docs/examples/{fsdp,vit,diffusion,hf}.md` were 480–1370-line pages dominated by a top-of-file full-source `--8<--` snippet — anyone visiting saw 800+ lines of unfamiliar code before any narrative.

Each page now leads with three new sections (grounded in the actual source):

- **What this example demonstrates** — 3-5 bullets on the specific concepts shown
- **Expected output** — first ~15 lines of typical output with deliberately-vague placeholders (no fabricated metrics)
- **Common modifications** — 3-5 bullets on what to change and where

The full source snippet is preserved verbatim, relocated to a collapsed `## Source code` section at the bottom. All other existing sections (Code Walkthrough, MFU Tracking, Output, Help) are unchanged.

Also fixed an inaccurate intro in `fsdp.md` that promised `wrap_model(use_fsdp=True)` was the API on display — the actual example uses raw `FullyShardedDataParallel(...)`. The new intro acknowledges both and links each.

`docs/examples/test.md` and `docs/examples/fsdp-tp.md` were left alone (already well-structured).

### 4. README polish

`README.md` was a sparser subset of `index.md`. Added:

- "Why ezpz?" section with one-line comparisons vs torchrun / accelerate / DeepSpeed
- Expanded CLI block (added `ezpz submit`, `ezpz benchmark`)
- "Useful entry points" link block pointing at the docs site's new Guides group

Kept the README skim-length (one screen) but eliminated the gap between what `index.md` covers and what GitHub visitors see first.

## Why now

Did a doc audit after v0.18.5 shipped — the docs site had a coherent landing page (`index.md`) but inconsistent navigation (6 of the most-linked pages were orphaned from the sidebar), inconsistent example depth (3 source-dump pages with no narrative scaffolding), and no consistent way to flag version-specific behavior. This PR addresses all four.

## Test plan

- [x] `git diff --stat`: 8 files, +328/−26
- [x] All new nav entries point to files that exist
- [x] Spot-checked each restructured example page for: (a) exactly one full-source `--8<--` include in `## Source code` at the bottom, (b) no duplication, (c) new sections grounded in real source
- [x] `fsdp.md` intro correctness fix verified against `src/ezpz/examples/fsdp.py` (uses `FSDP(model, ...)` directly, not `wrap_model`)
- [ ] **Render check (mkdocs serve)** — would prefer a maintainer with the docs env confirm the new Guides group renders + the `!!! info` admonitions style correctly. No code changes so behavior is binary-identical.

## Label

`release:skip` — pure docs, no version bump warranted. Same pattern used for #151, #152, #153.

## Followups not in scope

- Full `src/ezpz/bin/utils.sh` reference (~30 public functions) — separate task.
- `inference.md` / `minimal.md` / `hf-trainer/*` restructuring on the same narrative pattern — deferred to keep this PR reviewable.

## Summary by Sourcery

Improve documentation navigation, example discoverability, and versioned behavior callouts while polishing the README and CLI references.

New Features:
- Introduce a Guides section in the docs sidebar and surface previously orphaned hub and troubleshooting pages, plus missing CLI command docs for submit and benchmark.
- Add structured introductory sections to major example pages (FSDP, ViT, diffusion, Hugging Face) describing what each example demonstrates, expected output, and common modifications.

Enhancements:
- Clarify FSDP example documentation to accurately describe the use of FullyShardedDataParallel and its relationship to ezpz.wrap_model.
- Refine README with clearer CLI usage, rationale for using ezpz versus alternatives, and direct links into key documentation entry points.
- Reorganize example documentation so full source is available in collapsible sections at the bottom, improving readability without losing detail.

Documentation:
- Add explicit versioned info admonitions pointing to v0.18.4 and PR #149 for XPU FSDP2 hangs, custom DeviceMesh behavior, and Hugging Face dataset loading fixes in troubleshooting and distributed docs.