### PR TITLE
fix(utils): inline std tight in compact summary (drop intra-paren padding)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -116,12 +116,12 @@ Each call to `update()`:
 
 ### Console summary format
 
-`update()` returns a column-aligned `key=value(±std)` string designed to
+`update()` returns a compact `key=value(±std)` string designed to
 collapse the noisy `loss=…  loss/mean=…  loss/max=…  loss/min=…  loss/std=…`
 shape into a single scannable line:
 
 ```
-iter=180   loss=0.078(± 0.026) accuracy=0.984(±9.9e-3) dtf=0.014(±7.4e-4) lr=0.000059 memory=0.01/0.01GiB (0%)
+iter=180   loss=0.078(±0.026) accuracy=0.984(±9.9e-3) dtf=0.014(±7.4e-4) lr=0.000059 memory=0.01/0.01GiB (0%)
 ```
 
 Format rules (all handled by [`ezpz.utils.format_compact_summary`][ezpz.utils.format_compact_summary]):
@@ -130,19 +130,22 @@ Format rules (all handled by [`ezpz.utils.format_compact_summary`][ezpz.utils.fo
   distributed history is on), the std is appended inline as
   `X=value(±std)`. The `/mean`, `/min`, `/max`, `/avg` companions are
   dropped from the console — trackers still receive them.
-- **Std values are right-aligned in a 6-char column** so a row with
-  `(±0.070)` lines up under one with `(±5.1e-4)` or `(±  0.12)`.
+- **Std hugs its value**: `value(±std)` with no padding inside the
+  parentheses (`loss=0.078(±0.026)`, not `loss=0.078(±  0.026)`). The
+  values preceding each `(±…)` are themselves variable-width, so padding
+  the std never actually aligned the parentheticals into columns — it just
+  added ragged whitespace after every `±`.
 - **Counter-like keys** (`iter`, `step`, `epoch`, `batch`, `idx`) are
   bare (no `(±std)`) and left-edge padded so the next field aligns
   across rows: `iter=8     loss=…` lines up under `iter=180   loss=…`.
+  (This per-field counter padding is unchanged — it aligns real columns.)
 - **Replicated hyperparameters** (`lr`, `momentum`, `weight_decay`,
   `beta1`, `beta2`, `eps`, `clip_grad`, `warmup_steps`, …) are bare —
-  their per-step std is always 0 across ranks, so no parenthetical and
-  no padding gap is emitted.
+  their per-step std is always 0 across ranks, so no parenthetical is
+  emitted.
 - **Std formatting**: 2 sig figs, fixed-point for magnitudes ≥ 0.01
   (`0.16`, `0.020`, `1.3`), scientific for magnitudes < 0.01 with the
-  leading exponent zero stripped (`5.1e-4`, not `5.1e-04`). Bounded
-  width keeps columns stable across runs.
+  leading exponent zero stripped (`5.1e-4`, not `5.1e-04`).
 
 ### Device memory tracking
 

--- a/src/ezpz/utils/__init__.py
+++ b/src/ezpz/utils/__init__.py
@@ -848,10 +848,11 @@ def format_compact_summary(
         if std is not None and not _is_counter(k) and not _is_known_constant(k):
             std_token = _format_std(std, precision=precision)
             if std_token is None:
-                # std rounds to zero at the chosen precision (e.g.
-                # `lr/std=1e-12` with precision=2). `(±0)` adds no signal,
-                # so drop the parenthetical entirely and emit the bare
-                # value — same as a metric with no std at all.
+                # std is exactly 0.0 (`_format_std` returns None only for
+                # std == 0; non-zero stds always format, in scientific
+                # notation if tiny). `(±0)` adds no signal, so drop the
+                # parenthetical entirely and emit the bare value — same as
+                # a metric with no std at all.
                 tokens.append(base_token)
             else:
                 # Inline the std tight: `loss=0.500000(±0.020)`. No column

--- a/src/ezpz/utils/__init__.py
+++ b/src/ezpz/utils/__init__.py
@@ -734,15 +734,6 @@ _DEFAULT_MIN_WIDTHS: dict[str, int] = {
     "bidx": 9,
 }
 
-# Max width of the std token produced by `_format_std` (see its
-# docstring for the bounds proof: fixed-point >= 0.01 caps at ~5 chars,
-# scientific notation < 0.01 caps at 6 chars like "5.1e-4"). Right-
-# aligning std tokens to this width makes every `(±X)` parenthetical
-# exactly `_STD_TOKEN_MAX_WIDTH + 3` chars wide ("(±" + token + ")"), so
-# columns align across log rows even when stds swing between fixed and
-# scientific forms.
-_STD_TOKEN_MAX_WIDTH = 6
-
 
 def format_compact_summary(
     metrics: dict[str, float],
@@ -858,19 +849,16 @@ def format_compact_summary(
             std_token = _format_std(std, precision=precision)
             if std_token is None:
                 # std rounds to zero at the chosen precision (e.g.
-                # `lr/std=1e-12` with precision=2). `(±0)` adds no
-                # signal; drop it. Pad with spaces matching the width
-                # of a full `(±XXXXXX)` parenthetical so this token's
-                # successor still aligns with its neighbors above/below
-                # — important for metrics that swing between zero and
-                # non-zero std across rows (e.g. small/sporadic noise).
-                pad = " " * (_STD_TOKEN_MAX_WIDTH + 3)
-                tokens.append(f"{base_token}{pad}")
+                # `lr/std=1e-12` with precision=2). `(±0)` adds no signal,
+                # so drop the parenthetical entirely and emit the bare
+                # value — same as a metric with no std at all.
+                tokens.append(base_token)
             else:
-                # Right-align the std token so `(±0.070)`, `(±0.12)`,
-                # and `(±5.1e-4)` all occupy the same number of columns.
-                padded = std_token.rjust(_STD_TOKEN_MAX_WIDTH)
-                tokens.append(f"{base_token}(±{padded})")
+                # Inline the std tight: `loss=0.500000(±0.020)`. No column
+                # padding inside the parens — the parenthetical hugs the
+                # value, and successive rows align per-token at the left
+                # edge rather than into std columns.
+                tokens.append(f"{base_token}(±{std_token})")
         else:
             # Counters and known-constant hyperparameters: no padding,
             # no parenthetical. Counters still get left-edge padding so

--- a/tests/test_memory_metrics.py
+++ b/tests/test_memory_metrics.py
@@ -527,15 +527,14 @@ class TestFormatCompactSummary:
     """The ``key=value(±std)`` console renderer."""
 
     def test_collapses_base_and_std_into_inline_format(self):
-        """`loss=0.5` + `loss/std=0.02` → `loss=0.50(± 0.020)` (std
-        right-aligned to 6 chars for column alignment across rows)."""
+        """`loss=0.5` + `loss/std=0.02` → `loss=0.50(±0.020)` (std inlined
+        tight, no column padding inside the parens)."""
         from ezpz.utils import format_compact_summary
         out = format_compact_summary(
             {"loss": 0.5, "loss/std": 0.02}, precision=2,
         )
-        # 0.02 at 2 sig figs (fixed-point, magnitude=-2) → "0.020"
-        # (5 chars), right-padded to 6 inside `(±...)`.
-        assert out == "loss=0.50(± 0.020)"
+        # 0.02 at 2 sig figs (fixed-point, magnitude=-2) → "0.020".
+        assert out == "loss=0.50(±0.020)"
 
     def test_drops_other_aggregation_suffixes(self):
         """`/mean`, `/min`, `/max`, `/avg` are dropped (W&B has them)."""
@@ -549,7 +548,7 @@ class TestFormatCompactSummary:
             precision=2,
         )
         # All four aggregation suffixes drop; only the inline std survives.
-        assert out == "loss=0.50(± 0.020)"
+        assert out == "loss=0.50(±0.020)"
         assert "/mean" not in out and "/max" not in out and "/min" not in out
 
     def test_std_uses_two_sig_figs(self):
@@ -564,8 +563,8 @@ class TestFormatCompactSummary:
         out = format_compact_summary(
             {"loss": 0.289993, "loss/std": 0.157124}, precision=6,
         )
-        # "0.16" is 4 chars; right-padded to 6 inside `(±...)`.
-        assert out == "loss=0.289993(±  0.16)"
+        # "0.16" inlined tight, no column padding.
+        assert out == "loss=0.289993(±0.16)"
 
     def test_zero_std_drops_parenthetical(self):
         """`(±0.0)` adds no signal — drop it entirely. Common for
@@ -609,8 +608,8 @@ class TestFormatCompactSummary:
         out = format_compact_summary(
             {"tflops": 16.778491, "tflops/std": 1.297581}, precision=6,
         )
-        # "1.3" is 3 chars; right-padded to 6 inside `(±...)`.
-        assert out == "tflops=16.778491(±   1.3)"
+        # "1.3" inlined tight, no column padding.
+        assert out == "tflops=16.778491(±1.3)"
 
     def test_skips_memory_keys_entirely(self):
         """Memory keys are handled by format_memory_summary; never appear here."""
@@ -632,7 +631,7 @@ class TestFormatCompactSummary:
         as bare `key=value` with no `(±...)` and no 9-char pad gap.
 
         This is the visual fix for log lines like
-            ... acc=0.5(±  0.12) lr=0.000059          dt=...
+            ... acc=0.5(±0.12) lr=0.000059          dt=...
         where the `lr` token's wide trailing whitespace gap was reserving
         space for a (±std) parenthetical that will never appear.
         """
@@ -647,7 +646,7 @@ class TestFormatCompactSummary:
         # No 9-char gap (the old behavior would emit "lr=0.000059         ").
         assert "lr=0.000059  " not in out
         # loss still gets its inline std as before.
-        assert "(±" in out  # loss=0.500000(± 0.020)
+        assert "(±" in out  # loss=0.500000(±0.020)
 
     def test_constant_keys_kwarg_extends_set(self):
         """Callers can mark extra metrics as known-constant via
@@ -675,8 +674,8 @@ class TestFormatCompactSummary:
         assert "iter=100" in out
         assert "iter=100(" not in out  # not "iter=100(±5.00)"
         # loss still has its inline std (2 sig figs, magnitude=-2 →
-        # "0.020", right-padded to 6 chars inside `(±...)`).
-        assert "loss=0.50(± 0.020)" in out
+        # "0.020", inlined tight).
+        assert "loss=0.50(±0.020)" in out
 
     def test_no_std_no_parenthetical(self):
         """When `/std` is absent, the metric prints as-is — no (±0) noise."""
@@ -760,9 +759,9 @@ class TestFormatCompactSummary:
         # 4 tokens: iter, loss(±std), accuracy(±std), dtf (no std — it's 0)
         assert out.count("=") == 4
         assert "iter=180" in out
-        # 2 sig figs fixed-point: 0.023 → "0.023" (5 chars, padded to 6).
-        assert "loss=0.047(± 0.023)" in out
-        # 0.007 < 0.01 → scientific: "7.0e-3" (already 6 chars, no pad).
+        # 2 sig figs fixed-point: 0.023 → "0.023", inlined tight.
+        assert "loss=0.047(±0.023)" in out
+        # 0.007 < 0.01 → scientific: "7.0e-3".
         assert "accuracy=1.000(±7.0e-3)" in out
         # dtf/std=0.000 → drop the parenthetical entirely.
         assert "dtf=0.009" in out


### PR DESCRIPTION
## What

Tighten the per-step training summary line so the `(±std)` parentheticals
hug their value instead of carrying right-justified column padding.

**Before:**
```
... loss=8.671097(±  0.34) ... tflops=72.869066(± 0.074) mfu=24.437224(± 0.025) ...
```

**After:**
```
... loss=8.671097(±0.34) ... tflops=72.869066(±0.074) mfu=24.437224(±0.025) ...
```

## Why

`format_compact_summary` right-justified each std token to a fixed 6-char
width *inside* the parens (`_STD_TOKEN_MAX_WIDTH`) so that `(±…)`
parentheticals would line up into columns across log rows. But the values
*before* each `(±…)` are themselves variable-width, so the parentheticals
never actually aligned — the padding just produced ragged whitespace after
every `±`.

## Changes

- Drop the `.rjust(_STD_TOKEN_MAX_WIDTH)` pad inside `(±…)`.
- Drop the companion 9-space reserve emitted when a *non-constant* metric's
  std rounds to zero (it only existed to keep the next field aligned under
  rows that had a `(±…)`; moot once parentheticals are tight).
- Remove the now-unused `_STD_TOKEN_MAX_WIDTH` constant.
- Counter left-edge padding (`iter=8   `) is **unchanged** — it aligns real
  columns and is a separate feature.
- Update `TestFormatCompactSummary` expectations to the tight form.

## Verified

On a Sunspot compute node (Aurora frameworks env):
- `tests/test_memory_metrics.py` — **56 passed**
- `tests/test_history.py` (summary subset) — **10 passed**
- Rendered the exact example line from the issue → matches the desired tight output.

## Summary by Sourcery

Tighten per-metric std parentheticals in compact training summaries so `(±std)` tokens hug their values instead of using intra-parenthesis column padding, and drop padding when std rounds to zero.

Enhancements:
- Remove std token right-justification and fixed-width padding inside `(±std)` in `format_compact_summary`, simplifying log line layout.
- Eliminate padding for metrics whose std rounds to zero so they render as bare `key=value`, matching metrics without std.

Tests:
- Update `TestFormatCompactSummary` expectations to the new tight `(±std)` formatting across realistic and synthetic summary cases.