### PR TITLE
docs: refresh fsdp-tp for #168/#169; document compile, fake MFU, activate_venv

### DIFF
--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -161,8 +161,8 @@ all pulled in here.
 
 A logger is set up and W&B is optionally imported.
 
-```python title="src/ezpz/examples/fsdp_tp.py:160:170"
---8<-- "src/ezpz/examples/fsdp_tp.py:160:170"
+```python title="src/ezpz/examples/fsdp_tp.py:160:169"
+--8<-- "src/ezpz/examples/fsdp_tp.py:160:169"
 ```
 
 </details>
@@ -251,8 +251,8 @@ model momentarily during `model.to(device)` before FSDP shards). If
 the model OOMs during init, raise `--tp` (halves per-rank weight
 memory for each doubling) or use a smaller preset.
 
-```python title="src/ezpz/examples/fsdp_tp.py:172:312"
---8<-- "src/ezpz/examples/fsdp_tp.py:172:312"
+```python title="src/ezpz/examples/fsdp_tp.py:170:297"
+--8<-- "src/ezpz/examples/fsdp_tp.py:170:297"
 ```
 
 </details>
@@ -261,8 +261,8 @@ memory for each doubling) or use a smaller preset.
 
 Maps user-facing string names to PyTorch `ShardingStrategy` enum values.
 
-```python title="src/ezpz/examples/fsdp_tp.py:315:321"
---8<-- "src/ezpz/examples/fsdp_tp.py:315:321"
+```python title="src/ezpz/examples/fsdp_tp.py:327:333"
+--8<-- "src/ezpz/examples/fsdp_tp.py:327:333"
 ```
 
 </details>
@@ -273,8 +273,8 @@ When sequence parallelism is active, each TP rank only sees a slice of
 the sequence dimension. This helper narrows the label tensor to match
 the local shard so `cross_entropy` computes the correct loss.
 
-```python title="src/ezpz/examples/fsdp_tp.py:324:379"
---8<-- "src/ezpz/examples/fsdp_tp.py:324:379"
+```python title="src/ezpz/examples/fsdp_tp.py:343:399"
+--8<-- "src/ezpz/examples/fsdp_tp.py:343:399"
 ```
 
 </details>
@@ -285,8 +285,8 @@ the local shard so `cross_entropy` computes the correct loss.
 from `MODEL_PRESETS`; any flag the user provides explicitly takes
 precedence over the preset via `apply_model_preset`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:553:898"
---8<-- "src/ezpz/examples/fsdp_tp.py:553:898"
+```python title="src/ezpz/examples/fsdp_tp.py:690:1086"
+--8<-- "src/ezpz/examples/fsdp_tp.py:690:1086"
 ```
 
 </details>
@@ -297,16 +297,16 @@ This is the core of the 2D parallelism setup. It takes the model and
 device mesh, applies tensor/sequence parallelism along the `"tp"` mesh
 dimension, then wraps the result with FSDP along the `"dp"` dimension.
 
-```python title="src/ezpz/examples/fsdp_tp.py:901:915"
---8<-- "src/ezpz/examples/fsdp_tp.py:901:915"
+```python title="src/ezpz/examples/fsdp_tp.py:1130:1147"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1130:1147"
 ```
 
 **Top-level TP plan.** The embedding is row-sharded, the final output
 projection is column-sharded, and the RMS norm between them uses
 `SequenceParallel`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:916:933"
---8<-- "src/ezpz/examples/fsdp_tp.py:916:933"
+```python title="src/ezpz/examples/fsdp_tp.py:1148:1198"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1148:1198"
 ```
 
 **Per-layer TP plan.** Each transformer block's attention and FFN
@@ -314,15 +314,15 @@ sub-modules are parallelized: Q/K/V projections are column-sharded,
 output projections are row-sharded, and norms use `SequenceParallel`.
 Attention head counts are divided by the TP mesh size.
 
-```python title="src/ezpz/examples/fsdp_tp.py:935:963"
---8<-- "src/ezpz/examples/fsdp_tp.py:935:963"
+```python title="src/ezpz/examples/fsdp_tp.py:1200:1230"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1200:1230"
 ```
 
 **FSDP wrapping.** After TP is applied, the entire model is wrapped with
 FSDP on the `"dp"` sub-mesh.
 
-```python title="src/ezpz/examples/fsdp_tp.py:972:990"
---8<-- "src/ezpz/examples/fsdp_tp.py:972:990"
+```python title="src/ezpz/examples/fsdp_tp.py:1239:1264"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1239:1264"
 ```
 
 </details>
@@ -335,28 +335,28 @@ loads data, then runs the epoch loop.
 **Device mesh creation.** World size is split into `dp` x `tp`
 dimensions.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1227:1233"
---8<-- "src/ezpz/examples/fsdp_tp.py:1227:1233"
+```python title="src/ezpz/examples/fsdp_tp.py:1517:1522"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1517:1522"
 ```
 
 **HuggingFace dataset loading.** If `--dataset` is not `"mnist"` or
 `"random"`, a tokenized HF text dataset is loaded and the vocab size is
 synced to the tokenizer.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1234:1260"
---8<-- "src/ezpz/examples/fsdp_tp.py:1234:1260"
+```python title="src/ezpz/examples/fsdp_tp.py:1524:1546"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1524:1546"
 ```
 
 **Model construction and parallelization.** A `Transformer` is built
 from `ModelArgs`, moved to the device, optionally given a
 `MixedPrecision` config, and then handed to `parallelize`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1262:1275"
---8<-- "src/ezpz/examples/fsdp_tp.py:1262:1275"
+```python title="src/ezpz/examples/fsdp_tp.py:1552:1632"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1552:1632"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:1468:1480"
---8<-- "src/ezpz/examples/fsdp_tp.py:1468:1480"
+```python title="src/ezpz/examples/fsdp_tp.py:1743:1750"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1743:1750"
 ```
 
 **DataLoader setup.** Three branches: MNIST, random synthetic data, or
@@ -364,15 +364,15 @@ HuggingFace datasets. For HF data, a `DistributedSampler` partitions
 across the DP dimension, and `TPBroadcastDataLoader` replicates batches
 within each TP group.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1559:1624"
---8<-- "src/ezpz/examples/fsdp_tp.py:1559:1624"
+```python title="src/ezpz/examples/fsdp_tp.py:1879:1939"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1879:1939"
 ```
 
 **Metric tracking.** An `ezpz.history.History` object is created for
 JSONL metric logging and optional distributed aggregation.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1626:1645"
---8<-- "src/ezpz/examples/fsdp_tp.py:1626:1645"
+```python title="src/ezpz/examples/fsdp_tp.py:1950:1962"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1950:1962"
 ```
 
 **Training loop.** Each batch is moved to device, split into
@@ -380,30 +380,30 @@ JSONL metric logging and optional distributed aggregation.
 `cross_entropy`. Labels are narrowed for sequence parallelism when
 needed. Gradient clipping is applied before `optimizer.step()`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1646:1742"
---8<-- "src/ezpz/examples/fsdp_tp.py:1646:1742"
+```python title="src/ezpz/examples/fsdp_tp.py:1970:2148"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1970:2148"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:1741:1742"
---8<-- "src/ezpz/examples/fsdp_tp.py:1741:1742"
+```python title="src/ezpz/examples/fsdp_tp.py:2067:2074"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2067:2074"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:1808:1818"
---8<-- "src/ezpz/examples/fsdp_tp.py:1808:1818"
+```python title="src/ezpz/examples/fsdp_tp.py:2078:2090"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2078:2090"
 ```
 
 After each step, timing and loss metrics are collected into a dict and
 passed to `history.update` and `history.log_metrics`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1808:1818"
---8<-- "src/ezpz/examples/fsdp_tp.py:1808:1818"
+```python title="src/ezpz/examples/fsdp_tp.py:2141:2148"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2141:2148"
 ```
 
 At the end of training, activation hooks are removed, a barrier syncs
 all ranks, and `history.finalize` writes the summary dataset on rank 0.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1819:1825"
