### PR TITLE
chore(launch): drop --no-vni from default Aurora/Sunspot mpiexec args

### DIFF
--- a/docs/notes/diagrams.md
+++ b/docs/notes/diagrams.md
@@ -435,8 +435,8 @@ flowchart TD
 
 Different HPC systems need different MPI flags. `pbs.build_launch_cmd()`
 encodes these per-machine defaults so users don't have to remember them —
-Aurora needs `--no-vni` and `--envall`, Polaris needs `--cpu-bind=depth`, and
-Sophia uses `mpirun` instead of `mpiexec`.
+Aurora/Sunspot get the Intel XPU `--cpu-bind=list:...` mask, Polaris gets
+`--cpu-bind=depth`, and Sophia uses `mpirun` instead of `mpiexec`.
 
 ```mermaid
 flowchart LR
@@ -447,7 +447,7 @@ flowchart LR
     build --> polaris{"Polaris / Other?"}
 
     sophia -- yes --> mpirun["mpirun -n N -N PPn --hostfile=..."]
-    aurora -- yes --> mpiexec_aurora["mpiexec --envall --np N --ppn PPn --no-vni"]
+    aurora -- yes --> mpiexec_aurora["mpiexec --envall --np N --ppn PPn --cpu-bind=list:..."]
     polaris -- yes --> mpiexec_pol["mpiexec --cpu-bind=depth --depth=8"]
 ```
 

