### PR TITLE
feat(yeet): retry per-target rsync on transient failures

### DIFF
--- a/src/ezpz/utils/yeet_env.py
+++ b/src/ezpz/utils/yeet_env.py
@@ -626,6 +626,22 @@ _DEFAULT_RSYNC_TIMEOUT = float(os.environ.get("EZPZ_YEET_RSYNC_TIMEOUT", "3600")
 _DEFAULT_RSYNC_RETRIES = int(os.environ.get("EZPZ_YEET_RSYNC_RETRIES", "2"))
 
 
+def _needs_local_copy(src: Path) -> bool:
+    """Return True if `src` needs to be copied to local `/tmp/` first.
+
+    /tmp is node-local on every ALCF system. If src is already there
+    (e.g. a prior yeet copied it, or the user pre-copied), skip the
+    local-copy step and fan out from src directly.
+
+    Extracted from inline logic so tests can monkeypatch the gate
+    deterministically. pytest's `tmp_path` lands under /tmp on Linux
+    runners but `/var/folders/...` on macOS — without this helper,
+    tests using `tmp_path / "fakenv"` as `src` silently exercise
+    different branches on different platforms.
+    """
+    return not str(src).startswith("/tmp")
+
+
 def _detect_rsync_progress_flag() -> list[str]:
     """Pick the right rsync progress flag for the local rsync binary.
 
@@ -1010,8 +1026,14 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
         return 1
 
     # Copy locally first (current node), then rsync to remote nodes.
-    # The local copy is needed because /tmp is node-local.
-    needs_local_copy = not str(src).startswith("/tmp")
+    # The local copy is needed because /tmp is node-local — but if
+    # src is ALREADY under /tmp (e.g. user pre-copied or this is a
+    # second invocation), skip the local step and fan out from src
+    # directly. Extracted as a helper so tests can override the
+    # platform-dependent /tmp prefix (pytest tmp_path lands under
+    # /tmp on Linux runners but /var/folders on macOS — which
+    # silently changes which branch the tests exercise).
+    needs_local_copy = _needs_local_copy(src)
     # Filter out the current node — also handle the HSN variant
     # (current node may appear as "node01" while nodes contain "node01-hsn0").
     current_variants = {current, current + "-hsn0", current.removesuffix("-hsn0")}
@@ -1285,10 +1307,14 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
     # of any caller that has seeded it for their own reasons.
     pick_rng = random.Random()
 
-    # Per-target retry bookkeeping.  Each map entry counts how many
-    # attempts have been made against that node so far (initial attempt
-    # = 0; first retry = 1; etc.).  Capped at _DEFAULT_RSYNC_RETRIES.
-    attempts: dict[str, int] = {n: 0 for n in remaining}
+    # Per-target retry bookkeeping. `retries_done[n]` counts how many
+    # *retries* have been performed against node `n` so far. The
+    # initial attempt is NOT a retry, so this is 0 before the first
+    # try, becomes 1 after the first failure (when we requeue),
+    # becomes 2 after the second failure, etc. Capped at
+    # _DEFAULT_RSYNC_RETRIES so the total attempt count for any node
+    # is at most _DEFAULT_RSYNC_RETRIES + 1.
+    retries_done: dict[str, int] = {n: 0 for n in remaining}
     # Accumulate per-target elapsed time across attempts so the final
     # reported wall-clock isn't just the last attempt's duration.
     elapsed_total: dict[str, float] = {n: 0.0 for n in remaining}
@@ -1335,18 +1361,23 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
                     # This node now has the data — register as a source
                     source_active[n] = 0
 
-            if rc != 0 and attempts[n] < _DEFAULT_RSYNC_RETRIES:
+            if rc != 0 and retries_done[n] < _DEFAULT_RSYNC_RETRIES:
                 # Transient failure — requeue for another attempt.
                 # Don't mark_done yet (final outcome still pending) and
                 # don't append to results yet.  Note we *don't* register
                 # this node as a source (rc != 0 branch above).
-                attempts[n] += 1
+                retries_done[n] += 1
+                # Human-readable attempt count: 1 (initial) + retries
+                # done so far. So after the first failure: attempt
+                # 1/(N+1) of N+1 budgeted.
+                attempt_human = retries_done[n]  # we just incremented
+                total_budgeted = _DEFAULT_RSYNC_RETRIES + 1
                 logger.warning(
                     "rsync to %s failed (attempt %d/%d, rc=%d) — "
                     "requeueing for retry",
                     n,
-                    attempts[n],
-                    _DEFAULT_RSYNC_RETRIES + 1,
+                    attempt_human,
+                    total_budgeted,
                     rc,
                 )
                 with source_lock:

--- a/src/ezpz/utils/yeet_env.py
+++ b/src/ezpz/utils/yeet_env.py
@@ -615,6 +615,16 @@ def _patch_venv_paths_local(dst: Path, src: Path) -> None:
 # accommodates large envs over slow links; bump via env var if needed.
 _DEFAULT_RSYNC_TIMEOUT = float(os.environ.get("EZPZ_YEET_RSYNC_TIMEOUT", "3600"))
 
+# Per-target retry count for transient rsync failures.  At scale (256N+),
+# a small fraction of nodes will fail with `Connection reset by ... port
+# 22` or similar transient SSH errors that succeed on a second attempt.
+# Without retries, a single bad node fails the whole `ezpz yeet`, which
+# in turn fails the downstream training script.  Default 2 retries (3
+# total attempts) catches the vast majority of these without unbounded
+# pile-up on a truly dead node.  Set to 0 to restore the prior
+# fail-fast-after-first-attempt behavior.
+_DEFAULT_RSYNC_RETRIES = int(os.environ.get("EZPZ_YEET_RSYNC_RETRIES", "2"))
+
 
 def _detect_rsync_progress_flag() -> list[str]:
     """Pick the right rsync progress flag for the local rsync binary.
@@ -1275,6 +1285,14 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
     # of any caller that has seeded it for their own reasons.
     pick_rng = random.Random()
 
+    # Per-target retry bookkeeping.  Each map entry counts how many
+    # attempts have been made against that node so far (initial attempt
+    # = 0; first retry = 1; etc.).  Capped at _DEFAULT_RSYNC_RETRIES.
+    attempts: dict[str, int] = {n: 0 for n in remaining}
+    # Accumulate per-target elapsed time across attempts so the final
+    # reported wall-clock isn't just the last attempt's duration.
+    elapsed_total: dict[str, float] = {n: 0.0 for n in remaining}
+
     def _submit_work(pool: ThreadPoolExecutor, futures: dict) -> None:  # type: ignore[type-arg]
         """Submit as many rsyncs as sources allow."""
         while remaining:
@@ -1309,6 +1327,7 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
             fut = next(done_iter)
             n, elapsed, rc = fut.result()
             _, src_used = futures.pop(fut)
+            elapsed_total[n] = elapsed_total.get(n, 0.0) + elapsed
 
             with source_lock:
                 source_active[src_used] -= 1
@@ -1316,9 +1335,28 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
                     # This node now has the data — register as a source
                     source_active[n] = 0
 
+            if rc != 0 and attempts[n] < _DEFAULT_RSYNC_RETRIES:
+                # Transient failure — requeue for another attempt.
+                # Don't mark_done yet (final outcome still pending) and
+                # don't append to results yet.  Note we *don't* register
+                # this node as a source (rc != 0 branch above).
+                attempts[n] += 1
+                logger.warning(
+                    "rsync to %s failed (attempt %d/%d, rc=%d) — "
+                    "requeueing for retry",
+                    n,
+                    attempts[n],
+                    _DEFAULT_RSYNC_RETRIES + 1,
+                    rc,
+                )
+                with source_lock:
+                    remaining.append(n)
+                _submit_work(pool, futures)
+                continue
+
             label = f"{n} (local)" if n == current else n
-            progress.mark_done(label, elapsed, rc)
-            results.append((n, elapsed, rc))
+            progress.mark_done(label, elapsed_total[n], rc)
+            results.append((n, elapsed_total[n], rc))
 
             # Submit more work now that a source slot freed up
             # (and possibly a new source appeared)

--- a/tests/test_yeet_env.py
+++ b/tests/test_yeet_env.py
@@ -145,6 +145,146 @@ class TestRsyncToNode:
 
 
 # ===================================================================
+# rsync retry on transient failure
+# ===================================================================
+
+
+class TestRsyncRetry:
+    """Verify the per-target retry loop in the fan-out completion handler.
+
+    The retry block lives inside ``run()`` (an end-to-end orchestrator
+    that does tarball detection, ssh-extracts, etc.) so we can't easily
+    unit-test it in isolation. Instead, mock ``_rsync_to_node`` at the
+    module boundary and drive the full pipeline against a fake hostfile.
+    """
+
+    def _make_hostfile(self, tmp_path, nodes):
+        hf = tmp_path / "hostfile"
+        hf.write_text("\n".join(nodes) + "\n")
+        return hf
+
+    def _make_src(self, tmp_path):
+        """Build a minimal venv-shaped dir so run() recognizes it."""
+        src = tmp_path / "fakenv"
+        (src / "bin").mkdir(parents=True)
+        (src / "bin" / "activate").write_text("# fake activate\n")
+        (src / "pyvenv.cfg").write_text(
+            "home = /usr/bin\nversion = 3.12.0\n"
+        )
+        return src
+
+    def test_retry_succeeds_on_second_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        """One node fails initially then succeeds on retry — final state
+        should record rc=0 for that node, not a failure."""
+        # Fail-then-succeed sequence per target node.
+        # Map: node -> list of returncodes to return on each call.
+        call_log = {"node01": [], "node02": []}
+        flake_count = {"node01": 0}  # node01 fails its first attempt
+
+        def fake_rsync(src, dst, node, **kwargs):
+            call_log.setdefault(node, []).append(node)
+            if node == "node01" and flake_count[node] < 1:
+                flake_count[node] += 1
+                return (node, 0.1, 255)  # transient ssh fail
+            return (node, 0.2, 0)
+
+        # Force retries=2 (default) so we have headroom; ensure rsync
+        # local-copy step succeeds too.
+        monkeypatch.setattr(yeet, "_DEFAULT_RSYNC_RETRIES", 2)
+        monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
+        # Bypass real hostname detection.
+        monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        # Skip the local venv-paths patcher (only relevant after a real copy).
+        monkeypatch.setattr(
+            yeet, "_patch_venv_paths_local", lambda dst, src: None
+        )
+
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(tmp_path, ["node00", "node01", "node02"])
+
+        rc = yeet.run(["--src", str(src), "--dst", str(dst),
+                       "--hostfile", str(hf)])
+
+        # The wrapper should have retried node01 and the whole run
+        # should succeed.
+        assert rc == 0, "run() should return 0 when retries recover"
+        # node01 should have been attempted twice (initial + 1 retry);
+        # node02 should have been attempted once.
+        assert len(call_log["node01"]) == 2
+        assert len(call_log["node02"]) == 1
+
+    def test_retry_exhausted_records_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """A persistently failing node should be retried RETRIES extra
+        times, then recorded as a final failure (not infinite loop)."""
+        call_log = {"badnode": []}
+
+        def fake_rsync(src, dst, node, **kwargs):
+            call_log.setdefault(node, []).append(node)
+            if node == "badnode":
+                return (node, 0.1, 255)  # always fails
+            return (node, 0.2, 0)
+
+        monkeypatch.setattr(yeet, "_DEFAULT_RSYNC_RETRIES", 2)
+        monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
+        monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        monkeypatch.setattr(
+            yeet, "_patch_venv_paths_local", lambda dst, src: None
+        )
+
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "badnode", "goodnode"]
+        )
+
+        yeet.run(["--src", str(src), "--dst", str(dst),
+                  "--hostfile", str(hf)])
+
+        # badnode should have been attempted exactly RETRIES + 1 = 3 times
+        # (1 initial + 2 retries), then bounded — not infinite.
+        assert len(call_log["badnode"]) == 3, (
+            f"expected 3 attempts on badnode "
+            f"(1 initial + 2 retries), got {len(call_log['badnode'])}"
+        )
+
+    def test_retries_zero_restores_fail_fast(
+        self, tmp_path, monkeypatch
+    ):
+        """Setting RETRIES=0 should disable retries (one attempt only)."""
+        call_log = {"flakynode": []}
+
+        def fake_rsync(src, dst, node, **kwargs):
+            call_log.setdefault(node, []).append(node)
+            if node == "flakynode":
+                return (node, 0.1, 255)
+            return (node, 0.2, 0)
+
+        monkeypatch.setattr(yeet, "_DEFAULT_RSYNC_RETRIES", 0)
+        monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
+        monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        monkeypatch.setattr(
+            yeet, "_patch_venv_paths_local", lambda dst, src: None
+        )
+
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "flakynode"]
+        )
+
+        yeet.run(["--src", str(src), "--dst", str(dst),
+                  "--hostfile", str(hf)])
+
+        # flakynode should be attempted exactly once (no retries)
+        assert len(call_log["flakynode"]) == 1
+
+
+# ===================================================================
 # parse_args
 # ===================================================================
 

