### PR TITLE
fix(utils.sh): route log_message output to stderr

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -133,8 +133,16 @@ log_message() {
 	esac
 
 	log_msg="[${date}][${log_level}][${BASH_SOURCE[1]}:${BASH_LINENO[0]}] ${string}"
-	# printf is predictable; preserves backslashes unless you add %b intentionally
-	printf "%b\n" "${log_msg}"
+	# Write to STDERR — not stdout. Many helpers in this file use
+	# `value=$(some_helper)` patterns, and any log_message emitted inside
+	# `some_helper` would otherwise be captured into `value` along with
+	# the intended return string. Example failure pre-fix: in
+	# `ezpz_get_venv_dir`, a "Found python root at: ..." log line ended
+	# up concatenated onto the venv path (which then propagated to a
+	# literal mkdir of a directory named after the log line). Sending
+	# logs to stderr keeps them visible in the terminal while making
+	# them invisible to `$(...)`.
+	printf "%b\n" "${log_msg}" >&2
 }
 
 # --- Global Variables ---


### PR DESCRIPTION
## Summary

Routes `log_message` (in `src/ezpz/bin/utils.sh`) output to **stderr** so it stops poisoning `$(...)` command substitutions.

## The bug

User on Sunspot ran:

```bash
source <(curl -fsSL https://bit.ly/ezpz-utils) && \
  ezpz_setup_job && ezpz_load_modules && ezpz_setup_uv_venv
```

…and ended up with literal directories named after log lines:

```
$ ls
'[2026-06-12-104735][I][:]   - Found python root at: python3.12\n'/   benchmarks/
'[2026-06-12-104756][I][:]   - Found python root at: python3.12\n'/   results/
```

## Root cause

`log_message` wrote via `printf "%b\n"` to **stdout**. Several helpers in `utils.sh` use the pattern:

```bash
value=$(some_helper)            # captures stdout
```

…and any `log_message` call emitted inside `some_helper` got captured into `value` along with the intended return string. Concrete chain that triggered the user's bug:

```bash
ezpz_setup_uv_venv() {
    ...
    venv_dir=$(ezpz_get_venv_dir)        # ← captures BOTH stdout
    log_message INFO "Creating venv in ${venv_dir}..."
    uv venv ... "${venv_dir}"            # ← uses contaminated path
}

ezpz_get_venv_dir() {
    ...
    log_message INFO "Found python root at: ${python_root}"  # → stdout (captured!)
    ...
    echo "${env_name}"                   # → stdout (intended)
}
```

Result: `venv_dir` contained both the log line AND the venv path. `uv venv` then created a directory literally named after the log string.

## Fix

One-line patch: `printf "%b\n" "${log_msg}"` → `printf "%b\n" "${log_msg}" >&2`. Logs stay visible in the terminal; `$(...)` substitutions return only the intended value.

Added an in-code comment explaining the rationale so future contributors don't switch it back.

## Verification

Before / after for the smoking-gun case:

```bash
$ source src/ezpz/bin/utils.sh
$ venv_dir=$(ezpz_get_venv_dir)
[2026-06-12-...][I][...]  - Found python root at: python3.12      ← stderr, visible
$ echo "venv_dir=[$venv_dir]"
venv_dir=[/.../venvs/host/repo-py3.12]                              ← stdout, clean ✓
```

And the minimal capture test:

```bash
$ val=$(log_message INFO "should not appear in val"; echo "REAL")
[2026-06-12-...][I][:4] should not appear in val                  ← stderr
$ echo "val=[$val]"
val=[REAL]                                                          ← stdout ✓
```

## Label

`release:patch` — bug fix only, no API surface change. Behavior change is that log messages now appear on stderr instead of stdout — affects users who pipe ezpz output, but anyone piping log output explicitly should have been using `2>&1` to merge streams anyway (otherwise they were already losing them on subshell capture).

## Test plan

- [x] Reproduced the bug; verified the fix produces a clean captured path
- [x] Verified `log_message` output still appears on the terminal (stderr)
- [x] Confirmed `ezpz_get_venv_dir` now returns just the path
- [ ] Live re-test on Sunspot with the original failing command from the bug report

## Summary by Sourcery

Route shell logging helper output to stderr to avoid contaminating values captured via command substitution.

Bug Fixes:
- Prevent log_message output from being captured into variables when helpers are used in $(...) command substitutions, which previously produced corrupted paths and directories named after log lines.

Enhancements:
- Document in-code why log_message writes to stderr to prevent future regressions when working with command-substitution-based helpers.