### PR TITLE
feat(yeet): --min-success-nodes / --min-success-fraction for proceed-with-spares

### DIFF
--- a/docs/cli/yeet.md
+++ b/docs/cli/yeet.md
@@ -188,8 +188,8 @@ ezpz yeet [SRC] [--src PATH] [--dst PATH] [--hostfile PATH]
 | `--copy` | — | Use `cp -a` for the local copy (faster on Lustre) |
 | `--compress` | — | tar.gz → copy → extract (least Lustre metadata I/O) |
 | `--dry-run` | — | Preview without transferring |
-| `--min-success-nodes N` | — | Return rc=0 if at least N nodes succeed (the rest are written to a sentinel file). See [proceed with spares](#proceed-with-spares-min-success-nodes-min-success-fraction). Mutually exclusive with `--min-success-fraction`. |
-| `--min-success-fraction F` | — | Same as `--min-success-nodes` but as a fraction of the total node count (e.g. `0.95` = ≥95%). Computed as `ceil(F × total_nodes)`. |
+| `--min-success-nodes N` | — | Hard lower bound: return rc=0 iff at least N nodes succeed. Failures (if any, up to `total − N`) are written to a sentinel file. See [proceed with spares](#proceed-with-spares-min-success-nodes-min-success-fraction). Mutually exclusive with `--min-success-fraction`. |
+| `--min-success-fraction F` | — | Same as `--min-success-nodes` but as a fraction of the **hostfile node count** (e.g. `0.95` = ≥95%). Resolves to `ceil(F × len(hostfile))`. |
 
 There's also one **environment variable**:
 
@@ -540,8 +540,17 @@ ezpz yeet --min-success-nodes 512
 ezpz yeet --min-success-fraction 0.95   # ≥ 95% must succeed
 ```
 
-The two flags are mutually exclusive. With a fraction, the absolute
-count is `ceil(fraction × total_nodes)`.
+The two flags are mutually exclusive. With a fraction, the
+absolute count is `ceil(fraction × len(hostfile))` — the
+**hostfile node count**, not the number of rsync operations
+(which can be 1 lower when the local-copy step is skipped
+because `src` is already under `/tmp`).
+
+**Hard lower bound.** Either flag enforces a hard floor on the
+success count: even a clean run (zero failures) returns rc=1 if
+fewer than `threshold` nodes were actually synced. Otherwise
+`--min-success-nodes 512` on a 500-node hostfile would silently
+succeed and downstream training would under-provision.
 
 When the threshold is met **and** there were failures, yeet:
 
@@ -562,11 +571,17 @@ When the threshold is met **and** there were failures, yeet:
    fi
    ```
 
+**Stale-sentinel safety.** Yeet always removes any pre-existing
+`$dst/.ezpz-yeet-failed-nodes.txt` at the start of finalization,
+then re-writes it only when proceeding-with-spares. So the file's
+presence is a definitive "yeet just succeeded but here are the
+hosts that didn't make it on this run" — never a stale list from
+a previous invocation that's since been cleaned up. This matters
+when re-running into the same `dst` (common when `src` is already
+under `/tmp` and the local-copy step is skipped on the second run).
+
 When the threshold is NOT met, behavior is unchanged — yeet returns
-rc=1 and no sentinel file is written. The sentinel only appears
-when we're proceeding-despite-failures, so downstream readers can
-treat its presence as definitive: "yeet succeeded but some hosts
-were dropped — here they are."
+rc=1 and no sentinel file is written.
 
 Without either flag the original fail-on-any behavior is preserved.
 
@@ -756,15 +771,19 @@ ezpz launch $HOSTFILE_ARG -- python3 -m my.train
 
 | Scenario | `ezpz yeet` rc | Sentinel file | Outcome |
 |---|---|---|---|
-| All 522 nodes succeed | 0 | not written | Train on 522 nodes |
-| 521 succeed, 1 transient fail recovers via retry | 0 | not written (retry path doesn't write it) | Train on 522 nodes |
-| 520 succeed, 2 permanent fails (threshold 512 met) | 0 | written with the 2 hostnames | Train on 520 nodes |
-| 500 succeed, 22 permanent fails (threshold 512 missed) | 1 | not written | Abort — user investigates |
+| All 522 nodes succeed | 0 | removed if stale, otherwise absent | Train on 522 nodes |
+| 521 succeed, 1 transient fail recovers via retry | 0 | removed if stale (retry path = no failure) | Train on 522 nodes |
+| 520 succeed, 2 permanent fails (threshold 512 met) | 0 | **written with the 2 hostnames** | Train on 520 nodes |
+| 500 succeed, 22 permanent fails (threshold 512 missed) | 1 | removed if stale | Abort — user investigates |
+| 511 succeed, 0 fails but hostfile only has 511 nodes | **1** | not written | Abort — `--min-success-nodes 512` is a hard floor |
 
 The sentinel file is **only** written when `yeet` is exiting
 successfully despite failures, so its presence is a definitive
 "yeet survived but here's who didn't make it" signal — never
-stale data from a previous run that's since been cleaned up.
+stale data from a previous run. Yeet unconditionally removes
+any pre-existing sentinel at the start of finalization, so the
+absence of the file means "no failures to report" regardless of
+what a previous run wrote.
 
 ## See Also
 

--- a/docs/cli/yeet.md
+++ b/docs/cli/yeet.md
@@ -176,6 +176,7 @@ section](#scaling-aurora-8-4096-nodes)).
 ```
 ezpz yeet [SRC] [--src PATH] [--dst PATH] [--hostfile PATH]
               [--copy | --compress] [--dry-run]
+              [--min-success-nodes N | --min-success-fraction F]
 ```
 
 | Arg / Flag | Default | Description |
@@ -187,6 +188,14 @@ ezpz yeet [SRC] [--src PATH] [--dst PATH] [--hostfile PATH]
 | `--copy` | — | Use `cp -a` for the local copy (faster on Lustre) |
 | `--compress` | — | tar.gz → copy → extract (least Lustre metadata I/O) |
 | `--dry-run` | — | Preview without transferring |
+| `--min-success-nodes N` | — | Return rc=0 if at least N nodes succeed (the rest are written to a sentinel file). See [proceed with spares](#proceed-with-spares-min-success-nodes-min-success-fraction). Mutually exclusive with `--min-success-fraction`. |
+| `--min-success-fraction F` | — | Same as `--min-success-nodes` but as a fraction of the total node count (e.g. `0.95` = ≥95%). Computed as `ceil(F × total_nodes)`. |
+
+There's also one **environment variable**:
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `EZPZ_YEET_RSYNC_RETRIES` | `2` | Per-target rsync retry budget for transient SSH/rsync failures (e.g. `Connection reset by ... port 22`). Each failed rsync gets up to N additional attempts before being marked as a final failure. Set to `0` to restore fail-fast-on-first-error. |
 
 !!! tip "Choosing a local copy method"
 
@@ -561,6 +570,13 @@ were dropped — here they are."
 
 Without either flag the original fail-on-any behavior is preserved.
 
+!!! tip "Worked example at scale"
+
+    See [At scale: surviving 1-2 bad nodes per allocation](#at-scale-surviving-1-2-bad-nodes-per-allocation)
+    for a complete end-to-end snippet (522 nodes → train on 520
+    when 2 fail), plus a behavior table covering each
+    success/failure scenario.
+
 ## Examples
 
 ### Default: sync the active env
@@ -692,6 +708,63 @@ under 1 minute through 1024 nodes and only really starts to climb at
 2048+ — consistent with `init_process_group` overhead growing with
 world size. At 4096 nodes the first step lands in 3 min 14 s, so
 total time-to-train (yeet + first step) is about 16 minutes.
+
+### At scale: surviving 1-2 bad nodes per allocation
+
+At 256+ nodes, it's near-certain that 1-2 nodes will fail
+permanently with SSH issues that retries can't recover (cable
+problems, daemon stuck, etc.). Without the proceed-with-spares
+flags from [Error handling](#error-handling), a single bad node
+fails the whole `yeet` even though the user usually has spare
+allocation to absorb the loss.
+
+Worked example: 522 nodes allocated on Aurora, only 512 actually
+needed for training:
+
+```bash
+# 1. Yeet with a threshold matching the actual training need.
+#    Transient failures are auto-retried (PR #160's logic) up to
+#    EZPZ_YEET_RSYNC_RETRIES times per node; the threshold only
+#    fires for nodes that exhaust retries.
+ezpz yeet --src .venv.tar.gz --min-success-nodes 512
+RC=$?
+
+# 2. yeet returns 0 with the failed-node list co-located with dst.
+if [[ $RC -ne 0 ]]; then
+    echo "yeet did not meet the threshold; aborting"
+    exit 1
+fi
+
+DST=/tmp/.venv  # the default --dst
+FAILED=$(cat "$DST"/.ezpz-yeet-failed-nodes.txt 2>/dev/null || true)
+
+# 3. Build a launch hostfile that excludes the failed nodes.
+#    `grep -vFf` filters PBS_NODEFILE against the failures.
+if [[ -n "$FAILED" ]]; then
+    echo "yeet succeeded but $FAILED was unreachable; excluding from launch"
+    grep -vFf <(echo "$FAILED") "$PBS_NODEFILE" > /tmp/hostfile-good
+    HOSTFILE_ARG="--hostfile /tmp/hostfile-good"
+else
+    HOSTFILE_ARG=""  # no failures → use default PBS_NODEFILE
+fi
+
+# 4. Launch training with the (possibly filtered) hostfile.
+ezpz launch $HOSTFILE_ARG -- python3 -m my.train
+```
+
+**What happens in practice:**
+
+| Scenario | `ezpz yeet` rc | Sentinel file | Outcome |
+|---|---|---|---|
+| All 522 nodes succeed | 0 | not written | Train on 522 nodes |
+| 521 succeed, 1 transient fail recovers via retry | 0 | not written (retry path doesn't write it) | Train on 522 nodes |
+| 520 succeed, 2 permanent fails (threshold 512 met) | 0 | written with the 2 hostnames | Train on 520 nodes |
+| 500 succeed, 22 permanent fails (threshold 512 missed) | 1 | not written | Abort — user investigates |
+
+The sentinel file is **only** written when `yeet` is exiting
+successfully despite failures, so its presence is a definitive
+"yeet survived but here's who didn't make it" signal — never
+stale data from a previous run that's since been cleaned up.
 
 ## See Also
 

--- a/docs/cli/yeet.md
+++ b/docs/cli/yeet.md
@@ -508,9 +508,58 @@ mode skips rsync entirely on the local step and is often a win.
 - **rsync exit 24** (vanished files): treated as success. This
   happens when concurrent rsyncs read from the same `/tmp/` source
   while temporary files (e.g. triton plugin builds) come and go.
+- **Transient rsync failures** (e.g. `Connection reset by ... port
+  22`): per-target retry up to `$EZPZ_YEET_RSYNC_RETRIES` (default 2)
+  times. Set to 0 to restore fail-fast.
 - **TTY-aware progress**: spinner and `\r` carriage returns are
   suppressed when stdout is not a terminal (e.g. redirected to a
   file), preventing garbled output in logs.
+
+### Proceed with spares (`--min-success-nodes` / `--min-success-fraction`)
+
+At scale (256N+ allocations), it's common for 1-2 nodes to fail
+permanently with SSH issues that retries can't recover. Without an
+opt-in, a single bad node fails the whole `yeet` even when the
+caller has spare allocation. Two flags relax this:
+
+```bash
+# Require at least 512 nodes to succeed (out of however many the
+# hostfile contains). Returns rc=0 as long as ≥ 512 ok.
+ezpz yeet --min-success-nodes 512
+
+# Same idea but as a fraction of the total node count:
+ezpz yeet --min-success-fraction 0.95   # ≥ 95% must succeed
+```
+
+The two flags are mutually exclusive. With a fraction, the absolute
+count is `ceil(fraction × total_nodes)`.
+
+When the threshold is met **and** there were failures, yeet:
+
+1. Returns rc=0
+2. Writes the list of failed hostnames to **`$dst/.ezpz-yeet-failed-nodes.txt`**
+   (one host per line) so downstream tooling (training scripts,
+   `ezpz launch` wrappers) can read and exclude those hosts. Example
+   consumer:
+
+   ```bash
+   FAILED=$(cat "$DST"/.ezpz-yeet-failed-nodes.txt 2>/dev/null || true)
+   if [[ -n "$FAILED" ]]; then
+     # Build a hostfile that excludes the yeet failures:
+     grep -vFf <(echo "$FAILED") "$PBS_NODEFILE" > /tmp/hostfile-good
+     ezpz launch --hostfile /tmp/hostfile-good -- python3 -m my.train
+   else
+     ezpz launch -- python3 -m my.train
+   fi
+   ```
+
+When the threshold is NOT met, behavior is unchanged — yeet returns
+rc=1 and no sentinel file is written. The sentinel only appears
+when we're proceeding-despite-failures, so downstream readers can
+treat its presence as definitive: "yeet succeeded but some hosts
+were dropped — here they are."
+
+Without either flag the original fail-on-any behavior is preserved.
 
 ## Examples
 

--- a/src/ezpz/utils/yeet_env.py
+++ b/src/ezpz/utils/yeet_env.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import atexit
 import logging
+import math
 import os
 import random
 import shlex
@@ -1456,36 +1457,75 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
     else:
         logger.info("Done in %.1fs", total_elapsed)
 
-    # Resolve the proceed-with-spares threshold. If neither flag is
-    # set, the threshold equals total_nodes (i.e. ALL must succeed —
-    # original fail-on-any behavior). If --min-success-fraction is
-    # set, derive an absolute count via ceil (so 0.95 of 100 = 95,
-    # not 95.0 ambiguity). --min-success-nodes wins as-is.
+    # Resolve the proceed-with-spares threshold.
+    #
+    # IMPORTANT: --min-success-fraction computes against the FULL
+    # hostfile node count (`len(nodes)`), NOT `total_nodes` (which
+    # is the rsync-op count — smaller by 1 when needs_local_copy is
+    # False because the local node isn't rsync'd to). This matches
+    # the docs' promise that the fraction is "of the total node
+    # count", which is the user-mental-model for a hostfile of N
+    # nodes regardless of which of those N happen to be the
+    # launcher's local host.
+    #
+    # --min-success-nodes is a HARD lower bound: it MUST be met
+    # regardless of whether there were failures. A clean run that
+    # only synced to 500 nodes when the user asked for >= 512
+    # MUST fail loudly, not silently under-provision downstream
+    # experiments (codex P2).
+    hostfile_node_count = len(nodes)
+
     if args.min_success_nodes is not None:
         threshold = args.min_success_nodes
         threshold_src = f"--min-success-nodes={args.min_success_nodes}"
     elif args.min_success_fraction is not None:
-        import math
-        threshold = math.ceil(args.min_success_fraction * total_nodes)
+        threshold = math.ceil(
+            args.min_success_fraction * hostfile_node_count
+        )
         threshold_src = (
             f"--min-success-fraction={args.min_success_fraction} "
-            f"× {total_nodes} = {threshold}"
+            f"× {hostfile_node_count} = {threshold}"
         )
     else:
+        # No flag → threshold equals total rsync ops (original
+        # fail-on-any-failure behavior preserved).
         threshold = total_nodes
         threshold_src = "default (all nodes must succeed)"
 
-    proceed_with_spares = (
-        failed > 0 and len(ok_nodes) >= threshold
-    )
+    # The threshold is met when at least `threshold` rsyncs
+    # succeeded. proceed_with_spares is True iff:
+    #   - we have at least one failure (otherwise sentinel path is
+    #     a no-op even if threshold is met), AND
+    #   - the threshold is met
+    threshold_met = len(ok_nodes) >= threshold
+    proceed_with_spares = failed > 0 and threshold_met
 
-    # Write the failed-nodes sentinel file when (a) we have failures
-    # and (b) the threshold is satisfied (i.e. we're proceeding
-    # despite the failures). The path is under `dst` for symmetry
-    # with the rest of the yeeted content. Downstream consumers
-    # (training scripts, ezpz launch wrappers) can read + exclude.
+    # ── Sentinel cleanup + write ────────────────────────────────────
+    # ALWAYS remove a stale sentinel from a prior run first. Without
+    # this, re-running into the same `dst` (common when `src` is
+    # already under /tmp and the local-copy step is skipped) would
+    # leave behind the previous run's failed-node list, and the
+    # documented downstream snippet would incorrectly exclude hosts
+    # that aren't actually problematic on this run (codex/copilot
+    # P2). Only re-write when proceed_with_spares is True.
+    sentinel_path = dst / ".ezpz-yeet-failed-nodes.txt"
+    try:
+        sentinel_path.unlink(missing_ok=True)
+    except OSError as exc:
+        # We can't proceed safely with a stale sentinel — fail
+        # rather than risk downstream tooling reading wrong data.
+        # Most likely a permissions issue or dst-doesn't-exist
+        # (the latter shouldn't happen since the sync wrote there
+        # successfully, but be defensive).
+        logger.error(
+            "Could not remove possibly-stale sentinel %s: %s. "
+            "Refusing to proceed — fix the permissions then retry.",
+            sentinel_path,
+            exc,
+        )
+        return 1
+
     if proceed_with_spares:
-        sentinel_path = dst / ".ezpz-yeet-failed-nodes.txt"
         try:
             sentinel_path.parent.mkdir(parents=True, exist_ok=True)
             sentinel_path.write_text(
@@ -1493,7 +1533,7 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
             )
             logger.warning(
                 "Proceeding despite %d failure(s) — threshold met "
-                "(%d/%d nodes ok, need >=%d). Failed nodes (%s) "
+                "(%d/%d nodes ok, need >=%d via %s). Failed nodes "
                 "written to %s",
                 failed,
                 len(ok_nodes),
@@ -1507,9 +1547,11 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
             # we couldn't write the bookkeeping file. Log loudly so
             # the user knows the file is missing.
             logger.warning(
-                "Threshold met (%d/%d ok) but couldn't write "
-                "failed-nodes file at %s: %s. Failed nodes were: %s",
-                len(ok_nodes), total_nodes, sentinel_path, exc,
+                "Threshold met (%d/%d ok via %s) but couldn't "
+                "write failed-nodes file at %s: %s. Failed nodes "
+                "were: %s",
+                len(ok_nodes), total_nodes, threshold_src,
+                sentinel_path, exc,
                 ", ".join(failed_nodes),
             )
 
@@ -1556,14 +1598,30 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
         print(f"  not see writes from worker nodes.")
 
     # rc semantics:
-    #   no failures               → 0 (always)
-    #   failures + threshold met  → 0 (with sentinel file written above)
-    #   failures + threshold miss → 1 (original behavior)
-    if failed == 0:
+    #
+    # When --min-success-* is set, the threshold is a HARD lower
+    # bound: it MUST be met regardless of failure count. Otherwise
+    # `yeet --min-success-nodes 512` on a 500-node hostfile with
+    # all 500 ok would return 0 and silently under-provision the
+    # downstream training (codex P2).
+    #
+    #   no flag set:        original behavior — 0 iff no failures
+    #   threshold set:      0 iff threshold met (regardless of `failed`)
+    threshold_explicitly_set = (
+        args.min_success_nodes is not None
+        or args.min_success_fraction is not None
+    )
+    if threshold_explicitly_set:
+        if not threshold_met:
+            logger.error(
+                "Threshold NOT met: only %d/%d nodes succeeded, "
+                "need >=%d via %s",
+                len(ok_nodes), total_nodes, threshold, threshold_src,
+            )
+            return 1
         return 0
-    if proceed_with_spares:
-        return 0
-    return 1
+    # Default path: original fail-on-any behavior.
+    return 1 if failed else 0
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/src/ezpz/utils/yeet_env.py
+++ b/src/ezpz/utils/yeet_env.py
@@ -958,6 +958,43 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="Show what would be synced without doing it.",
     )
+
+    # Proceed-with-spares: when set, yeet returns 0 even if some
+    # nodes failed, as long as the success count meets the threshold.
+    # Useful at scale where 1-2 nodes always fail with permanent SSH
+    # issues and the user has spare allocation. The failed-nodes list
+    # is written to $dst/.ezpz-yeet-failed-nodes.txt so downstream
+    # tooling (training scripts, ezpz launch wrappers) can read +
+    # exclude those hosts. Mutually exclusive flags.
+    threshold = parser.add_mutually_exclusive_group()
+    threshold.add_argument(
+        "--min-success-nodes",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Return success (rc=0) as long as at least N nodes "
+            "received the rsync successfully, even if some "
+            "failed. The failed-node list is written to "
+            "$dst/.ezpz-yeet-failed-nodes.txt for downstream "
+            "consumers. Mutually exclusive with "
+            "--min-success-fraction."
+        ),
+    )
+    threshold.add_argument(
+        "--min-success-fraction",
+        type=float,
+        default=None,
+        metavar="F",
+        help=(
+            "Same as --min-success-nodes but expressed as a "
+            "fraction of the total node count (e.g. 0.95 = at "
+            "least 95%% of nodes must succeed). Computed against "
+            "the full node list including the local node. "
+            "Mutually exclusive with --min-success-nodes."
+        ),
+    )
+
     args, unknown = parser.parse_known_args(argv)
     if unknown:
         # Tolerate one stray "yeet-env"/"yeet" token leaked from old
@@ -975,6 +1012,21 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         )
     if args.src is None:
         args.src = args.src_positional
+
+    # Validate the threshold args (argparse can't easily do range
+    # validation for floats).
+    if args.min_success_nodes is not None and args.min_success_nodes < 1:
+        parser.error(
+            f"--min-success-nodes must be >= 1, got {args.min_success_nodes}"
+        )
+    if args.min_success_fraction is not None and not (
+        0.0 < args.min_success_fraction <= 1.0
+    ):
+        parser.error(
+            f"--min-success-fraction must be in (0, 1], got "
+            f"{args.min_success_fraction}"
+        )
+
     return args
 
 
@@ -1396,11 +1448,70 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
     progress.clear()
 
     total_elapsed = time.perf_counter() - t0
-    failed = sum(1 for _, _, rc in results if rc != 0)
+    failed_nodes = [n for n, _, rc in results if rc != 0]
+    failed = len(failed_nodes)
+    ok_nodes = [n for n, _, rc in results if rc == 0]
     if failed:
         logger.warning("%d/%d node(s) failed!", failed, total_nodes)
     else:
         logger.info("Done in %.1fs", total_elapsed)
+
+    # Resolve the proceed-with-spares threshold. If neither flag is
+    # set, the threshold equals total_nodes (i.e. ALL must succeed —
+    # original fail-on-any behavior). If --min-success-fraction is
+    # set, derive an absolute count via ceil (so 0.95 of 100 = 95,
+    # not 95.0 ambiguity). --min-success-nodes wins as-is.
+    if args.min_success_nodes is not None:
+        threshold = args.min_success_nodes
+        threshold_src = f"--min-success-nodes={args.min_success_nodes}"
+    elif args.min_success_fraction is not None:
+        import math
+        threshold = math.ceil(args.min_success_fraction * total_nodes)
+        threshold_src = (
+            f"--min-success-fraction={args.min_success_fraction} "
+            f"× {total_nodes} = {threshold}"
+        )
+    else:
+        threshold = total_nodes
+        threshold_src = "default (all nodes must succeed)"
+
+    proceed_with_spares = (
+        failed > 0 and len(ok_nodes) >= threshold
+    )
+
+    # Write the failed-nodes sentinel file when (a) we have failures
+    # and (b) the threshold is satisfied (i.e. we're proceeding
+    # despite the failures). The path is under `dst` for symmetry
+    # with the rest of the yeeted content. Downstream consumers
+    # (training scripts, ezpz launch wrappers) can read + exclude.
+    if proceed_with_spares:
+        sentinel_path = dst / ".ezpz-yeet-failed-nodes.txt"
+        try:
+            sentinel_path.parent.mkdir(parents=True, exist_ok=True)
+            sentinel_path.write_text(
+                "\n".join(failed_nodes) + "\n"
+            )
+            logger.warning(
+                "Proceeding despite %d failure(s) — threshold met "
+                "(%d/%d nodes ok, need >=%d). Failed nodes (%s) "
+                "written to %s",
+                failed,
+                len(ok_nodes),
+                total_nodes,
+                threshold,
+                threshold_src,
+                sentinel_path,
+            )
+        except OSError as exc:
+            # The threshold IS met — don't fail the run just because
+            # we couldn't write the bookkeeping file. Log loudly so
+            # the user knows the file is missing.
+            logger.warning(
+                "Threshold met (%d/%d ok) but couldn't write "
+                "failed-nodes file at %s: %s. Failed nodes were: %s",
+                len(ok_nodes), total_nodes, sentinel_path, exc,
+                ", ".join(failed_nodes),
+            )
 
     # ── Guidance ────────────────────────────────────────────────────
     # Detect from `dst` so tarball sources (where the directory only
@@ -1444,7 +1555,15 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
         print(f"  worker (e.g. {dst}) — the shared-filesystem source path will")
         print(f"  not see writes from worker nodes.")
 
-    return 1 if failed else 0
+    # rc semantics:
+    #   no failures               → 0 (always)
+    #   failures + threshold met  → 0 (with sentinel file written above)
+    #   failures + threshold miss → 1 (original behavior)
+    if failed == 0:
+        return 0
+    if proceed_with_spares:
+        return 0
+    return 1
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/tests/test_yeet_env.py
+++ b/tests/test_yeet_env.py
@@ -480,6 +480,164 @@ class TestProceedWithSpares:
         assert rc != 0, "no flag = original fail-on-any behavior"
         assert not (dst / ".ezpz-yeet-failed-nodes.txt").exists()
 
+    # ── Regressions for review findings ─────────────────────────────
+
+    def test_clean_run_under_threshold_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression (codex P2): --min-success-nodes is a HARD lower bound.
+
+        A clean run (zero failures) that synced fewer nodes than the
+        threshold MUST fail. Otherwise downstream training silently
+        under-provisions: `yeet --min-success-nodes 512` against a
+        500-node hostfile with all 500 successful would return 0
+        and the user would launch on 500 nodes thinking they had 512.
+        """
+        self._setup_common(monkeypatch, fail_nodes=set())
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        # Only 4 nodes available, but caller asks for >=10.
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "node02", "node03"]
+        )
+
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-nodes", "10",  # > total
+        ])
+        assert rc != 0, (
+            "clean run with too few nodes must fail when threshold "
+            "exceeds the available node count — otherwise the flag "
+            "isn't a real lower bound"
+        )
+        # No sentinel — there are no FAILED nodes to record. The
+        # situation is "we needed 10 but only had 4." That belongs
+        # in the log, not the sentinel file (which is documented as
+        # the list of nodes that failed, not the list of nodes the
+        # user wished they had).
+        assert not (dst / ".ezpz-yeet-failed-nodes.txt").exists()
+
+    def test_stale_sentinel_removed_on_clean_rerun(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression (codex+copilot P2): stale sentinel must not survive.
+
+        Set up: a prior run wrote a sentinel listing badnode. The
+        next run is clean (no failures), so the sentinel from the
+        prior run must be removed. Otherwise downstream tooling
+        would read the stale list and exclude badnode from a launch
+        that should be using it.
+        """
+        self._setup_common(monkeypatch, fail_nodes=set())
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        dst.mkdir()
+        stale_sentinel = dst / ".ezpz-yeet-failed-nodes.txt"
+        stale_sentinel.write_text("badnode-from-prior-run\n")
+        assert stale_sentinel.exists()  # pre-condition
+
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "node02"]
+        )
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-nodes", "3",
+        ])
+        assert rc == 0
+        assert not stale_sentinel.exists(), (
+            "stale sentinel from prior run must be removed when the "
+            "current run has no failures — otherwise downstream "
+            "tooling reads wrong data"
+        )
+
+    def test_stale_sentinel_removed_when_threshold_missed(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: stale sentinel removed even on failed run.
+
+        If the threshold isn't met, we return rc=1 (don't write a
+        new sentinel) — but we ALSO must remove any prior sentinel,
+        so downstream tooling doesn't see a "yeet succeeded with
+        these failures" marker from a run that actually failed.
+        """
+        self._setup_common(monkeypatch, fail_nodes={"bad1", "bad2"})
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        dst.mkdir()
+        stale_sentinel = dst / ".ezpz-yeet-failed-nodes.txt"
+        stale_sentinel.write_text("badnode-from-prior-run\n")
+        assert stale_sentinel.exists()  # pre-condition
+
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "bad1", "bad2"]
+        )
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-nodes", "3",  # 2/4 ok, threshold missed
+        ])
+        assert rc != 0
+        assert not stale_sentinel.exists(), (
+            "stale sentinel must be cleared even when the new run "
+            "fails the threshold — otherwise downstream tooling "
+            "consumes a marker from a previous run that no longer "
+            "describes reality"
+        )
+
+    def test_fraction_uses_hostfile_count_not_rsync_op_count(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression (copilot P2): denominator is len(nodes), not total_nodes.
+
+        When `src` is under /tmp (needs_local_copy = False),
+        `total_nodes` = remote_nodes_count (no +1 for the local
+        node). But the docs promise the fraction is computed
+        against the "full node list including the local node" —
+        which is the HOSTFILE count, not the rsync-op count.
+        Pin the contract.
+
+        Setup: 5-node hostfile, _needs_local_copy returns False
+        (so local rsync skipped, only 4 remote rsyncs run).
+        Fraction 0.6 should round-ceil to 3 against hostfile=5
+        (NOT to 3 against total_nodes=4 — but in this case the
+        threshold value is the same so we have to detect the bug
+        via fraction 0.8 → ceil(0.8*5)=4 vs ceil(0.8*4)=4 …).
+        Easier: use fraction 0.5 → ceil(0.5*5)=3 vs ceil(0.5*4)=2.
+        Make 2 nodes fail; should land below threshold of 3 →
+        fail. (If bug were still present: threshold would be 2,
+        2 nodes ok would meet it, return 0.)
+        """
+        # Override _needs_local_copy → False so total_nodes <
+        # len(nodes). This is the scenario the bug only manifests in.
+        self._setup_common(monkeypatch, fail_nodes={"bad1", "bad2"})
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: False)
+
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path,
+            ["node00", "node01", "node02", "bad1", "bad2"],  # 5 hosts
+        )
+
+        # With the fix: threshold = ceil(0.5 * 5) = 3.
+        # 2 succeed (node01, node02 — node00 is local + skipped),
+        # 2 fail (bad1, bad2). 2 < 3 → fail.
+        #
+        # If bug were still present: threshold = ceil(0.5 * 4) = 2.
+        # 2 >= 2 → return 0. The assertion below would fail.
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-fraction", "0.5",
+        ])
+        assert rc != 0, (
+            "fraction must be computed against the hostfile node "
+            "count (5), not the rsync-op count (4). With 0.5 of 5 "
+            "→ ceil = 3 needed; only 2 succeeded; should fail."
+        )
+
 
 # ===================================================================
 # parse_args

