### PR TITLE
fix(launch): errors='replace' on Popen so _drain survives bad UTF-8

### DIFF
--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -493,6 +493,26 @@ def _run_attempt_with_tee(
     #      a terminal — no privilege boundary is crossed here.
     # Sourcery's lint can't distinguish "user-runs-their-own-code"
     # from "untrusted-input-to-shell"; this is the former.
+    #
+    # `errors="replace"` is load-bearing: without it, ANY non-UTF-8
+    # byte in the child's stdout (binary log fragment, terminal
+    # control codes some libraries emit, a partial multibyte
+    # sequence at a buffer boundary) raises UnicodeDecodeError
+    # inside the `for line in proc.stdout` loop in `_drain`. That
+    # crashes the drain thread, leaving the auto-retry monitor
+    # "deaf" — training keeps going (tqdm writes via its own
+    # handler) but the watchdog can no longer see crash
+    # signatures, so a real failure later in the run would not
+    # trigger a retry. Caught on Sunspot SFT job 12468338 — a
+    # 32-min, 32-node run that lost its monitor thread to a
+    # decode error mid-training.
+    #
+    # `replace` substitutes U+FFFD for bad bytes. We lose the
+    # exact original byte in the log, which is fine: this is a
+    # human-readable log + a crash-signature scraper, not a
+    # binary protocol. The crash signatures we scrape for
+    # (`shepherd died from signal 9`, `Connection closed by peer`,
+    # etc.) are pure ASCII so substitution can't corrupt them.
     proc = subprocess.Popen(  # noqa: S603 — see comment above
         list(cmd),
         stdout=subprocess.PIPE,
@@ -500,6 +520,7 @@ def _run_attempt_with_tee(
         text=True,
         bufsize=1,
         env=child_env,
+        errors="replace",
     )
 
     last_activity = time.monotonic()

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -1166,3 +1166,57 @@ class TestRunAttemptWithTee:
         )
         assert rc == 7
         assert "before-exit" in log_path.read_text()
+
+    def test_non_utf8_bytes_do_not_crash_drain(self, tmp_path):
+        """Regression: non-UTF-8 bytes in stdout must NOT crash _drain.
+
+        Caught on Sunspot SFT job 12468338 — a 32-min, 32-node SFT
+        run logged the following thread-crash mid-training:
+
+            Exception in thread Thread-2 (_drain):
+              File ".../launch_autoretry.py", line 514, in _drain
+                for line in proc.stdout:
+              File "<frozen codecs>", line 325, in decode
+            UnicodeDecodeError: 'utf-8' codec can't decode bytes
+              in position 0-1: invalid continuation byte
+
+        Training kept going (tqdm has its own progress writer) but
+        the auto-retry watchdog went deaf — if a real crash hit
+        after that, it wouldn't have triggered a retry.
+
+        Fix: `errors="replace"` on Popen. The bad byte becomes
+        U+FFFD in the log; the drain loop keeps running.
+
+        This test emits a deliberately-broken UTF-8 sequence (a
+        bare 0xff byte, which can never start a valid UTF-8 code
+        point) followed by normal lines. Pre-fix: drain thread
+        dies, log truncates around the bad byte, the post-bad-byte
+        lines never land in the log file. Post-fix: bad byte
+        replaced, all lines captured.
+        """
+        from ezpz.launch_autoretry import _run_attempt_with_tee
+
+        log_path = tmp_path / "bad-utf8.log"
+        # printf '\xff' emits a single bare 0xff byte. Wrap with
+        # ASCII bookends so we can assert lines on either side of
+        # it landed in the log.
+        script = (
+            'echo before-bad-byte; '
+            "printf '\\xff\\n'; "
+            'echo after-bad-byte'
+        )
+        rc = _run_attempt_with_tee(
+            ["sh", "-c", script], log_path, idle_timeout_s=0
+        )
+        assert rc == 0
+        text = log_path.read_text()
+        assert "before-bad-byte" in text, (
+            "log missing pre-bad-byte content — drain may have "
+            "crashed before flushing"
+        )
+        assert "after-bad-byte" in text, (
+            "Regression: drain thread died on the bad UTF-8 byte. "
+            "Without errors='replace' on Popen, the post-bad-byte "
+            "lines never reach the log file because the iterator "
+            "raises UnicodeDecodeError mid-stream."
+        )


### PR DESCRIPTION
## Summary

One-character fix (well, fifteen characters): add `errors="replace"` to `subprocess.Popen` in `_run_attempt_with_tee` so the drain thread doesn't crash on non-UTF-8 bytes.

## Why

Caught on Sunspot SFT job 12468338 — a 32-min, 32-node run logged this mid-training:

```
Exception in thread Thread-2 (_drain):
  File ".../launch_autoretry.py", line 514, in _drain
    for line in proc.stdout:
  File "<frozen codecs>", line 325, in decode
UnicodeDecodeError: 'utf-8' codec can't decode bytes
  in position 0-1: invalid continuation byte
```

**Training kept going** (tqdm has its own progress writer that bypasses the drain thread) **but the auto-retry monitor went DEAF**. If a real crash had hit after this point, the scraper wouldn't have seen any signatures and wouldn't have triggered a retry. Silent loss of the entire `--auto-retry` value prop.

## Root cause

`Popen(..., text=True)` defaults to **strict** UTF-8 decoding. Any non-UTF-8 byte in the child's stdout — binary log fragment, terminal control codes some libraries emit, a partial multibyte sequence at a buffer boundary — raises `UnicodeDecodeError` inside the `for line in proc.stdout` iterator, which kills the drain thread.

## Fix

```python
proc = subprocess.Popen(
    ...,
    text=True,
    errors="replace",   # ← this
)
```

`errors="replace"` substitutes U+FFFD for bad bytes. We lose the exact original byte in the log, which is fine: this is a human-readable log + a crash-signature scraper, not a binary protocol. The crash signatures we scrape for (`shepherd died from signal 9`, `Connection closed by peer`, etc.) are pure ASCII so replacement can't corrupt them.

## Test

`test_non_utf8_bytes_do_not_crash_drain` emits a bare `0xff` byte between ASCII bookends:

```python
script = (
    'echo before-bad-byte; '
    "printf '\\xff\\n'; "
    'echo after-bad-byte'
)
```

Pre-fix: drain thread dies on the `0xff`, log truncates around it, `after-bad-byte` never lands → test fails with `UnicodeDecodeError: ... byte 0xff in position 0` (the **exact same error** the Sunspot job hit).

Post-fix: `0xff` becomes U+FFFD, `after-bad-byte` lands in the log → test passes.

Verified by stash-reverting the fix.

**100/100 in `test_launch_autoretry.py`.**

## Label

`release:patch` — bug fix, single kwarg, no API change, no behavior change for any caller currently relying on logged content (we add ~3 bytes of U+FFFD on the rare bad-byte event, nothing else).

## Urgency

This bug bites every multi-hour Aurora/Sunspot job that streams binary-tainted stdout — i.e. effectively all of them at scale. Worth merging soon so future runs don't lose their `--auto-retry` watchdog the way 12468338 did.

## Test plan

- [x] `pytest tests/test_launch_autoretry.py -q` → 100/100 PASS
- [x] New regression test verified to fail when the fix is stashed (exact same byte 0xff error as the production crash)
- [ ] Live re-verify on Sunspot: any subsequent SFT run should NOT log the `Thread-2 (_drain)` traceback

## Summary by Sourcery

Prevent the launch autoretry drain thread from crashing on invalid UTF-8 output from child processes.

Bug Fixes:
- Ensure subprocess stdout decoding in _run_attempt_with_tee tolerates non-UTF-8 bytes so the drain thread and auto-retry monitoring keep running.

Tests:
- Add a regression test that emits non-UTF-8 bytes to verify the drain thread continues and all expected log lines are captured.