### PR TITLE
docs(agents): use merge commits (not squash) for richer release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,17 @@ Guidance for AI coding assistants (and humans) working in this repo.
 - **Every PR needs a `release:` label before merge**: one of
   `release:patch`, `release:minor`, `release:major`, or `release:skip`.
   There is no default-to-patch — pick deliberately. Merging triggers
-  release-please to auto-cut a tagged release (except `release:skip`).
-- Squash-merge is the current convention (commit subject ends with the
-  `(#NN)` PR number).
+  `.github/workflows/release-on-merge.yml` to bump the version (via
+  `hatch version`), append a `CHANGELOG.md` entry, tag, and cut a GitHub
+  release (except `release:skip`).
+- **Merge with a merge commit, not squash.** `release-on-merge.yml` builds
+  the changelog + release notes from `git log --pretty=%s {prev_tag}..HEAD`
+  — i.e. *every* commit in the range. A merge commit preserves each
+  branch commit as its own release-note bullet; a squash collapses the
+  whole PR to one line. Keep branch commits atomic and well-titled
+  (`type(scope): message`) so each becomes a clean bullet. (Trade-off: the
+  `Merge pull request #NN …` line also appears as a bullet — acceptable
+  noise for the per-change detail.)
 
 ## Module structure
 


### PR DESCRIPTION
## What

Update the **Commits & PRs** section of `AGENTS.md` to recommend **merge
commits instead of squash** when landing PRs, and fix a stale workflow
reference.

## Why

`.github/workflows/release-on-merge.yml` generates the `CHANGELOG.md` entry
and GitHub release body from:

```
git log --pretty=format:%s|%H  {prev_tag}..HEAD
```

That's *every commit in the range*, one bullet each. So:

- **Squash merge** → the whole PR collapses to a single release-note bullet.
- **Merge commit** → each atomic branch commit becomes its own bullet.

The merge-commit form gives readers of the release notes far more insight
into what actually changed. Verified live on v0.21.1 (PR #173 merged as a
merge commit → 9 individual commit bullets in the release notes).

Also fixes a stale reference: the section said merging triggers
*release-please*, but the actual workflow is the hatch-based
`release-on-merge.yml`.

## Trade-off (documented)

The `Merge pull request #NN …` commit also shows up as a bullet — minor
noise, accepted in exchange for the per-change detail. Mitigated by keeping
branch commits atomic and well-titled (`type(scope): message`).

## Summary by Sourcery

Document merge commits as the preferred strategy for landing PRs so release notes include all atomic commits and ensure the release workflow reference is accurate.

Documentation:
- Update AGENTS.md to recommend using merge commits instead of squash merges to produce richer, per-commit release notes.
- Clarify that the release-on-merge workflow handles version bumps, changelog updates, tagging, and GitHub releases instead of release-please.