--- a/docs/notes/pbs.md
+++ b/docs/notes/pbs.md
@@ -79,7 +79,7 @@ To build a PBS-aware launch command (using the current job’s hostfile when ava
 - Detect your active PBS job (if any) and locate its nodefile.
 - Infer topology (`ngpus`, `nhosts`, `ngpu_per_host`) from the hostfile and machine limits unless you override them.
 - Build the correct launcher (`mpiexec`/`mpirun`) with sensible CPU binding:
-  - Intel GPU machines (`aurora`, `sunspot`) get `--no-vni` and vendor binding lists.
+  - Intel GPU machines (`aurora`, `sunspot`) get a vendor-specific CPU binding list.
   - If `CPU_BIND` is set, its value is forwarded verbatim.
   - Otherwise, a generic `--cpu-bind=depth --depth=8` is applied.
 - Optionally inject PBS environment metadata (`PBS_NODEFILE`, host list, launch command) via `get_pbs_env`.

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -1771,7 +1771,9 @@ ezpz_get_dist_launch_cmd() {
 		fi
 		if [[ "${mn}" == "aurora" || "${mn}" == "sunspot" ]]; then
 			CPU_BIND="verbose,list:2-4:10-12:18-20:26-28:34-36:42-44:54-56:62-64:70-72:78-80:86-88:94-96"
-			dist_launch_cmd="${dist_launch_cmd} --no-vni --cpu-bind=${CPU_BIND}"
+			# Note: --no-vni was auto-added here for a transient
+			# network-interface workaround; dropped as of v0.18.x.
+			dist_launch_cmd="${dist_launch_cmd} --cpu-bind=${CPU_BIND}"
 		else
 			dist_launch_cmd="${dist_launch_cmd} --cpu-bind=depth -d ${depth}"
 		fi

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -350,10 +350,14 @@ def _maybe_add_cpu_bind(
         cmd.append(f"--cpu-bind={cpu_bind_val}")
         return cmd
 
-    # No explicit CPU_BIND -> set sensible defaults by machine
+    # No explicit CPU_BIND -> set sensible defaults by machine.
+    # NOTE: `--no-vni` used to be auto-added on Aurora/Sunspot for a
+    # transient network-interface workaround; dropped as of v0.18.x.
+    # Users who still need it can pass it via the launcher
+    # passthrough or set their own CPU_BIND.
     machine_name_l = machine_name.lower()
     if machine_name_l in {"aurora", "sunspot"}:
-        cmd.extend(["--no-vni", f"--cpu-bind={_CPU_BIND_AURORA}"])
+        cmd.append(f"--cpu-bind={_CPU_BIND_AURORA}")
     else:
         cmd.extend(["--cpu-bind=depth", "--depth=8"])
 
@@ -468,12 +472,11 @@ def get_pbs_launch_cmd(
     else:
         is_intel_xpu_machine = machine_name in {"aurora", "sunspot"}
         if is_intel_xpu_machine:
-            cmd_list.extend(
-                [
-                    "--no-vni",
-                    f"{cpu_bind_prefix}{_CPU_BIND_AURORA}",
-                ]
-            )
+            # `--no-vni` was previously auto-added here for a
+            # transient network-interface workaround; dropped as of
+            # v0.18.x. Pass via launcher passthrough or set a custom
+            # CPU_BIND if you still need it.
+            cmd_list.append(f"{cpu_bind_prefix}{_CPU_BIND_AURORA}")
         else:
             # generic CPU binding
             cmd_list.extend(["--cpu-bind=depth", "--depth=8"])

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -81,13 +81,20 @@ def test_get_pbs_launch_cmd_raises_on_inconsistent_topology(patch_topology):
 
 
 def test_get_pbs_launch_cmd_intel_cpu_binding_defaults(patch_topology, monkeypatch):
-    """Intel GPU machines add vendor-specific CPU binding and no-vni flag."""
+    """Intel GPU machines add vendor-specific CPU binding (no longer --no-vni).
+
+    Pre-v0.18.x this also auto-added `--no-vni` for a transient
+    network-interface workaround; that was dropped. Users who still
+    need it can pass it via launcher passthrough or set CPU_BIND.
+    """
     hostfile = patch_topology(machine="aurora")
     monkeypatch.delenv("CPU_BIND", raising=False)
 
     cmd = pbs.get_pbs_launch_cmd(hostfile=hostfile)
 
-    assert "--no-vni" in cmd
+    assert "--no-vni" not in cmd, (
+        "--no-vni should no longer be auto-added on Aurora/Sunspot"
+    )
     assert "--cpu-bind=list:1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100" in cmd
 
 


### PR DESCRIPTION
## Summary

`--no-vni` was auto-added to `mpiexec` invocations on Aurora and Sunspot for a transient network-interface workaround. The flag is no longer needed; drop from the three call sites that injected it by default.

## Three call sites updated

| File | Function | Was |
|---|---|---|
| `src/ezpz/pbs.py` | `_maybe_add_cpu_bind` | `cmd.extend(["--no-vni", f"--cpu-bind={...}"])` → just the cpu-bind |
| `src/ezpz/pbs.py` | `get_pbs_launch_cmd` | parallel removal in the alternate code path |
| `src/ezpz/bin/utils.sh` | `ezpz_get_dist_launch_cmd` | bash equivalent |

## Escape hatch

Users who still need `--no-vni` can:
- Pass it via the launcher passthrough: `ezpz launch --no-vni -- python3 ...`
- Set a custom `CPU_BIND` that includes it

## Tests

`test_get_pbs_launch_cmd_intel_cpu_binding_defaults` flipped from `assert "--no-vni" in cmd` → `assert "--no-vni" not in cmd`. Verified regression-catching by stash-reverting the fix — the test correctly fails when `--no-vni` is reintroduced. **38/38 in test_pbs.py.**

## Docs touched

- `docs/notes/diagrams.md` — removed `--no-vni` from the Aurora mermaid node + reworded the intro sentence
- `docs/notes/pbs.md` — dropped the "get `--no-vni` and vendor binding lists" claim

Historical example outputs in `docs/cli/test.md`, `docs/examples/*`, `docs/notes/pbs.md` (the indented log captures showing `mpiexec ... --no-vni ...`) are **left alone** — those are real captured terminal output from prior runs and shouldn't be retroactively edited.

## Label

`release:patch` — public API unchanged; only the auto-injected default differs.

## Test plan

- [x] `pytest tests/test_pbs.py -q` → 38/38 PASS
- [x] Regression test verified to fail when `--no-vni` is re-added
- [ ] Manual smoke on Aurora: `ezpz launch python3 -c "import ezpz; ezpz.setup_torch()"` — confirm no `--no-vni` in the printed launch command, and the job runs cleanly without it

## Summary by Sourcery

Remove automatic injection of the `--no-vni` flag in Aurora/Sunspot mpiexec launch commands and update tests and docs to reflect the new default behavior.

Enhancements:
- Standardize Intel XPU launch defaults to only apply vendor-specific CPU binding on Aurora/Sunspot without `--no-vni`.
- Document the change in default launch flags and provide guidance for users who still need `--no-vni`.