---8<-- "src/ezpz/examples/fsdp_tp.py:1819:1825"
+```python title="src/ezpz/examples/fsdp_tp.py:2151:2156"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2151:2156"
 ```
 
 </details>
@@ -414,15 +414,15 @@ all ranks, and `history.finalize` writes the summary dataset on rank 0.
 distributed backend (including TP groups), determines the output
 directory, and dispatches to `train`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1827:1860"
---8<-- "src/ezpz/examples/fsdp_tp.py:1827:1860"
+```python title="src/ezpz/examples/fsdp_tp.py:2160:2198"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2160:2198"
 ```
 
 The `if __name__ == "__main__"` block parses args, runs `main`, cleans
 up distributed state, and exits.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1862:1864"
---8<-- "src/ezpz/examples/fsdp_tp.py:1862:1864"
+```python title="src/ezpz/examples/fsdp_tp.py:2201:2206"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2201:2206"
 ```
 
 </details>
@@ -462,10 +462,10 @@ See [`ezpz.flops`](../python/Code-Reference/flops.md) for details.
 
 ## torch.compile
 
-Pass `--compile` to wrap the model with `torch.compile` after the
-FSDP/TP wrap. The example compiles **each `TransformerBlock`
-individually** (matching torchtitan's `apply_compile`) rather than the
-whole model:
+Pass `--compile` to apply `torch.compile` after the FSDP/TP wrap. The
+example compiles **each `TransformerBlock` individually** (matching
+torchtitan's `apply_compile`) rather than wrapping the whole model in a
+single `torch.compile` call:
 
 ```bash
 ezpz launch python3 -m ezpz.examples.fsdp_tp --model agpt-2b --tp 2 --compile

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -61,11 +61,13 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
   `block`/`full` wraps each TransformerBlock (~30-40 pct activation-memory
   reduction, ~20 pct throughput hit); matches torchtitan's default for
   agpt-2b/agpt-20b. See [Activation checkpointing](#activation-checkpointing).
-- **Compile with torch.compile** — pass `--compile` to wrap the model with
-  `torch.compile()` after FSDP/DDP wrap. Tune the mode with
+- **Compile with torch.compile** — pass `--compile` to compile each
+  TransformerBlock after the FSDP/TP wrap. Tune the mode with
   `--compile-mode {default,reduce-overhead,max-autotune}` (default: `default`).
   Use `reduce-overhead` for cudagraphs on small models / large batches;
-  `max-autotune` for the slowest startup / fastest steady-state.
+  `max-autotune` for the slowest startup / fastest steady-state. See
+  [torch.compile](#torchcompile) for the per-block rationale and the
+  `--tp`/`--ac`/`--compile` interaction caveat.
 
 > Note: combining `--compile` with `--ac` on HuggingFace models can trigger a
 > `CheckpointError: tensor count mismatch` due to HF's DynamicCache. Drop one
@@ -153,8 +155,8 @@ Standard library, PyTorch, and `ezpz` imports. The key distributed
 primitives -- `DeviceMesh`, `FSDP`, and `parallelize_module` -- are
 all pulled in here.
 
-```python title="src/ezpz/examples/fsdp_tp.py:118:158"
---8<-- "src/ezpz/examples/fsdp_tp.py:118:158"
+```python title="src/ezpz/examples/fsdp_tp.py:115:158"
+--8<-- "src/ezpz/examples/fsdp_tp.py:115:158"
 ```
 
 A logger is set up and W&B is optionally imported.
@@ -226,10 +228,11 @@ Modes:
 
 - **`none`** (default) — keeps all forward activations in memory.
   Lowest latency, highest memory.
-- **`block`** (alias: **`full`**) — wraps each TransformerBlock's
-  forward with `torch.utils.checkpoint`. The block re-runs its
-  forward during backward instead of caching intermediate
-  activations. Typical **30-40% activation-memory reduction**,
+- **`block`** (alias: **`full`**) — wraps each TransformerBlock with
+  the compile-aware `checkpoint_wrapper`
+  (`torch.distributed.algorithms._checkpoint.checkpoint_wrapper`). The
+  block re-runs its forward during backward instead of caching
+  intermediate activations. Typical **30-40% activation-memory reduction**,
   **~20% throughput hit**. Matches torchtitan's default for
   agpt-2b / agpt-20b. `--ac full` is accepted as a compatibility
   alias with torchtitan's CLI.
@@ -248,8 +251,8 @@ model momentarily during `model.to(device)` before FSDP shards). If
 the model OOMs during init, raise `--tp` (halves per-rank weight
 memory for each doubling) or use a smaller preset.
 
-```python title="src/ezpz/examples/fsdp_tp.py:172:303"
---8<-- "src/ezpz/examples/fsdp_tp.py:172:303"
+```python title="src/ezpz/examples/fsdp_tp.py:172:312"
+--8<-- "src/ezpz/examples/fsdp_tp.py:172:312"
 ```
 
 </details>
@@ -258,8 +261,8 @@ memory for each doubling) or use a smaller preset.
 
 Maps user-facing string names to PyTorch `ShardingStrategy` enum values.
 
-```python title="src/ezpz/examples/fsdp_tp.py:226:232"
---8<-- "src/ezpz/examples/fsdp_tp.py:226:232"
+```python title="src/ezpz/examples/fsdp_tp.py:315:321"
+--8<-- "src/ezpz/examples/fsdp_tp.py:315:321"
 ```
 
 </details>
@@ -270,8 +273,8 @@ When sequence parallelism is active, each TP rank only sees a slice of
 the sequence dimension. This helper narrows the label tensor to match
 the local shard so `cross_entropy` computes the correct loss.
 
-```python title="src/ezpz/examples/fsdp_tp.py:235:290"
---8<-- "src/ezpz/examples/fsdp_tp.py:235:290"
+```python title="src/ezpz/examples/fsdp_tp.py:324:379"
+--8<-- "src/ezpz/examples/fsdp_tp.py:324:379"
 ```
 
 </details>
@@ -282,8 +285,8 @@ the local shard so `cross_entropy` computes the correct loss.
 from `MODEL_PRESETS`; any flag the user provides explicitly takes
 precedence over the preset via `apply_model_preset`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:444:524"
---8<-- "src/ezpz/examples/fsdp_tp.py:444:524"
+```python title="src/ezpz/examples/fsdp_tp.py:553:898"
+--8<-- "src/ezpz/examples/fsdp_tp.py:553:898"
 ```
 
 </details>
@@ -294,16 +297,16 @@ This is the core of the 2D parallelism setup. It takes the model and
 device mesh, applies tensor/sequence parallelism along the `"tp"` mesh
 dimension, then wraps the result with FSDP along the `"dp"` dimension.
 
-```python title="src/ezpz/examples/fsdp_tp.py:527:541"
---8<-- "src/ezpz/examples/fsdp_tp.py:527:541"
+```python title="src/ezpz/examples/fsdp_tp.py:901:915"
+--8<-- "src/ezpz/examples/fsdp_tp.py:901:915"
 ```
 
 **Top-level TP plan.** The embedding is row-sharded, the final output
 projection is column-sharded, and the RMS norm between them uses
 `SequenceParallel`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:542:558"
---8<-- "src/ezpz/examples/fsdp_tp.py:542:558"
+```python title="src/ezpz/examples/fsdp_tp.py:916:933"
+--8<-- "src/ezpz/examples/fsdp_tp.py:916:933"
 ```
 
 **Per-layer TP plan.** Each transformer block's attention and FFN
@@ -311,15 +314,15 @@ sub-modules are parallelized: Q/K/V projections are column-sharded,
 output projections are row-sharded, and norms use `SequenceParallel`.
 Attention head counts are divided by the TP mesh size.
 
-```python title="src/ezpz/examples/fsdp_tp.py:560:589"
---8<-- "src/ezpz/examples/fsdp_tp.py:560:589"
+```python title="src/ezpz/examples/fsdp_tp.py:935:963"
+--8<-- "src/ezpz/examples/fsdp_tp.py:935:963"
 ```
 
 **FSDP wrapping.** After TP is applied, the entire model is wrapped with
 FSDP on the `"dp"` sub-mesh.
 
-```python title="src/ezpz/examples/fsdp_tp.py:598:606"
---8<-- "src/ezpz/examples/fsdp_tp.py:598:606"
+```python title="src/ezpz/examples/fsdp_tp.py:972:990"
+--8<-- "src/ezpz/examples/fsdp_tp.py:972:990"
 ```
 
 </details>
@@ -332,28 +335,28 @@ loads data, then runs the epoch loop.
 **Device mesh creation.** World size is split into `dp` x `tp`
 dimensions.
 
-```python title="src/ezpz/examples/fsdp_tp.py:681:695"
---8<-- "src/ezpz/examples/fsdp_tp.py:681:695"
+```python title="src/ezpz/examples/fsdp_tp.py:1227:1233"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1227:1233"
 ```
 
 **HuggingFace dataset loading.** If `--dataset` is not `"mnist"` or
 `"random"`, a tokenized HF text dataset is loaded and the vocab size is
 synced to the tokenizer.
 
-```python title="src/ezpz/examples/fsdp_tp.py:697:718"
---8<-- "src/ezpz/examples/fsdp_tp.py:697:718"
+```python title="src/ezpz/examples/fsdp_tp.py:1234:1260"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1234:1260"
 ```
 
 **Model construction and parallelization.** A `Transformer` is built
 from `ModelArgs`, moved to the device, optionally given a
 `MixedPrecision` config, and then handed to `parallelize`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:720:729"
---8<-- "src/ezpz/examples/fsdp_tp.py:720:729"
+```python title="src/ezpz/examples/fsdp_tp.py:1262:1275"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1262:1275"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:753:782"
---8<-- "src/ezpz/examples/fsdp_tp.py:753:782"
+```python title="src/ezpz/examples/fsdp_tp.py:1468:1480"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1468:1480"
 ```
 
 **DataLoader setup.** Three branches: MNIST, random synthetic data, or
@@ -361,15 +364,15 @@ HuggingFace datasets. For HF data, a `DistributedSampler` partitions
 across the DP dimension, and `TPBroadcastDataLoader` replicates batches
 within each TP group.
 
-```python title="src/ezpz/examples/fsdp_tp.py:840:862"
---8<-- "src/ezpz/examples/fsdp_tp.py:840:862"
+```python title="src/ezpz/examples/fsdp_tp.py:1559:1624"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1559:1624"
 ```
 
 **Metric tracking.** An `ezpz.history.History` object is created for
 JSONL metric logging and optional distributed aggregation.
 
-```python title="src/ezpz/examples/fsdp_tp.py:870:885"
---8<-- "src/ezpz/examples/fsdp_tp.py:870:885"
+```python title="src/ezpz/examples/fsdp_tp.py:1626:1645"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1626:1645"
 ```
 
 **Training loop.** Each batch is moved to device, split into
@@ -377,30 +380,30 @@ JSONL metric logging and optional distributed aggregation.
 `cross_entropy`. Labels are narrowed for sequence parallelism when
 needed. Gradient clipping is applied before `optimizer.step()`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:893:922"
---8<-- "src/ezpz/examples/fsdp_tp.py:893:922"
+```python title="src/ezpz/examples/fsdp_tp.py:1646:1742"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1646:1742"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:958:962"
---8<-- "src/ezpz/examples/fsdp_tp.py:958:962"
+```python title="src/ezpz/examples/fsdp_tp.py:1741:1742"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1741:1742"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:978:985"
---8<-- "src/ezpz/examples/fsdp_tp.py:978:985"
+```python title="src/ezpz/examples/fsdp_tp.py:1808:1818"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1808:1818"
 ```
 
 After each step, timing and loss metrics are collected into a dict and
 passed to `history.update` and `history.log_metrics`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:989:997"
---8<-- "src/ezpz/examples/fsdp_tp.py:989:997"
+```python title="src/ezpz/examples/fsdp_tp.py:1808:1818"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1808:1818"
 ```
 
 At the end of training, activation hooks are removed, a barrier syncs
 all ranks, and `history.finalize` writes the summary dataset on rank 0.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1058:1101"
---8<-- "src/ezpz/examples/fsdp_tp.py:1058:1101"
+```python title="src/ezpz/examples/fsdp_tp.py:1819:1825"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1819:1825"
 ```
 
 </details>
@@ -411,34 +414,80 @@ all ranks, and `history.finalize` writes the summary dataset on rank 0.
 distributed backend (including TP groups), determines the output
 directory, and dispatches to `train`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1066:1087"
---8<-- "src/ezpz/examples/fsdp_tp.py:1066:1087"
+```python title="src/ezpz/examples/fsdp_tp.py:1827:1860"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1827:1860"
 ```
 
 The `if __name__ == "__main__"` block parses args, runs `main`, cleans
 up distributed state, and exits.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1104:1108"
---8<-- "src/ezpz/examples/fsdp_tp.py:1104:1108"
+```python title="src/ezpz/examples/fsdp_tp.py:1862:1864"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1862:1864"
 ```
 
 </details>
 
 ## MFU Tracking
 
-Model FLOPS are estimated via [`try_estimate`](../recipes.md#mfu-tracking)
-on the unwrapped model **before** the 2D FSDP+TP parallelization.
-Per-step **TFLOPS** and **MFU** are reported under `train/tflops`
-and `train/mfu`.
+Model FLOPs are estimated on the unwrapped model **before** the 2D
+FSDP+TP parallelization, and per-step **TFLOPS** and **MFU** are reported
+under `train/tflops` and `train/mfu`.
+
+The example prefers an **exact** count via
+[`try_estimate_fake`](../python/Code-Reference/flops.md): it runs a
+forward+backward under `FakeTensorMode` (shape-only tensors — no
+allocations, so it never OOMs at the real `(batch, seq)` shape) with
+`sdpa_kernel(MATH)` forced so attention decomposes into matmuls the FLOP
+counter can see. If that path fails it falls back to the older
+linear-scaling probe (`try_estimate` at a tiny seq, scaled by the token
+ratio).
+
+> **Why the fake-tensor path matters.** The linear-scaling probe
+> under-counts the `O(seq²)` attention term — and on CPU and the fused
+> SDPA backends `FlopCounterMode` reports *zero* for the attention op
+> entirely, so both the probe and the real shape silently drop it. For
+> agpt-xl at `seq=8192` that made reported MFU ~36% **low**. The exact
+> path includes attention, so when it falls back the printed MFU is a
+> *lower bound*, not an upper bound.
 
 ```python
-_model_flops = try_estimate(model, (args.batch_size, args.seq_len))
+# exact (preferred), with a graceful fallback:
+_model_flops = try_estimate_fake(model, (args.batch_size, args.seq_len))
 # ... per step:
 metrics["train/tflops"] = _model_flops / (t2 - t0) / 1e12
 metrics["train/mfu"] = compute_mfu(_model_flops, t2 - t0)
 ```
 
 See [`ezpz.flops`](../python/Code-Reference/flops.md) for details.
+
+## torch.compile
+
+Pass `--compile` to wrap the model with `torch.compile` after the
+FSDP/TP wrap. The example compiles **each `TransformerBlock`
+individually** (matching torchtitan's `apply_compile`) rather than the
+whole model:
+
+```bash
+ezpz launch python3 -m ezpz.examples.fsdp_tp --model agpt-2b --tp 2 --compile
+```
+
+- Per-block compile dodges a Dynamo graph break that whole-model compile
+  hits on the TP-wrapped `tok_embeddings` (the embedding's
+  `RowwiseParallel` output transform redistributes a `_MaskPartial`
+  DTensor, which Dynamo can't trace under fake tensors), and it amortizes
+  compile cost across the `N` identical layers.
+- `--compile-mode {default,reduce-overhead,max-autotune}` selects the
+  compile mode (default: `default`).
+- For `--compile` to work with FSDP, the example wraps FSDP with
+  `use_orig_params=True` (Dynamo refuses the default `False`), and
+  activation checkpointing uses the compile-aware
+  `checkpoint_wrapper` (see [Activation checkpointing](#activation-checkpointing)).
+
+> **Known limitation.** Combining all three of `--tp > 1`,
+> `--activation-checkpoint`, and `--compile` at once trips an upstream
+> AOTAutograd assertion (a `DeviceMesh` reaches the saved-tensors check).
+> Drop any one of the three until it's fixed upstream. Any two together
+> work.
 
 ## Help
 
@@ -454,26 +503,43 @@ usage: fsdp_tp.py [-h] [--dim DIM] [--n-layers N_LAYERS] [--n-heads N_HEADS]
                   [--epochs EPOCHS] [--batch-size BATCH_SIZE] [--model MODEL]
                   [--test-batch-size TEST_BATCH_SIZE]
                   [--num-workers NUM_WORKERS] [--seed SEED] [--tp TP]
-                  [--sharding-strategy SHARDING_STRATEGY]
+                  [--sharding-strategy {no_shard,full_shard,shard_grad_op,hybrid_shard,hybrid_shard_zero2}]
                   [--activation-checkpoint {none,block,full,selective}]
                   [--max-grad-norm MAX_GRAD_NORM] [--outdir OUTDIR]
                   [--dataset DATASET] [--tokenizer_name TOKENIZER_NAME]
-                  [--model_name_or_path MODEL_NAME_OR_PATH]
                   [--hf-split HF_SPLIT] [--hf-text-column HF_TEXT_COLUMN]
                   [--hf-limit HF_LIMIT] [--seq-len SEQ_LEN]
-                  [--max-seq-len MAX_SEQ_LEN] [--depth-init DEPTH_INIT]
-                  [--fp32]
+                  [--max-seq-len MAX_SEQ_LEN] [--fp32] [--compile]
+                  [--compile-mode {default,reduce-overhead,max-autotune}]
 
 2D Parallel Training
 
 options:
   -h, --help            show this help message and exit
-  --dim DIM
-  --n-layers N_LAYERS
-  --n-heads N_HEADS
+  --dim DIM             Model hidden / embedding dimension (a.k.a. d_model).
+                        Overridden when --model selects a preset. (default:
+                        256)
+  --n-layers N_LAYERS   Number of TransformerBlocks stacked in the model.
+                        Overridden when --model selects a preset. (default:
+                        32)
+  --n-heads N_HEADS     Number of attention heads per layer. Must divide
+                        --dim. Overridden when --model selects a preset.
+                        (default: 32)
   --n-kv-heads N_KV_HEADS
+                        Number of key/value heads for grouped-query attention
+                        (GQA). Must divide --n-heads. Set equal to --n-heads
+                        for standard MHA. Overridden when --model selects a
+                        preset. (default: 4)
   --multiple-of MULTIPLE_OF
+                        Round the SwiGLU FFN hidden dim up to a multiple of
+                        this value (for hardware-friendly shapes). Ignored
+                        when --hidden-dim is set explicitly. (default: 360)
   --ffn-dim-multiplier FFN_DIM_MULTIPLIER
+                        Scale factor applied to the SwiGLU FFN hidden dim
+                        before the --multiple-of rounding step. None (default)
+                        means no extra scaling; Llama2-style models use 1.3.
+                        Ignored when --hidden-dim is set explicitly. (default:
+                        None)
   --hidden-dim HIDDEN_DIM
                         Override SwiGLU FFN hidden dim. When None (default),
                         TransformerBlock derives it as `4 * dim` and
@@ -486,11 +552,20 @@ options:
                         Base frequency for RoPE positional embeddings.
                         Llama1/2 used 10000 (the default); Llama3 uses 500000;
                         agpt-2b uses 50000. (default: 10000.0)
-  --norm-eps NORM_EPS
+  --norm-eps NORM_EPS   Epsilon added to RMSNorm denominators for numerical
+                        stability. (default: 1e-05)
   --vocab-size VOCAB_SIZE
-  --lr LR
-  --epochs EPOCHS
+                        Tokenizer vocabulary size. Sets the embedding table
+                        and output projection sizes; must match the tokenizer
+                        used for the dataset. (default: 32000)
+  --lr LR               Peak learning rate for the AdamW optimizer. (default:
+                        0.003)
+  --epochs EPOCHS       Number of passes over the training dataset. (default:
+                        5)
   --batch-size BATCH_SIZE
+                        Per-DP-rank training batch size (a.k.a. micro-batch).
+                        Global batch = --batch-size * (world_size / --tp).
+                        (default: 1)
   --model MODEL         Model size preset (overrides dim/layer defaults).
                         Presets:
                         debug/small/medium/large/xl/xxl/xxxl/agpt-2b/agpt-20b.
@@ -500,10 +575,35 @@ options:
                         `meta-llama/Llama-3.2-1B`) to load HF weights instead
                         — that path forces --tp 1 (FSDP-only). (default: None)
   --test-batch-size TEST_BATCH_SIZE
+                        Per-DP-rank batch size for the eval/test loader. Only
+                        consumed by the MNIST data path; ignored for random
+                        and HF datasets. (default: 1000)
   --num-workers NUM_WORKERS
-  --seed SEED
-  --tp TP
-  --sharding-strategy SHARDING_STRATEGY
+                        Subprocess workers for the DataLoader. 0 (default)
+                        loads in-process — fine for tokenized HF datasets;
+                        bump for image pipelines or heavy on-the-fly
+                        preprocessing. (default: 0)
+  --seed SEED           Seed for torch/numpy/python RNGs (forwarded to
+                        ezpz.setup_torch). None (default) leaves the RNGs
+                        unseeded for non-deterministic runs. (default: None)
+  --tp TP               Tensor-parallel degree (a.k.a. TP / Megatron-style
+                        sharding). Must divide WORLD_SIZE. The remaining
+                        dimension (WORLD_SIZE / --tp) is used for FSDP data
+                        parallelism. Set to 1 for FSDP-only. Forced to 1 when
+                        --model is a HF repo id. (default: 2)
+  --sharding-strategy {no_shard,full_shard,shard_grad_op,hybrid_shard,hybrid_shard_zero2}
+                        FSDP sharding strategy. `full_shard` (default,
+                        ZeRO-3): shards params, grads, and optimizer state
+                        across all ranks — lowest memory, highest comm.
+                        `shard_grad_op` (ZeRO-2): shards grads and optimizer
+                        state; params replicated — moderate memory, less comm
+                        than full_shard. `no_shard` (ZeRO-0 / DDP-equivalent):
+                        no sharding, pure data parallel — highest memory,
+                        lowest comm. `hybrid_shard`: full_shard within a node,
+                        replicate across nodes — trades inter-node comm for
+                        intra-node sharding (good on slow interconnects).
+                        `hybrid_shard_zero2`: shard_grad_op within a node,
+                        replicate across nodes. (default: full_shard)
   --activation-checkpoint {none,block,full,selective}, --ac {none,block,full,selective}
                         Activation checkpointing strategy. `none` (default)
                         keeps all forward activations in memory. `block`
@@ -515,13 +615,24 @@ options:
                         memory reduction, ~10 pct throughput hit. Trade
                         activation memory for recomputation cost — useful when
                         OOM-ing during training (NOT during init; for init-
-                        time OOM consider increasing --tp or reducing
-                        --seq-len). (default: none)
+                        time OOM consider increasing --tp or reducing --seq-
+                        len). (default: none)
   --max-grad-norm MAX_GRAD_NORM
-  --outdir OUTDIR
-  --dataset DATASET
+                        Clip gradients to this L2 norm before the optimizer
+                        step. Set to 0 (or negative) to disable gradient
+                        clipping. (default: 1.0)
+  --outdir OUTDIR       Base directory for checkpoints and logs. None
+                        (default) writes under the current working directory.
+                        (default: None)
+  --dataset DATASET     Training dataset. Special values: `mnist` (image debug
+                        dataset) and `random` (synthetic tokens, no IO).
+                        Anything else is treated as a HuggingFace dataset repo
+                        id. (default: eliplutchok/fineweb-small-sample)
   --tokenizer_name TOKENIZER_NAME
-  --model_name_or_path MODEL_NAME_OR_PATH
+                        HuggingFace tokenizer repo id used to tokenize the HF
+                        dataset. Auto-overridden to --model when --model is a
+                        HF repo id and --tokenizer_name wasn't passed
+                        explicitly. (default: meta-llama/llama-2-7b-hf)
   --hf-split HF_SPLIT, --hf_split HF_SPLIT
                         Dataset split to load. (default: train)
   --hf-text-column HF_TEXT_COLUMN, --hf_text_column HF_TEXT_COLUMN
@@ -533,11 +644,29 @@ options:
                         positive value (e.g. `--hf-limit 512`) to subsample
                         for smoke tests. Subsampling is deterministic given
                         $EZPZ_HF_SAMPLE_SEED. (default: 0)
-  --seq-len SEQ_LEN
+  --seq-len SEQ_LEN     Training sequence length (tokens per sample). Defaults
+                        to $SEQ_LEN if set, otherwise 1024. Must be <= --max-
+                        seq-len. (default: 1024)
   --max-seq-len MAX_SEQ_LEN
-  --depth-init DEPTH_INIT
+                        Maximum sequence length the model is built to support
+                        — sets the RoPE frequency table size and the attention
+                        scratch budget. Increase if you raise --seq-len.
+                        (default: 32768)
   --fp32                Disable mixed precision (use fp32) for debugging NaNs.
                         (default: False)
+  --compile             Compile each TransformerBlock with torch.compile after
+                        FSDP/TP wrap (matches torchtitan's apply_compile
+                        pattern). Per-block compile dodges the Dynamo +
+                        DTensor _MaskPartial graph break that whole-model
+                        compile hits on TP-wrapped tok_embeddings, and
+                        amortizes compile cost across N layers. (default:
+                        False)
+  --compile-mode {default,reduce-overhead,max-autotune}
+                        torch.compile mode (only used when --compile is set).
+                        `default` is safest. `reduce-overhead` enables
+                        cudagraphs for small models / large batches. `max-
+                        autotune` does extensive kernel search — slow startup,
+                        fastest steady state. (default: default)
 ```
 
 </details>

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -237,9 +237,9 @@ The HF path:
   `feed_forward.w1`, etc.) and won't apply cleanly to HF's
   `LlamaDecoderLayer` / `GemmaDecoderLayer` / etc. The example logs a
   warning if you pass `--tp > 1` along with a HF model.