--- a/tests/test_yeet_env.py
+++ b/tests/test_yeet_env.py
@@ -306,6 +306,182 @@ class TestRsyncRetry:
 
 
 # ===================================================================
+# --min-success-nodes / --min-success-fraction (proceed-with-spares)
+# ===================================================================
+
+
+class TestProceedWithSpares:
+    """Tests for the --min-success-nodes / --min-success-fraction flags.
+
+    When set, yeet returns rc=0 even with some failures, as long as
+    the success count meets the threshold. Writes the failed-nodes
+    list to $dst/.ezpz-yeet-failed-nodes.txt for downstream
+    consumers (training scripts, ezpz launch wrappers).
+    """
+
+    def _make_hostfile(self, tmp_path, nodes):
+        hf = tmp_path / "hostfile"
+        hf.write_text("\n".join(nodes) + "\n")
+        return hf
+
+    def _make_src(self, tmp_path):
+        src = tmp_path / "fakenv"
+        (src / "bin").mkdir(parents=True)
+        (src / "bin" / "activate").write_text("# fake activate\n")
+        (src / "pyvenv.cfg").write_text(
+            "home = /usr/bin\nversion = 3.12.0\n"
+        )
+        return src
+
+    def _setup_common(self, monkeypatch, fail_nodes):
+        """Stub out the heavy machinery so we can drive run() in unit."""
+        def fake_rsync(src, dst, node, **kwargs):
+            if node in fail_nodes:
+                return (node, 0.1, 255)
+            return (node, 0.2, 0)
+
+        # No retries — make the failure permanent so we can test the
+        # threshold logic in isolation from PR #160's retry path.
+        monkeypatch.setattr(yeet, "_DEFAULT_RSYNC_RETRIES", 0)
+        monkeypatch.setattr(yeet, "_rsync_to_node", fake_rsync)
+        monkeypatch.setattr(yeet, "_get_current_hostname", lambda: "node00")
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: True)
+        monkeypatch.setattr(
+            yeet, "_patch_venv_paths_local", lambda dst, src: None
+        )
+
+    def test_threshold_met_returns_zero_and_writes_sentinel(
+        self, tmp_path, monkeypatch
+    ):
+        """When ok_nodes >= --min-success-nodes, return 0 + write file."""
+        self._setup_common(monkeypatch, fail_nodes={"badnode"})
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "node02", "badnode"]
+        )
+
+        # 4 total, 3 succeed, 1 fails. With --min-success-nodes=3,
+        # threshold is met → rc=0.
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-nodes", "3",
+        ])
+        assert rc == 0, "threshold met (3/4 ok, need >=3); should return 0"
+
+        # Sentinel file should exist and contain just the failed node.
+        sentinel = dst / ".ezpz-yeet-failed-nodes.txt"
+        assert sentinel.exists()
+        assert sentinel.read_text().strip() == "badnode"
+
+    def test_threshold_missed_returns_one_no_sentinel(
+        self, tmp_path, monkeypatch
+    ):
+        """When ok_nodes < threshold, fail like before (no sentinel)."""
+        self._setup_common(monkeypatch, fail_nodes={"bad1", "bad2"})
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "bad1", "bad2"]
+        )
+
+        # 4 total, 2 succeed, 2 fail. With --min-success-nodes=3,
+        # threshold is NOT met → rc=1, no sentinel.
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-nodes", "3",
+        ])
+        assert rc != 0, "threshold not met (2/4 ok, need >=3); should fail"
+        assert not (dst / ".ezpz-yeet-failed-nodes.txt").exists(), (
+            "sentinel must NOT be written when threshold isn't met — "
+            "otherwise downstream tooling would silently consume a "
+            "stale 'this run partially succeeded' marker."
+        )
+
+    def test_no_failures_no_sentinel_even_with_threshold(
+        self, tmp_path, monkeypatch
+    ):
+        """When ALL nodes succeed, no sentinel written, rc=0."""
+        self._setup_common(monkeypatch, fail_nodes=set())
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "node02"]
+        )
+
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-nodes", "2",
+        ])
+        assert rc == 0
+        # No failures → no sentinel (avoids stale data confusing
+        # downstream readers next run).
+        assert not (dst / ".ezpz-yeet-failed-nodes.txt").exists()
+
+    def test_fraction_threshold_met(
+        self, tmp_path, monkeypatch
+    ):
+        """--min-success-fraction 0.75 of 4 nodes = ceil(3) → 3 needed."""
+        self._setup_common(monkeypatch, fail_nodes={"badnode"})
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "node02", "badnode"]
+        )
+
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            "--min-success-fraction", "0.75",
+        ])
+        assert rc == 0, "3/4 = 75% ok, threshold = ceil(0.75*4) = 3, met"
+        sentinel = dst / ".ezpz-yeet-failed-nodes.txt"
+        assert sentinel.exists()
+        assert "badnode" in sentinel.read_text()
+
+    def test_flags_mutex_rejects_both(self):
+        """--min-success-nodes and --min-success-fraction are mutex."""
+        with pytest.raises(SystemExit):
+            yeet.parse_args([
+                "--min-success-nodes", "5",
+                "--min-success-fraction", "0.9",
+            ])
+
+    def test_fraction_out_of_range_rejected(self):
+        """--min-success-fraction must be in (0, 1]."""
+        for bad in ["0.0", "-0.5", "1.5", "2.0"]:
+            with pytest.raises(SystemExit):
+                yeet.parse_args(["--min-success-fraction", bad])
+
+    def test_min_success_nodes_zero_rejected(self):
+        """--min-success-nodes < 1 is meaningless and rejected."""
+        with pytest.raises(SystemExit):
+            yeet.parse_args(["--min-success-nodes", "0"])
+
+    def test_default_behavior_unchanged_without_threshold(
+        self, tmp_path, monkeypatch
+    ):
+        """Without --min-success-* flags, any failure → rc=1 + no sentinel."""
+        self._setup_common(monkeypatch, fail_nodes={"badnode"})
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "tmp_dst"
+        hf = self._make_hostfile(
+            tmp_path, ["node00", "node01", "badnode"]
+        )
+
+        rc = yeet.run([
+            "--src", str(src), "--dst", str(dst),
+            "--hostfile", str(hf),
+            # no --min-success-* flag
+        ])
+        assert rc != 0, "no flag = original fail-on-any behavior"
+        assert not (dst / ".ezpz-yeet-failed-nodes.txt").exists()
+
+
+# ===================================================================
 # parse_args
 # ===================================================================
 