--- a/tests/test_yeet_env.py
+++ b/tests/test_yeet_env.py
@@ -196,6 +196,13 @@ class TestRsyncRetry:
         monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
         # Bypass real hostname detection.
         monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        # Force the local-copy path regardless of platform. Without
+        # this, pytest's tmp_path under /tmp on Linux runners makes
+        # run() skip the local-copy step and fan out from `dst`
+        # directly — a different code path than the test claims to
+        # model. On macOS tmp_path is under /var/folders so this is
+        # already True, but pin it for consistency.
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: True)
         # Skip the local venv-paths patcher (only relevant after a real copy).
         monkeypatch.setattr(
             yeet, "_patch_venv_paths_local", lambda dst, src: None
@@ -232,6 +239,7 @@ class TestRsyncRetry:
         monkeypatch.setattr(yeet, "_DEFAULT_RSYNC_RETRIES", 2)
         monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
         monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: True)
         monkeypatch.setattr(
             yeet, "_patch_venv_paths_local", lambda dst, src: None
         )
@@ -242,8 +250,15 @@ class TestRsyncRetry:
             tmp_path, ["node00", "badnode", "goodnode"]
         )
 
-        yeet.run(["--src", str(src), "--dst", str(dst),
-                  "--hostfile", str(hf)])
+        rc = yeet.run(["--src", str(src), "--dst", str(dst),
+                       "--hostfile", str(hf)])
+
+        # run() must report failure (non-zero rc) when any node
+        # exhausts retries — otherwise a regression that silently
+        # returns 0 despite failed nodes would slip through and
+        # downstream training would burn its allocation thinking
+        # yeet succeeded.
+        assert rc != 0, "run() must return non-zero when a node exhausts retries"
 
         # badnode should have been attempted exactly RETRIES + 1 = 3 times
         # (1 initial + 2 retries), then bounded — not infinite.