-- Wraps the model with FSDP using a transformer-block auto-wrap policy
-  derived from the HF model's own `ModuleList` children — so each
-  decoder layer becomes its own FSDP unit.
+- Wraps the model with FSDP2: each block in the HF model's own decoder
+  `ModuleList` gets its own `fully_shard` unit, then the root — so each
+  decoder layer is sharded independently.
 
 ### Activation checkpointing
 
@@ -267,9 +267,10 @@ Modes:
   throughput hit (~10%). Less robust than `block` for arbitrary
   architectures.
 
-AC is applied **after** the TP/FSDP wrap so the checkpoint envelope
-contains FSDP's unshard/reshard bookkeeping; reversed order would
-double-shard and corrupt grads.
+Under FSDP2, AC is applied to each block **before** `fully_shard` (the
+checkpoint wrapper lives inside the FSDP2 unit) — this is torchtitan's
+ordering. (This is the reverse of the FSDP1 order, where AC wrapped the
+already-sharded module.)
 
 Caveat: AC only helps with **training-time** activation memory. It
 will NOT fix init-time OOMs (every rank holds the full unsharded
@@ -285,7 +286,10 @@ memory for each doubling) or use a smaller preset.
 
 <details closed markdown><summary><strong>Sharding Strategies</strong></summary>
 
