### PR TITLE
test(top-level-exports): add init_device_mesh_safe to EXPECTED_STATIC_REEXPORTS

### DIFF
--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -52,6 +52,7 @@ EXPECTED_STATIC_REEXPORTS = [
     ("get_world_size", "ezpz.distributed"),
     ("get_world_size_in_use", "ezpz.distributed"),
     ("get_world_size_total", "ezpz.distributed"),
+    ("init_device_mesh_safe", "ezpz.distributed"),
     ("log_dict_as_bulleted_list", "ezpz.distributed"),
     ("print_dist_setup", "ezpz.distributed"),
     ("query_environment", "ezpz.distributed"),


### PR DESCRIPTION
## Summary

One-line fix: add `init_device_mesh_safe` to the `EXPECTED_STATIC_REEXPORTS` list in `tests/test_top_level_exports.py`.

## Background

`init_device_mesh_safe` was added to `ezpz._STATIC_REEXPORTS` as part of v0.18.4's xccl-`split_group` workaround. The drift-guard test (`TestStaticReexports::test_expected_list_matches_runtime_static_reexports`) specifically exists to catch this kind of omission — it asserts the two lists stay in sync so the per-symbol resolution test runs against the full set.

It correctly caught the drift; nobody noticed because **CI doesn't run pytest** (only Documentation / CodeQL / Sourcery). Surfaced locally on a routine `uv run --active pytest`.

## Reproducer

Without this fix, on current `main`:

```
$ uv run --active pytest tests/test_top_level_exports.py
FAILED tests/test_top_level_exports.py::TestStaticReexports::test_expected_list_matches_runtime_static_reexports
AssertionError: ezpz._STATIC_REEXPORTS has names not covered by this test
file's EXPECTED_STATIC_REEXPORTS: ['init_device_mesh_safe'].
```

After this fix: **8/8 in test_top_level_exports.py pass.**

## Label

`release:patch` — test-only change.

## Test plan

- [x] `pytest tests/test_top_level_exports.py -q` → 8/8 PASS

## Out of scope (worth follow-up)

The fact that CI doesn't run `pytest` is the real bug here — a test that exists specifically to catch a class of drift isn't worth much if it doesn't gate merges. Consider adding a `pytest` step to `.github/workflows/ci.yml`. Separate PR.

## Summary by Sourcery

Tests:
- Add init_device_mesh_safe to EXPECTED_STATIC_REEXPORTS in test_top_level_exports to keep tests aligned with runtime static reexports.