### PR DESCRIPTION
## Summary

Complement to #160's transient-retry logic. PR #160 handles "same node, second attempt succeeds" (flaky SSH); this PR handles the other half of the at-scale failure pattern: **"this node is permanently dead, but I have spare allocation, so move on."**

## CLI

```bash
ezpz yeet --min-success-nodes 512        # require ≥ 512 to succeed
ezpz yeet --min-success-fraction 0.95    # require ≥ 95% to succeed
```

Mutually exclusive flags. Argparse validation rejects both at once + out-of-range values.

## Behavior

| Scenario | rc | sentinel file |
|---|---|---|
| All nodes succeed | 0 | not written |
| Some fail, threshold met | **0** | **written** |
| Some fail, threshold missed | 1 | not written |
| Any fail, no threshold flag | 1 (unchanged) | not written |

When the threshold is met AND there are failures, yeet writes the failed hostnames to **`$dst/.ezpz-yeet-failed-nodes.txt`** (hidden, one host per line) so downstream tooling can read + exclude:

```bash
FAILED=$(cat "$DST"/.ezpz-yeet-failed-nodes.txt 2>/dev/null || true)
if [[ -n "$FAILED" ]]; then
  grep -vFf <(echo "$FAILED") "$PBS_NODEFILE" > /tmp/hostfile-good
  ezpz launch --hostfile /tmp/hostfile-good -- python3 -m my.train
else
  ezpz launch -- python3 -m my.train
fi
```