-Maps user-facing string names to PyTorch `ShardingStrategy` enum values.
+Maps the legacy FSDP1 strategy names (kept as the CLI surface so existing
+scripts don't break) to FSDP2's `reshard_after_forward` policy: `True`
+reshards params after forward (ZeRO-3-like), `False` keeps them gathered
+(ZeRO-2-like).
 
 ```python title="src/ezpz/examples/fsdp_tp.py:327:333"
 --8<-- "src/ezpz/examples/fsdp_tp.py:327:333"
@@ -327,9 +331,10 @@ dimension, then wraps the result with FSDP along the `"dp"` dimension.
 --8<-- "src/ezpz/examples/fsdp_tp.py:1130:1147"
 ```
 
-**Top-level TP plan.** The embedding is row-sharded, the final output
-projection is column-sharded, and the RMS norm between them uses
-`SequenceParallel`.
+**Top-level TP plan.** Applied only when `--tp > 1` (at `--tp 1` the whole
+TP plan is skipped — no SequenceParallel overhead). The embedding is
+row-sharded, the final output projection is column-sharded, and the RMS
+norm between them uses `SequenceParallel`.
 
 ```python title="src/ezpz/examples/fsdp_tp.py:1148:1198"
 --8<-- "src/ezpz/examples/fsdp_tp.py:1148:1198"
@@ -344,8 +349,11 @@ Attention head counts are divided by the TP mesh size.
 --8<-- "src/ezpz/examples/fsdp_tp.py:1200:1230"
 ```
 
-**FSDP wrapping.** After TP is applied, the entire model is wrapped with
-FSDP on the `"dp"` sub-mesh.
+**FSDP2 wrapping.** After TP is applied, each module group is sharded
+independently on the `"dp"` sub-mesh with `fully_shard` — the embedding,
+each TransformerBlock, then `[norm, output]`, then the root last. A final
+`_configure_fsdp_gradient_division` call forces SUM reduction for gradient
+comms on CCL/XPU (matching torchtitan).
 
 ```python title="src/ezpz/examples/fsdp_tp.py:1239:1264"
 --8<-- "src/ezpz/examples/fsdp_tp.py:1239:1264"

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -6,6 +6,19 @@ layers across GPUs within a node) with FSDP (sharding parameters across
 nodes). This is the approach for training very large transformer models where
 both memory and communication efficiency matter.
 
+!!! note "FSDP2 (`fully_shard`)"
+
+    This example uses **FSDP2** — each module group (embedding, every
+    `TransformerBlock`, `[norm, output]`, then the root) is sharded
+    independently with `fully_shard`. Per-module sharding keeps backward
+    memory bounded — in particular for the 256K-vocab embedding + output
+    projection — where FSDP1's single flat-parameter wrap OOM'd at long
+    sequence length. Tensor parallelism is only applied when `--tp > 1`
+    (at `--tp 1` the model stays in plain tensors, no SequenceParallel
+    overhead). The first-step logits debug probe is gated behind
+    `EZPZ_TRACK_LOGITS=1` (off by default — it allocates a full-logits
+    tensor that can itself OOM a large-vocab run).
+
 !!! info "Key API Functions"
 
     - [`setup_torch()`][ezpz.distributed.setup_torch] — Initialize distributed training
@@ -68,6 +81,19 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
   `max-autotune` for the slowest startup / fastest steady-state. See
   [torch.compile](#torchcompile) for the per-block rationale and the
   `--tp`/`--ac`/`--compile` interaction caveat.
+- **Cross-entropy implementation** — `--loss-impl {eager,chunked,compiled}`
+  (default `eager`). At a large vocab (agpt's 256K) and long sequence, eager
+  `F.cross_entropy` materializes a multi-GB `(B·T, vocab)` fp32 logits +
+  gradient transient in backward. `chunked` bounds it to
+  `--loss-chunk-size` rows at a time; `compiled` wraps the CE in
+  `torch.compile` so inductor fuses log-softmax + NLL + backward (what
+  torchtitan does). See [Matching torchtitan](#matching-torchtitan).
+- **Activation-memory budget** — `--act-mem-budget <float>` (default `1.0`,
+  only active with `--compile`). Sets
+  `torch._functorch.config.activation_memory_budget`: `1.0` saves every
+  activation, lower values let the inductor partitioner recompute a fraction
+  in backward to cut peak memory. This is the knob that lets larger batches
+  fit. See [Matching torchtitan](#matching-torchtitan).
 
 > Note: combining `--compile` with `--ac` on HuggingFace models can trigger a
 > `CheckpointError: tensor count mismatch` due to HF's DynamicCache. Drop one
@@ -355,8 +381,8 @@ from `ModelArgs`, moved to the device, optionally given a
 --8<-- "src/ezpz/examples/fsdp_tp.py:1552:1632"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:1743:1750"
---8<-- "src/ezpz/examples/fsdp_tp.py:1743:1750"
+```python title="src/ezpz/examples/fsdp_tp.py:1743:1749"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1743:1749"
 ```
 
 **DataLoader setup.** Three branches: MNIST, random synthetic data, or
@@ -478,10 +504,11 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp --model agpt-2b --tp 2 --compile
   compile cost across the `N` identical layers.
 - `--compile-mode {default,reduce-overhead,max-autotune}` selects the
   compile mode (default: `default`).
-- For `--compile` to work with FSDP, the example wraps FSDP with
-  `use_orig_params=True` (Dynamo refuses the default `False`), and
-  activation checkpointing uses the compile-aware
-  `checkpoint_wrapper` (see [Activation checkpointing](#activation-checkpointing)).
+- The example uses **FSDP2** (`fully_shard`), which has no flat
+  `FlatParameter` and so no `use_orig_params` knob — the Dynamo refusal that
+  FSDP1 hit there is moot. Activation checkpointing still uses the
+  compile-aware `checkpoint_wrapper` (see
+  [Activation checkpointing](#activation-checkpointing)).
 
 > **Known limitation.** Combining all three of `--tp > 1`,
 > `--activation-checkpoint`, and `--compile` at once trips an upstream
@@ -489,28 +516,103 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp --model agpt-2b --tp 2 --compile
 > Drop any one of the three until it's fixed upstream. Any two together
 > work.
 
+## Matching torchtitan
+
+This example targets parity with [torchtitan](https://github.com/pytorch/torchtitan)
+on the same AuroraGPT model. On Sunspot (Intel PVC), agpt-2b at
+`--batch-size 2 --seq-len 7320 --tp 1`, full-shard, 2 nodes (dp=24), the
+recipe below reproduces torchtitan's throughput within noise:
+
+```bash
+ezpz launch python3 -m ezpz.examples.fsdp_tp \
+  --model agpt-2b --seq-len 7320 --batch-size 2 --tp 1 \
+  --sharding-strategy full_shard \
+  --compile --loss-impl compiled --act-mem-budget 0.5
+```
+
+| metric | torchtitan | this example |
+|---|---|---|
+| MFU | ~26% | ~26% |
+| TFLOP/s (per rank) | ~79 | ~77 |
+| tokens/s (per rank) | ~7,300 | ~7,180 |
+
+Three pieces close the gap, all matching what torchtitan does:
+
+- **`--act-mem-budget 0.5`** — the decisive one for memory. torchtitan's
+  `MemoryBudgetAC` sets `activation_memory_budget = 0.5`; this example
+  defaulted to `1.0` (save all activations) and so OOM'd at `bs=2` where
+  torchtitan fit. The budget only takes effect with `--compile` (it drives
+  the inductor min-cut partitioner). `--loss-impl` alone is **not** enough —
+  the eager `(B·T, vocab)` cross-entropy transient is only one contributor;
+  the activation budget is what actually makes `bs=2` fit.
+- **`--loss-impl compiled`** — torchtitan compiles its loss
+  (`compile.components = ["model", "loss"]`); this fuses the large-vocab
+  cross-entropy so its logits/grad transient never fully materializes.
+- **Fused AdamW + FSDP gradient division** — the optimizer now uses
+  `fused=True` with torchtitan's betas/eps/wd, and FSDP2 gradient comms force
+  SUM reduction on CCL/XPU (mirroring torchtitan's
+  `disable_fsdp_gradient_division`). Both are automatic — no flags.
+
+!!! warning "Reading the memory number: allocated vs reserved"
+
+    This example's `memory=alloc/peak` line reports **peak *allocated***
+    bytes; torchtitan's `memory:` line reports **peak *reserved*** bytes,
+    reset per step. They are different metrics, so don't compare them
+    directly. The **allocated** peaks match (~44 GiB for this recipe vs
+    torchtitan's ~44 GiB). This example's cumulative *reserved* peak looks
+    higher only because it includes the one-time compile-warmup
+    high-water mark that torchtitan's per-step reset discards — it is not
+    extra real usage.
+
+Verified batch/loss/budget sweep (agpt-2b, seq=8192, tp=1, full_shard,
+dp=48, `--compile`):
+
+| batch | `--loss-impl` | `--act-mem-budget` | result |
+|---|---|---|---|
+| 1 | eager | 1.0 | fits (peak ~41 GiB alloc) |
+| 2 | eager | 1.0 | OOM in `loss.backward()` |
+| 2 | compiled | 1.0 | OOM (FSDP reduce-scatter) |
+| 2 | chunked | 1.0 | OOM in backward |
+| 2 | compiled | 0.5 | **fits** (peak ~44 GiB alloc) |
+
+Lower the budget further (e.g. `0.3`) to trade more recompute for less
+memory if you need headroom for a bigger batch.
+
 ## Help
 
 <details closed><summary><code>--help</code></summary>
 
 ```bash
-$ python3 -m ezpz.examples.fsdp_tp --help
-usage: fsdp_tp.py [-h] [--dim DIM] [--n-layers N_LAYERS] [--n-heads N_HEADS]
-                  [--n-kv-heads N_KV_HEADS] [--multiple-of MULTIPLE_OF]
+usage: fsdp_tp.py [-h] [--dim DIM] [--n-layers N_LAYERS]
+                  [--n-heads N_HEADS]
+                  [--n-kv-heads N_KV_HEADS]
+                  [--multiple-of MULTIPLE_OF]
                   [--ffn-dim-multiplier FFN_DIM_MULTIPLIER]
-                  [--hidden-dim HIDDEN_DIM] [--rope-theta ROPE_THETA]
-                  [--norm-eps NORM_EPS] [--vocab-size VOCAB_SIZE] [--lr LR]
-                  [--epochs EPOCHS] [--batch-size BATCH_SIZE] [--model MODEL]
+                  [--hidden-dim HIDDEN_DIM]
+                  [--rope-theta ROPE_THETA]
+                  [--norm-eps NORM_EPS]
+                  [--vocab-size VOCAB_SIZE] [--lr LR]
+                  [--epochs EPOCHS]
+                  [--batch-size BATCH_SIZE]
+                  [--model MODEL]
                   [--test-batch-size TEST_BATCH_SIZE]
-                  [--num-workers NUM_WORKERS] [--seed SEED] [--tp TP]
+                  [--num-workers NUM_WORKERS]
+                  [--seed SEED] [--tp TP]
                   [--sharding-strategy {no_shard,full_shard,shard_grad_op,hybrid_shard,hybrid_shard_zero2}]
                   [--activation-checkpoint {none,block,full,selective}]
-                  [--max-grad-norm MAX_GRAD_NORM] [--outdir OUTDIR]
-                  [--dataset DATASET] [--tokenizer_name TOKENIZER_NAME]
-                  [--hf-split HF_SPLIT] [--hf-text-column HF_TEXT_COLUMN]
-                  [--hf-limit HF_LIMIT] [--seq-len SEQ_LEN]
-                  [--max-seq-len MAX_SEQ_LEN] [--fp32] [--compile]
+                  [--max-grad-norm MAX_GRAD_NORM]
+                  [--outdir OUTDIR] [--dataset DATASET]
+                  [--tokenizer_name TOKENIZER_NAME]
+                  [--hf-split HF_SPLIT]
+                  [--hf-text-column HF_TEXT_COLUMN]
+                  [--hf-limit HF_LIMIT]
+                  [--seq-len SEQ_LEN]
+                  [--max-seq-len MAX_SEQ_LEN] [--fp32]
+                  [--compile]
                   [--compile-mode {default,reduce-overhead,max-autotune}]
+                  [--act-mem-budget ACT_MEM_BUDGET]
+                  [--loss-impl {eager,chunked,compiled}]
+                  [--loss-chunk-size LOSS_CHUNK_SIZE]
 
 2D Parallel Training
 
@@ -592,19 +694,23 @@ options:
                         parallelism. Set to 1 for FSDP-only. Forced to 1 when
                         --model is a HF repo id. (default: 2)
   --sharding-strategy {no_shard,full_shard,shard_grad_op,hybrid_shard,hybrid_shard_zero2}
-                        FSDP sharding strategy. `full_shard` (default,
-                        ZeRO-3): shards params, grads, and optimizer state
-                        across all ranks — lowest memory, highest comm.
-                        `shard_grad_op` (ZeRO-2): shards grads and optimizer
-                        state; params replicated — moderate memory, less comm
-                        than full_shard. `no_shard` (ZeRO-0 / DDP-equivalent):
-                        no sharding, pure data parallel — highest memory,
-                        lowest comm. `hybrid_shard`: full_shard within a node,
-                        replicate across nodes — trades inter-node comm for
-                        intra-node sharding (good on slow interconnects).
-                        `hybrid_shard_zero2`: shard_grad_op within a node,
-                        replicate across nodes. (default: full_shard)
-  --activation-checkpoint {none,block,full,selective}, --ac {none,block,full,selective}
+                        FSDP sharding behavior. The model uses FSDP2
+                        (`fully_shard`), which controls sharding via
+                        `reshard_after_forward` rather than a strategy enum;
+                        the legacy FSDP1 names below are kept as the CLI
+                        surface and mapped to the nearest FSDP2 policy.
+                        `full_shard` (default, ZeRO-3): reshard params after
+                        forward — lowest memory, params re-all-gathered in
+                        backward. `shard_grad_op` (ZeRO-2): keep params
+                        unsharded after forward — more memory, avoids the
+                        backward all-gather. `no_shard`: mapped to keep-
+                        unsharded (FSDP2 has no true per-module no-shard).
+                        `hybrid_shard`/`hybrid_shard_zero2`: FSDP1 hybrid has
+                        no one-flag FSDP2 equivalent — `hybrid_shard` maps to
+                        reshard-after-forward, `hybrid_shard_zero2` to keep-
+                        unsharded (mirroring their ZeRO-3/ZeRO-2 variants).
+                        (default: full_shard)
+  --activation-checkpoint, --ac {none,block,full,selective}
                         Activation checkpointing strategy. `none` (default)
                         keeps all forward activations in memory. `block`
                         (alias: `full`) wraps each TransformerBlock — typical
@@ -616,7 +722,12 @@ options:
                         activation memory for recomputation cost — useful when
                         OOM-ing during training (NOT during init; for init-
                         time OOM consider increasing --tp or reducing --seq-
-                        len). (default: none)
+                        len). NOTE: cannot be combined with --compile
+                        (upstream AOTAutograd DeviceMesh-in-saved-tensors bug
+                        — see the --compile warning). With FSDP2 you usually
+                        don't need --ac anyway; it was a workaround for the
+                        FSDP1 backward-memory OOM that FSDP2 fixes. (default:
+                        none)
   --max-grad-norm MAX_GRAD_NORM
                         Clip gradients to this L2 norm before the optimizer
                         step. Set to 0 (or negative) to disable gradient