@@ -267,6 +282,7 @@ class TestRsyncRetry:
         monkeypatch.setattr(yeet, "_DEFAULT_RSYNC_RETRIES", 0)
         monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
         monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: True)
         monkeypatch.setattr(
             yeet, "_patch_venv_paths_local", lambda dst, src: None
         )
@@ -277,8 +293,13 @@ class TestRsyncRetry:
             tmp_path, ["node00", "flakynode"]
         )
 
-        yeet.run(["--src", str(src), "--dst", str(dst),
-                  "--hostfile", str(hf)])
+        rc = yeet.run(["--src", str(src), "--dst", str(dst),
+                       "--hostfile", str(hf)])
+
+        # With RETRIES=0 and a permanently-failing node, run() must
+        # return non-zero — this pins the fail-fast contract that
+        # `--retries 0` is meant to restore.
+        assert rc != 0, "run() must return non-zero when retries=0 and a node fails"
 
         # flakynode should be attempted exactly once (no retries)
         assert len(call_log["flakynode"]) == 1


### PR DESCRIPTION
## Why

At scale (256N+ allocations), a small fraction of nodes will fail their
rsync with `Connection reset by ... port 22` or similar transient SSH
errors that succeed on a second attempt. Without retries, a **single**
bad node fails the whole `ezpz yeet`, and any downstream training
script that bails on yeet-env partial failure burns its entire
allocation never having entered the training loop.

