### PR TITLE
feat(utils.sh): port bad-node failover helpers from torchtitan

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -3237,6 +3237,286 @@ ezpz_check_working_dir_pbs() {
 	fi
 }
 
+# =============================================================================
+# Bad-node failover support for ezpz / torchtitan training.
+#
+# Ported from torchtitan's experiments/ezpz/scripts/failover_lib.sh. Source
+# this library from a submit script that has requested NHOSTS_TRAIN +
+# NHOSTS_SPARE nodes via PBS, then:
+#
+#   ezpz_failover_init NHOSTS_TRAIN
+#   ezpz_failover_run <command...>
+#
+# ezpz_failover_init splits PBS_NODEFILE → active.hostfile (first N lines) +
+# spare.hostfile (rest), exports PBS_NODEFILE → active.hostfile so downstream
+# `ezpz launch` only sees the training subset, and (via ezpz_failover_yeet_all)
+# yeets the venv to ALL nodes so any spare can swap in cleanly.
+#
+# ezpz_failover_run runs the command, scrapes the output for known bad-node
+# failure modes (see `python3 -m ezpz.utils.scrape_bad_nodes`), swaps the
+# offending node out for a spare, and retries (up to FAILOVER_MAX_RETRIES,
+# default 3).
+#
+# Env vars (all optional):
+#   FAILOVER_MAX_RETRIES   default 3
+#   FAILOVER_LOG_DIR       default $(pwd)/logs/failover-${PBS_JOBID%%.*}
+#   FAILOVER_IDLE_TIMEOUT  default 1800 (s) — idle-output watchdog for launch
+#
+# NOTE: the source file set `set -o pipefail` at top level; we deliberately do
+# NOT do that here (it would change behavior for the whole shared library).
+# The functions below use ${PIPESTATUS[0]}, which works without it.
+# =============================================================================
+
+_ezpz_failover_log() { echo "[failover] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# ezpz_failover_init NHOSTS_TRAIN
+#
+# Splits PBS_NODEFILE into active + spare files in $FAILOVER_LOG_DIR.
+# Exports PBS_NODEFILE → active.hostfile.
+# ---------------------------------------------------------------------------
+ezpz_failover_init() {
+	local nhosts_train="$1"
+	[[ -n "$nhosts_train" ]] || { _ezpz_failover_log "ERROR: ezpz_failover_init needs NHOSTS_TRAIN arg"; return 1; }
+	[[ -n "${PBS_NODEFILE:-}" && -f "$PBS_NODEFILE" ]] || { _ezpz_failover_log "ERROR: PBS_NODEFILE not set or missing"; return 1; }
+
+	local total
+	total=$(wc -l < "$PBS_NODEFILE")
+	if (( total < nhosts_train )); then
+		_ezpz_failover_log "ERROR: PBS gave us $total nodes, training needs $nhosts_train"
+		return 1
+	fi
+
+	export FAILOVER_LOG_DIR="${FAILOVER_LOG_DIR:-$(pwd)/logs/failover-${PBS_JOBID%%.*}}"
+	mkdir -p "$FAILOVER_LOG_DIR"
+
+	export FAILOVER_PBS_NODEFILE_ORIG="$PBS_NODEFILE"
+	export FAILOVER_ACTIVE="$FAILOVER_LOG_DIR/active.hostfile"
+	export FAILOVER_SPARE="$FAILOVER_LOG_DIR/spare.hostfile"
+	export FAILOVER_BAD="$FAILOVER_LOG_DIR/bad_nodes.txt"
+
+	head -n "$nhosts_train"   "$PBS_NODEFILE" > "$FAILOVER_ACTIVE"
+	tail -n +"$((nhosts_train + 1))" "$PBS_NODEFILE" > "$FAILOVER_SPARE"
+	: > "$FAILOVER_BAD"  # truncate
+
+	export PBS_NODEFILE="$FAILOVER_ACTIVE"
+	export NHOSTS="$nhosts_train"
+
+	_ezpz_failover_log "PBS gave us $total nodes ($(wc -l < "$FAILOVER_ACTIVE") active, $(wc -l < "$FAILOVER_SPARE") spare)"
+	_ezpz_failover_log "active hostfile: $FAILOVER_ACTIVE"
+	_ezpz_failover_log "spare hostfile:  $FAILOVER_SPARE"
+	_ezpz_failover_log "bad-node log:    $FAILOVER_BAD"
+}
+
+# ---------------------------------------------------------------------------
+# ezpz_failover_yeet_all
+#
+# Run `ezpz yeet-env` against the FULL nodelist (active + spare), so a spare
+# can swap in without re-broadcast. Restores PBS_NODEFILE → active afterwards.
+# ---------------------------------------------------------------------------
+ezpz_failover_yeet_all() {
+	local full_nodefile="$FAILOVER_LOG_DIR/all.hostfile"
+	cat "$FAILOVER_ACTIVE" "$FAILOVER_SPARE" > "$full_nodefile"
+	local saved_pbs_nodefile="$PBS_NODEFILE"
+	local saved_nhosts="$NHOSTS"
+	export PBS_NODEFILE="$full_nodefile"
+	NHOSTS=$(wc -l < "$full_nodefile") && export NHOSTS
+	_ezpz_failover_log "yeet-env to ALL $NHOSTS nodes (active + spare)"
+	if [[ -f .venv.tar.gz ]]; then
+		ezpz yeet-env --src .venv.tar.gz
+	else
+		ezpz yeet-env
+	fi
+	local rc=$?
+	export PBS_NODEFILE="$saved_pbs_nodefile"
+	export NHOSTS="$saved_nhosts"
+	return $rc
+}
+
+# ---------------------------------------------------------------------------
+# ezpz_failover_swap_in BAD_HOSTNAMES...
+#
+# For each bad hostname, remove it from active.hostfile and replace it with
+# the next available spare (popping from spare.hostfile). Logs all bad
+# hostnames to bad_nodes.txt for postmortem. Returns 0 if all swaps
+# succeeded, 1 if we ran out of spares.
+# ---------------------------------------------------------------------------
+ezpz_failover_swap_in() {
+	local bad
+	local swapped=0
+	for bad in "$@"; do
+		# Bad node must actually be in active set
+		if ! grep -qxF "$bad" "$FAILOVER_ACTIVE" 2>/dev/null; then
+			_ezpz_failover_log "skip: $bad not in active hostfile"
+			continue
+		fi
+		# Need a spare
+		local spare
+		spare=$(head -n 1 "$FAILOVER_SPARE")
+		if [[ -z "$spare" ]]; then
+			_ezpz_failover_log "ERROR: out of spares — cannot replace $bad"
+			return 1
+		fi
+		# Pop spare, swap in
+		tail -n +2 "$FAILOVER_SPARE" > "$FAILOVER_SPARE.tmp" && mv "$FAILOVER_SPARE.tmp" "$FAILOVER_SPARE"
+		sed -i "s|^$bad\$|$spare|" "$FAILOVER_ACTIVE"
+		echo "$bad" >> "$FAILOVER_BAD"
+		_ezpz_failover_log "swapped: $bad -> $spare"
+		swapped=$((swapped + 1))
+	done
+	_ezpz_failover_log "swap summary: $swapped bad nodes replaced; $(wc -l < "$FAILOVER_SPARE") spares remaining"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# ezpz_failover_swap_one_blind
+#
+# Generic init-time crash with no specific bad hostname (e.g. a
+# `std::bad_alloc` during init). Just rotate ONE spare into the active set.
+# Returns 0 if success, 1 if no spares left.
+# ---------------------------------------------------------------------------
+ezpz_failover_swap_one_blind() {
+	local first_active
+	first_active=$(head -n 1 "$FAILOVER_ACTIVE")
+	[[ -n "$first_active" ]] || return 1
+	ezpz_failover_swap_in "$first_active"
+}
+
+# ---------------------------------------------------------------------------
+# ezpz_failover_run COMMAND...
+#
+# Run COMMAND, capturing its output to $FAILOVER_LOG_DIR/attempt-N.log.
+# On non-zero exit, scrape the log for bad-node signatures and retry with
+# swap-ins, up to $FAILOVER_MAX_RETRIES times.
+# ---------------------------------------------------------------------------
+ezpz_failover_run() {
+	local max=${FAILOVER_MAX_RETRIES:-3}
+	local attempt=1
+	local rc
+
+	# If the command is `ezpz launch ...`, inject explicit topology args so
+	# ezpz launch doesn't re-derive nhosts/ngpus from the original PBS aux
+	# file (which still has the full node count — including the spares we
+	# excluded). Without this, topology inference computes ngpus for the full
+	# allocation and trips "ngpus must be > 0 and <= N_active*12".
+	#
+	# IMPORTANT: ezpz launch's argparse uses UNDERSCORE forms for the long
+	# flags (--nproc_per_node, --nnodes), not dash forms. Passing the dash
+	# variant silently leaks the arg into cmd_to_launch where mpiexec then
+	# rejects it with "unrecognized option". Use the short flags (-n, -ppn)
+	# and the registered long forms to avoid that.
+	local cmd=("$@")
+	if [[ "${cmd[0]}" == "ezpz" && "${cmd[1]}" == "launch" ]]; then
+		local ppn="${NGPU_PER_HOST:-12}"
+		local nproc=$(( NHOSTS * ppn ))
+		# FAILOVER_IDLE_TIMEOUT (default 1800s = 30min): if the launched
+		# process emits no output for this long, ezpz launch sends SIGTERM
+		# and exits 124. Catches silent collective hangs.
+		local idle_timeout="${FAILOVER_IDLE_TIMEOUT:-1800}"
+		cmd=(
+			"${cmd[@]:0:2}"
+			"--hostfile=$FAILOVER_ACTIVE"
+			"--nnodes=$NHOSTS"
+			"-ppn" "$ppn"
+			"-n" "$nproc"
+			"--timeout=$idle_timeout"
+			"${cmd[@]:2}"
+		)
+	fi
+
+	while (( attempt <= max + 1 )); do
+		local logf="$FAILOVER_LOG_DIR/attempt-${attempt}.log"
+		_ezpz_failover_log "attempt ${attempt}/${max} — active=$(wc -l < "$FAILOVER_ACTIVE") nodes, spare=$(wc -l < "$FAILOVER_SPARE") nodes"
+		_ezpz_failover_log "logging to $logf"
+
+		# Use tee to capture output; redirect both stderr and stdout.
+		"${cmd[@]}" 2>&1 | tee "$logf"
+		rc=${PIPESTATUS[0]}
+
+		# ezpz launch's outer python wrapper sometimes exits 0 even when the
+		# mpiexec child crashed (e.g. mpiexec --help dump, walltime SIGTERM).
+		# When that happens we lose the bad-node signal. Always cross-check
+		# the log for known crash patterns + the explicit "Execution finished
+		# with N" trailer, and override rc accordingly.
+		# Strip ANSI escape codes first — ezpz launch logs the trailer with
+		# color codes baked in, and a naive regex extracts '1' from the
+		# [1;36m prefix instead of the real exit code. Pre-filter with sed.
+		local inner_rc
+		inner_rc=$(sed -r 's/\x1b\[[0-9;]*m//g' "$logf" 2>/dev/null | grep -oE "Execution finished with [0-9]+" | tail -1 | grep -oE "[0-9]+$")
+		if [[ -n "$inner_rc" && "$inner_rc" != "0" ]]; then
+			if (( rc == 0 )); then
+				_ezpz_failover_log "WARNING: shell exit 0 but log shows 'Execution finished with $inner_rc'; treating as failure"
+				rc=$inner_rc
+			fi
+		elif (( rc == 0 )); then
+			# Even without the trailer, mass-traceback / Connection-closed
+			# patterns mean training crashed. Catch them. Any single
+			# occurrence of these patterns means training crashed.
+			local crash_lines
+			crash_lines=$(grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file" "$logf" 2>/dev/null)
+			if (( crash_lines >= 1 )); then
+				_ezpz_failover_log "WARNING: shell exit 0 but log has $crash_lines crash-pattern line(s); treating as failure (rc=1)"
+				rc=1
+			fi
+		fi
+
+		if (( rc == 0 )); then
+			_ezpz_failover_log "attempt ${attempt} succeeded (exit 0)"
+			return 0
+		fi
+
+		# Walltime kills are NOT bad-node failures — PBS reports exit -29 as
+		# bash exit 143 (128+15). Don't retry on those UNLESS we also found
+		# bad-node crash patterns (a real bad-node failure that surfaced as
+		# shell exit 143 after mpiexec SIGTERM'd the job).
+		if (( rc == 143 )); then
+			local bad_crash_lines
+			bad_crash_lines=$(grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file" "$logf" 2>/dev/null)
+			if (( bad_crash_lines == 0 )); then
+				_ezpz_failover_log "attempt ${attempt} exited 143 (walltime / SIGTERM) — not a bad-node failure, no retry"
+				return $rc
+			fi
+			_ezpz_failover_log "attempt ${attempt} exited 143 but log has $bad_crash_lines bad-node lines — proceeding with retry"
+		fi
+
+		# exit 124 = ezpz launch idle-output watchdog (--timeout) fired.
+		# Treat as a bad-node failure: scrape, swap, retry. The scraper
+		# likely won't find a specific hostname (the hang IS the silence) so
+		# ezpz_failover_swap_one_blind will rotate a spare.
+		if (( rc == 124 )); then
+			_ezpz_failover_log "attempt ${attempt} exited 124 (ezpz idle-output watchdog tripped after ${FAILOVER_IDLE_TIMEOUT:-1800}s) — treating as silent-hang bad-node failure"
+		fi
+
+		_ezpz_failover_log "attempt ${attempt} failed (exit $rc) — scraping for bad nodes"
+		local bad_nodes
+		bad_nodes=$(python3 -m ezpz.utils.scrape_bad_nodes "$logf" 2>/dev/null || true)
+
+		if (( attempt > max )); then
+			_ezpz_failover_log "ERROR: max retries ($max) exhausted; giving up"
+			return $rc
+		fi
+
+		if [[ -n "$bad_nodes" ]]; then
+			_ezpz_failover_log "bad nodes detected: $bad_nodes"
+			# shellcheck disable=SC2086
+			ezpz_failover_swap_in $bad_nodes || { _ezpz_failover_log "swap failed; giving up"; return $rc; }
+		else
+			_ezpz_failover_log "no specific bad node identified — rotating one spare in blindly"
+			ezpz_failover_swap_one_blind || { _ezpz_failover_log "no spares left; giving up"; return $rc; }
+		fi
+
+		# Sanity check: still have nhosts_train active nodes
+		local active_count
+		active_count=$(wc -l < "$FAILOVER_ACTIVE")
+		if (( active_count != NHOSTS )); then
+			_ezpz_failover_log "ERROR: active count drifted ($active_count != $NHOSTS); giving up"
+			return $rc
+		fi
+
+		attempt=$((attempt + 1))
+	done
+}
+
 # --- Script Entry Point ---
 if [[ -n "${EZPZ_CHECK_WORKING_DIR:-}" ]]; then
 	if ! ezpz_check_working_dir; then

--- a/src/ezpz/utils/scrape_bad_nodes.py
+++ b/src/ezpz/utils/scrape_bad_nodes.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""scrape_bad_nodes.py — extract bad-node hostnames from a training log.
+
+Reads the log file given on the command line and prints one bad
+hostname per line on stdout (deduplicated, in first-seen order).
+
+Used by the ``ezpz_failover_*`` shell helpers in ``ezpz/bin/utils.sh``:
+when a distributed run crashes, this scraper identifies the offending
+node(s) so a spare can be swapped in. Invoke as a module::
+
+    python3 -m ezpz.utils.scrape_bad_nodes <log-file>
+
+Detected patterns (each tied to a specific failure mode seen in
+production training on ALCF machines):
+
+  1. "<hostname>: shepherd died from signal 9"
+     PALS shepherd kill — node went bad mid-run (Aurora's most common
+     failure mode). We do NOT match ``rank N died from signal {11,15}``
+     because those are almost always cascading deaths from a primary
+     kill on a *different* node — including them would falsely tag
+     innocent nodes.
+
+  2. "Connection closed by peer [IP]:port" / "Timed out waiting Nms for recv"
+     gloo TCP failure — usually one bad node taking down peer
+     connections from many ranks. We resolve the IP via ``getent hosts``
+     to get the hostname. gloo errors usually point at a single peer IP
+     across many "Connection closed" lines, so the deduplicated output
+     is typically just one node.
+
+If no specific bad hostname is identifiable (e.g. the ``set_determinism``
+``std::bad_alloc`` init crash), nothing is printed and the caller
+(``ezpz_failover_run``) falls back to rotating one spare in blindly.
+
+Hostname normalization: PBS hostfile entries use the
+``.hsn.cm.<machine>.alcf.anl.gov`` form (``<machine>`` is e.g. ``aurora``,
+``sunspot``, ``polaris``). We always emit hostnames in that form
+regardless of whether the log used ``.hostmgmtNNNN.cm.<machine>...`` or
+some other suffix, preserving the machine token from the matched host.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ALCF compute hostnames look like `xNNNNcNsNbNnN.hsn.cm.<machine>.alcf.anl.gov`
+# where <machine> is aurora / sunspot / polaris / etc. Keep the patterns
+# machine-agnostic (match any lowercase-alnum machine token) so failover
+# works on every ALCF system, not just Aurora.
+_MACHINE = r"[a-z0-9]+"
+
+# Pattern 1: "<host>.hsn.cm.<machine>.alcf.anl.gov: shepherd died from signal 9"
+# Excludes "rank N died from signal {11,15}" because those are almost
+# always cascading deaths downstream of a primary kill elsewhere.
+SIGNAL_RX = re.compile(
+    r"^([a-zA-Z0-9.-]+\.hsn\.cm\." + _MACHINE + r"\.alcf\.anl\.gov):\s+"
+    r"shepherd\s+died\s+from\s+signal\s+9\b",
+    re.MULTILINE,
+)
+
+# Pattern 2: "RuntimeError: ... Connection closed by peer [IP]:port"
+GLOO_PEER_RX = re.compile(
+    r"Connection closed by peer\s+\[([0-9.]+)\]:\d+",
+    re.MULTILINE,
+)
+
+# Canonical compute hostname: xNNNNcNsNbNnN.hsn.cm.<machine>.alcf.anl.gov
+HSN_RX = re.compile(
+    r"^x\d+c\d+s\d+b\d+n\d+\.hsn\.cm\." + _MACHINE + r"\.alcf\.anl\.gov$"
+)
+
+# A host whose first label is the xNcNsNbNnN compute id, with any suffix.
+# Used to recover the machine token (group 2) from non-canonical forms
+# like `xNcNsNbNnN.hostmgmtNNNN.cm.<machine>.alcf.anl.gov`.
+_PREFIX_RX = re.compile(
+    r"^(x\d+c\d+s\d+b\d+n\d+)\.(?:[a-z0-9-]+\.)*?cm\.("
+    + _MACHINE
+    + r")\.alcf\.anl\.gov$"
+)
+# Bare prefix with no resolvable machine suffix (last resort).
+_BARE_PREFIX_RX = re.compile(r"^(x\d+c\d+s\d+b\d+n\d+)\.")
+
+
+def normalize_hostname(host: str) -> str | None:
+    """Return the canonical ``.hsn.cm.<machine>.alcf.anl.gov`` form, or
+    ``None`` if ``host`` doesn't look like a valid ALCF compute hostname.
+
+    The machine token (aurora/sunspot/polaris/...) is preserved from the
+    input rather than hardcoded, so the scraper works on any ALCF system.
+    """
+    # Already in canonical form.
+    if HSN_RX.match(host):
+        return host
+    # `xNcNsNbNnN.<other-suffix>.cm.<machine>.alcf.anl.gov` → canonicalize
+    # to the hsn form while keeping the machine token.
+    m = _PREFIX_RX.match(host)
+    if m:
+        return f"{m.group(1)}.hsn.cm.{m.group(2)}.alcf.anl.gov"
+    # Bare `xNcNsNbNnN.<something>` with no recoverable machine token:
+    # return as-given rather than inventing a machine.
+    if _BARE_PREFIX_RX.match(host):
+        return host
+    return None
+
+
+def resolve_ip(ip: str) -> str | None:
+    """Reverse-resolve an IP to a hostname via ``getent hosts``. Returns
+    a canonical ALCF hostname, or ``None`` if the lookup fails or the
+    result doesn't look like a compute node.
+    """
+    try:
+        out = subprocess.check_output(
+            ["getent", "hosts", ip], text=True, timeout=5
+        ).strip()
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        return None
+    if not out:
+        return None
+    # `getent hosts <ip>` → `<ip>  <hostname1> <hostname2>...`
+    # Walk all returned names, return the first one that normalizes.
+    parts = out.split()
+    for p in parts[1:]:
+        canonical = normalize_hostname(p)
+        if canonical:
+            return canonical
+    return None
+
+
+def scrape(log_path: Path) -> list[str]:
+    """Return deduplicated list of bad hostnames in first-seen order."""
+    text = log_path.read_text(errors="replace")
+    seen: list[str] = []
+    seen_set: set[str] = set()
+
+    for m in SIGNAL_RX.finditer(text):
+        host = normalize_hostname(m.group(1))
+        if host and host not in seen_set:
+            seen.append(host)
+            seen_set.add(host)
+
+    for m in GLOO_PEER_RX.finditer(text):
+        ip = m.group(1)
+        host = resolve_ip(ip)
+        if host and host not in seen_set:
+            seen.append(host)
+            seen_set.add(host)
+
+    return seen
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv if argv is None else argv)
+    if len(argv) != 2:
+        print("usage: scrape_bad_nodes.py <log-file>", file=sys.stderr)
+        return 2
+    log_path = Path(argv[1])
+    if not log_path.is_file():
+        print(f"log file not found: {log_path}", file=sys.stderr)
+        return 1
+    for host in scrape(log_path):
+        print(host)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## What

Ports the bad-node **failover** support from torchtitan (`experiments/ezpz/scripts/failover_lib.sh` + `scrape_bad_nodes.py`) into ezpz so it's available directly from the shared shell library — no dependency on the torchtitan experiment tree.

## Why

For resilient large-scale training: request `N + spare` nodes via PBS, run the job on the active subset, and on a detected bad-node crash swap the offending node for a spare and retry. Previously this lived only in torchtitan.

## Added

**`src/ezpz/bin/utils.sh`** — 6 functions (prefixed `ezpz_`, per the file's convention):
| function | purpose |
|---|---|
| `ezpz_failover_init NHOSTS_TRAIN` | split `PBS_NODEFILE` → active/spare hostfiles; export `PBS_NODEFILE` → active subset |
| `ezpz_failover_yeet_all` | `yeet-env` to all nodes (active + spare) so a spare swaps in without re-broadcast |
| `ezpz_failover_swap_in HOSTS...` | replace bad node(s) with spare(s); log to `bad_nodes.txt`; returns 1 when out of spares |
| `ezpz_failover_swap_one_blind` | rotate one spare in when no specific bad node is identifiable (init crash / silent hang) |
| `ezpz_failover_run CMD...` | run CMD, scrape output for bad-node signatures, swap + retry up to `FAILOVER_MAX_RETRIES` |
| `_ezpz_failover_log` | internal `[failover]` stderr logger |

**`src/ezpz/utils/scrape_bad_nodes.py`** — new module: extracts bad-node hostnames from a training log (PALS shepherd signal-9 kills + gloo Connection-closed peer IPs resolved via `getent`).

## Notable deltas from the torchtitan original

- **Generalized beyond Aurora.** The scraper's hostname regexes now match any ALCF machine token (`.hsn.cm.<machine>.alcf.anl.gov`), so node-scraping works on Sunspot/Polaris too — not just Aurora. (The original hardcoded `aurora`.)
- `ezpz_failover_run` invokes the scraper as `python3 -m ezpz.utils.scrape_bad_nodes` instead of a `$(dirname "${BASH_SOURCE[0]}")/scrape_bad_nodes.py` path — robust regardless of where `utils.sh` is sourced from.
- **No top-level `set -o pipefail`** (the source file set it globally; that must not leak into the shared library). The functions use `${PIPESTATUS[0]}`, which works without it.

## Verification

- `bash -n src/ezpz/bin/utils.sh` clean; all 6 functions defined on `source` (`declare -F | grep ezpz_failover`).
- Scratch-dir unit test (no PBS needed): fake 4-node `PBS_NODEFILE` → `ezpz_failover_init 2` yields 2 active + 2 spare; `ezpz_failover_swap_in` replaces a bad node with the first spare and logs it; out-of-spares returns 1.
- Scraper: matches both `*.hsn.cm.aurora...` and `*.hsn.cm.sunspot...` signal-9 host lines, dedups, and correctly excludes cascading `signal 11` deaths; `hostmgmt` suffix normalizes to the `hsn` form preserving the machine token.

Additive shell/utility tooling — independent of #168 (examples/flops) and #169 (`ezpz_activate_venv`).

## Summary by Sourcery

Add shared bad-node failover support for distributed training and integrate it into ezpz utilities.

New Features:
- Introduce ezpz_failover_* shell helpers to initialize PBS node failover state, swap bad nodes for spares, and run commands with automatic retry based on log-scraped failures.
- Add a Python log-scraping utility ezpz.utils.scrape_bad_nodes to detect bad compute nodes from training logs across ALCF machines using PALS and gloo error patterns.

Enhancements:
- Ensure failover tooling works across multiple ALCF systems by generalizing hostname matching and canonicalization, and by invoking the scraper as a Python module rather than via a local script path.