## What's NOT in this PR

**Automatic `ezpz launch` integration.** Originally considered, but the user and I agreed to keep the two subsystems decoupled for now. `ezpz launch`'s hostfile resolution is load-bearing; changing it without more careful design risks surprising regressions. The docs include the 4-line bash snippet above as the canonical opt-in pattern. A future PR can add `ezpz launch --read-yeet-failures` or similar if the pattern proves useful.

## Tests (8 new in `TestProceedWithSpares`)

- threshold met → rc=0 + sentinel exists with right content
- threshold missed → rc=1 + sentinel does NOT exist
- no failures → rc=0 + sentinel does NOT exist (no stale data confusing future runs)
- `--min-success-fraction` works with ceil math
- mutex enforced (both flags rejected)
- fraction out-of-range rejected (0.0, -0.5, 1.5, 2.0)
- nodes < 1 rejected
- no flag → original fail-on-any behavior preserved

**244/244 across `yeet_env + distributed + top_level_exports`.**

## Label

`release:minor` — net-new public CLI flag. Existing behavior unchanged when the flag isn't passed, so backward-compatible — but adding a documented opt-in flag is more than a bugfix.

## Test plan

- [x] `pytest tests/test_yeet_env.py::TestProceedWithSpares -v` → 8/8 PASS
- [x] `pytest tests/test_yeet_env.py -q` → 65/65 PASS (was 57 pre-PR; 8 new)
- [ ] Live verification on Aurora: `ezpz yeet --min-success-nodes 510` on a 522-node allocation, kill SSH on 1-2 nodes mid-run, verify rc=0 + sentinel file appears + contains the killed hostnames