This actually happened to me last night (production job
`agpt-2b-n512-v2-failover-sync-cont9`, 522 nodes):

```
[2026-06-07 21:21:27][W][utils/yeet_env:851:_rsync_to_node]
  rsync to x4112c1s7b0n0-hsn0 failed (exit 255):
  Connection reset by 10.112.164.235 port 22
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: unexplained error (code 255) at io.c(228) [sender=3.2.3]
    ✗ x4112c1s7b0n0-hsn0 — 120.7s
[2026-06-07 21:21:27][W][utils/yeet_env:1332:run] 1/522 node(s) failed!
```

521 of 522 nodes succeeded in ~20s each. One node's rsync hit
`Connection reset` at the 120s timeout, yeet reported the failure,
training script bailed before `mpiexec` was even invoked — ~8 min of a
12h allocation wasted.

## What

Add a per-target retry loop in the fan-out completion handler:

- On `rc != 0`, requeue the target up to `EZPZ_YEET_RSYNC_RETRIES`
  more times (default `2` retries = 3 total attempts) before recording
  the final failure.
- Per-target elapsed time accumulates across attempts so the reported
  wall-clock isn't just the last attempt's duration.
- Failed-during-retry nodes don't become rsync sources (existing
  `rc == 0` guard already handles this — `source_active` only gets
  the target entry on success).