@@ -633,12 +744,12 @@ options:
                         dataset. Auto-overridden to --model when --model is a
                         HF repo id and --tokenizer_name wasn't passed
                         explicitly. (default: meta-llama/llama-2-7b-hf)
-  --hf-split HF_SPLIT, --hf_split HF_SPLIT
+  --hf-split, --hf_split HF_SPLIT
                         Dataset split to load. (default: train)
-  --hf-text-column HF_TEXT_COLUMN, --hf_text_column HF_TEXT_COLUMN
+  --hf-text-column, --hf_text_column HF_TEXT_COLUMN
                         Column containing raw text in the dataset. (default:
                         text)
-  --hf-limit HF_LIMIT, --hf_limit HF_LIMIT
+  --hf-limit, --hf_limit HF_LIMIT
                         Maximum number of rows to sample from the HF dataset.
                         0 (default) = no limit (use the full dataset). Pass a
                         positive value (e.g. `--hf-limit 512`) to subsample
@@ -667,6 +778,40 @@ options:
                         cudagraphs for small models / large batches. `max-
                         autotune` does extensive kernel search — slow startup,
                         fastest steady state. (default: default)
+  --act-mem-budget ACT_MEM_BUDGET
+                        Activation-memory budget for the inductor min-cut
+                        partitioner (sets
+                        torch._functorch.config.activation_memory_budget).
+                        Only takes effect with --compile. 1.0 (default) saves
+                        ALL activations (no recompute); lower values let the
+                        compiler recompute activations in backward to cut peak
+                        memory — e.g. 0.5 keeps ~half. This is how torchtitan
+                        fits larger batches for the same model (its
+                        MemoryBudgetAC sets 0.5). Try 0.5 if you OOM in
+                        backward at a batch size that should fit. (default:
+                        1.0)
+  --loss-impl {eager,chunked,compiled}
+                        Cross-entropy implementation. `eager` (default) is the
+                        plain F.cross_entropy over the full (B*T, vocab)
+                        logits — simplest, but at large vocab (e.g. agpt's
+                        256K) and long seq it materializes a multi-GB fp32
+                        logits+grad transient in loss.backward() that can OOM
+                        a GPU tile (UR_RESULT_ERROR_OUT_OF_RESOURCES) even
+                        when the model itself fits. `chunked` computes CE over
+                        row-chunks (see --loss-chunk-size) so only one chunk's
+                        logits/grad exist at once — pure eager, no
+                        torch.compile needed. `compiled` wraps CE in
+                        torch.compile so inductor fuses
+                        log_softmax+NLL+backward and never materializes the
+                        full transient (torchtitan's approach). NOTE:
+                        `--compile` only compiles the transformer blocks, NOT
+                        the loss, so it does NOT fix this — use --loss-impl
+                        for the loss transient. (default: eager)
+  --loss-chunk-size LOSS_CHUNK_SIZE
+                        Row-chunk size for --loss-impl=chunked (number of
+                        (B*T) token rows per cross-entropy chunk). Smaller =
+                        lower peak memory, more kernel launches. Ignored for
+                        other --loss-impl. (default: 1024)
 ```
 
 </details>

--- a/docs/notes/shell-environment.md
+++ b/docs/notes/shell-environment.md
@@ -164,6 +164,7 @@ ezpz_setup_env
 | `ezpz_get_scheduler_type`    | Echo the active scheduler: `pbs`, `slurm`, or empty when neither is detected              |
 | `ezpz_get_working_dir`       | Echo the current working directory (shells out to `python3 -c 'os.getcwd()'`)             |
 | `ezpz_check_working_dir`     | Resolve and export `WORKING_DIR`; returns non-zero on failure (see below)                 |
+| `ezpz_activate_venv`         | Activate a venv **and** put its bundled libs first on `LD_LIBRARY_PATH` (see below)        |
 
 ### Shell Variables Exported
 
@@ -211,6 +212,43 @@ Two failure modes the function now signals:
 Pre-v0.18.4 the function had no `return 1` anywhere, so the
 `|| log_message ERROR ...` branch in `ezpz_setup_job` was unreachable
 and a silent empty `WORKING_DIR` could leak through.
+
+### `ezpz_activate_venv` — activate + fix `LD_LIBRARY_PATH`
+
+```bash
+ezpz_activate_venv [venv_dir]   # defaults to ${WORKING_DIR:-$(pwd)}/.venv
+```
+
+Activates a Python venv **and** ensures the venv's bundled libraries are
+**first** on `LD_LIBRARY_PATH`. This matters for accelerator wheels (e.g.
+`torch+xpu`) that ship their own runtime libs (`libsycl`,
+`libur_loader`, …) under `${VIRTUAL_ENV}/lib`: if `ezpz_load_modules`
+loaded a system oneAPI whose copy of those libs is **older**, it shadows
+the wheel's and `import torch` fails with e.g.
+
+```
+ImportError: libsycl.so.9: undefined symbol: urDeviceWaitExp, version LIBUR_LOADER_0.12
+```
+
+`LD_LIBRARY_PATH` takes precedence over a library's own `RUNPATH`
+(`$ORIGIN`), so the robust fix is to (re-)prepend `${VIRTUAL_ENV}/lib`
+**after** module setup. Put it last in the chain:
+
+```bash
+source <(curl -fsSL https://bit.ly/ezpz-utils) \
+  && ezpz_setup_job && ezpz_load_modules && ezpz_activate_venv
+```
+
+Behavior:
+
+- venv `bin/activate` exists → source it, then prepend its lib dir.
+- already in a venv (`VIRTUAL_ENV` set), no activate script at the path →
+  skip activation but still (re-)prepend the lib dir.
+- neither → warn and return `1` (does **not** create a venv; use
+  `ezpz_setup_uv_venv`).
+- The lib dir is forced to the **front**: no-op only if already first,
+  otherwise any existing occurrence is removed and it is re-prepended.
+  Skipped when `${VIRTUAL_ENV}/lib` doesn't exist (a plain CPU venv).
 
 ## Setup Python
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -249,6 +249,7 @@ TORCH_DDP_TIMEOUT=7200 ezpz launch -- python3 train.py
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | OOM during forward pass | All-gather materializes full parameters | Use `reshard_after_forward=True` (ZeRO-3) or reduce batch size |
+| OOM in `loss.backward()` at a batch size that "should" fit (large-vocab / long-seq) | Activations saved at full size (`activation_memory_budget=1.0`) + a multi-GB cross-entropy logits/grad transient | In `ezpz.examples.fsdp_tp`: add `--compile --act-mem-budget 0.5` (inductor recomputes activations) and `--loss-impl compiled` (fuses the CE). See [Matching torchtitan](examples/fsdp-tp.md#matching-torchtitan) |
 | `FSDP not supported on mps` | Apple MPS doesn't support FSDP | Expected — ezpz auto-falls back to DDP; or use `use_fsdp=False` |
 | Checkpoint saved with FSDP won't load in DDP | State dict format mismatch | Save a portable checkpoint (see below) |
 | `RuntimeError: ... DeviceMesh` | PyTorch version mismatch | FSDP2 requires PyTorch 2.4+; check `python -c "import torch; print(torch.__version__)"` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,7 +75,7 @@ source <(curl -fsSL https://bit.ly/ezpz-utils) \
   && ezpz_setup_job && ezpz_load_modules && ezpz_activate_venv
 ```
 
-See [`ezpz_activate_venv`](notes/shell-environment.md#ezpz_activate_venv--activate--fix-ld_library_path)
+See [`ezpz_activate_venv`](notes/shell-environment.md#ezpz_activate_venv-activate-fix-ld_library_path)
 for details.
 
 ### Distributed Training Hangs / Deadlocks

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,32 @@ recommended fix.
 |---------|-------|-----|
 | `ModuleNotFoundError: ezpz` | Not installed | `pip install git+https://github.com/saforem2/ezpz` |
 | `ImportError: ... .so` | Binary incompatibility | Rebuild from source; match Python/PyTorch versions |
+| `ImportError: libsycl.so.9: undefined symbol: urDeviceWaitExp` (XPU) | System oneAPI libs shadow the venv's bundled ones | Prepend the venv libs — use `ezpz_activate_venv` (see below) |
+
+#### `libsycl.so` undefined symbol on XPU
+
+When a `torch+xpu` wheel is installed in a venv, it ships its own
+`libsycl` / `libur_loader` under `${VIRTUAL_ENV}/lib`. If you load a
+system oneAPI module (e.g. via `ezpz_load_modules`) **after** activating
+the venv, the module's older copy lands first on `LD_LIBRARY_PATH` and
+shadows the wheel's, so `import torch` dies with:
+
+```
+ImportError: .../torch/lib/../../../../libsycl.so.9: undefined symbol: urDeviceWaitExp, version LIBUR_LOADER_0.12
+```
+
+`LD_LIBRARY_PATH` wins over a library's own `RUNPATH`, so the fix is to
+ensure `${VIRTUAL_ENV}/lib` is **first**. Use `ezpz_activate_venv`
+(activates the venv and re-prepends its lib dir), and put it **last** in
+the setup chain so it runs after module loading:
+
+```bash
+source <(curl -fsSL https://bit.ly/ezpz-utils) \
+  && ezpz_setup_job && ezpz_load_modules && ezpz_activate_venv
+```
+
+See [`ezpz_activate_venv`](notes/shell-environment.md#ezpz_activate_venv--activate--fix-ld_library_path)
+for details.
 
 ### Distributed Training Hangs / Deadlocks
 


### PR DESCRIPTION
Documentation follow-up for #168 (fsdp_tp `--compile`/MFU/flag changes) and #169 (`ezpz_activate_venv`), both now merged. Those code changes left the docs stale — this fixes that and documents the new features.

## `docs/examples/fsdp-tp.md`

**Fix stale/broken content from #168:**
- **Regenerated the `--help` block** — it still listed the deleted `--model_name_or_path` and `--depth-init` flags and a bare `--sharding-strategy`. The new block is verified **byte-identical** to live `python3 -m ezpz.examples.fsdp_tp --help` (drops the deleted flags, shows `--sharding-strategy {no_shard,…}` choices + the per-block `--compile` help).
- **Re-anchored all 22 `--8<--` snippet line-ranges.** #168 added ~280 lines to `parse_args` + new functions, so every range below it had drifted — several were embedding the wrong code mid-statement (e.g. the "Argument Parsing" snippet landed on `except ValueError:`). All ranges re-derived from the current file and validated in-bounds on clean boundaries.
- **AC prose** updated: `checkpoint_wrapper` (ptd), not `torch.utils.checkpoint`.

**New content:**
- **`## torch.compile` section** — per-block compile rationale (dodges the `_MaskPartial` embedding graph break), the `use_orig_params=True` + `checkpoint_wrapper` requirements, and the `{--tp, --ac, --compile}` upstream-limitation caveat.
- **MFU section** — documents the exact `try_estimate_fake` path and why it matters (the linear probe under-counts attention → MFU was ~36% low).

## `docs/notes/shell-environment.md`
- Document **`ezpz_activate_venv`** — Key Functions table row + dedicated section (behavior, fallbacks, and the libsycl/`LD_LIBRARY_PATH` rationale).

## `docs/troubleshooting.md`
- Add the **`libsycl.so: undefined symbol: urDeviceWaitExp`** (XPU) entry with the `ezpz_activate_venv` fix.

## Verification
- `--help` block diffs byte-identical against live output.
- All 22 snippet ranges validated: in-bounds (file is 1872 lines), `start ≤ end`, landing on clean statement boundaries.
- Stale references confirmed gone (0 hits for the deleted flags / old AC mechanism); new anchors resolve.

Docs-only → `release:skip`.

## Summary by Sourcery

Refresh and expand documentation around the FSDP+TP example, MFU tracking, and shell environment virtualenv handling to match recently merged features.

Documentation:
- Update the FSDP/TP example docs to reflect current CLI flags, activation checkpointing behavior, MFU estimation, and torch.compile usage, including regenerated --help output and corrected code snippet ranges.
- Document the new ezpz_activate_venv helper, explaining its behavior, LD_LIBRARY_PATH handling, and rationale for accelerator wheels shipping their own libs.
- Add troubleshooting guidance for libsycl.so undefined symbol errors on XPU, pointing users to ezpz_activate_venv and proper environment setup.