- Set `EZPZ_YEET_RSYNC_RETRIES=0` to restore the prior
  fail-fast-after-first-attempt behavior.

Default of 2 retries was chosen because:
- 1 retry catches the single-attempt transient (the failure mode I saw).
- 2 retries adds a buffer for the case where the second SSH ping
  also times out before the underlying network blip clears.
- 3+ retries piles up on a truly dead node — by then it's not a blip,
  it's hardware.

## Tests

`tests/test_yeet_env.py::TestRsyncRetry` — three cases that mock
`_rsync_to_node` and drive `run()` end-to-end:

- `test_retry_succeeds_on_second_attempt` — mocked node fails once
  with `rc=255`, succeeds on retry. `run()` returns 0; retried node
  attempted exactly twice.
- `test_retry_exhausted_records_failure` — mocked node always fails;
  attempts cap at `RETRIES+1 = 3`, no infinite loop.
- `test_retries_zero_restores_fail_fast` — `RETRIES=0` disables
  retries (one attempt only).

(Tests don't run on Aurora login nodes — local MPI auto-inits on Python
import and aborts. They are expected to pass on CI / inside a real
PBS allocation.)

## Smoke

Patched ezpz installed into the torchtitan-ezpz production `.venv`,
tarball rebuilt, smoke job `8530108` (8N debug-scaling) running now to
confirm the no-failure path still works end-to-end. Once that passes,
will deploy to the `/flare/.../agpt-{2b,20b,80b}-v2/` production
venvs so chains pick up the retry behavior on the next continuation.