### PR TITLE
feat(examples): --profile support across all ezpz.examples.* via shared helpers

### DIFF
--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -48,6 +48,120 @@ def _spare_nodes_value(value: str) -> "int | str":
     return _non_negative_int(value)
 
 
+def add_profiling_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Add the shared profiling flag-set used across ``ezpz.examples.*``.
+
+    This is the single source of truth for the profiler CLI surface.
+    ``ezpz.examples.test`` was the only example with profiling support;
+    these flags were inlined in :func:`build_test_parser`. Extracting
+    them here lets every example (`fsdp_tp`, `fsdp`, `vit`, `diffusion`)
+    expose an identical surface by calling this once, instead of
+    copy-pasting ~80 lines that would inevitably drift.
+
+    Pair with :func:`ezpz.profile.profiling_context_from_args`, which
+    consumes the resulting namespace and returns the context manager.
+
+    The flag spellings are kept exactly as they were in ``test`` so
+    existing muscle-memory / docs / scripts carry over unchanged:
+
+    - ``--pyinstrument-profiler`` — statistical (pyinstrument) profiler.
+    - ``-p`` / ``--profile`` (dest ``pytorch_profiler``) — torch profiler.
+    - ``--rank-zero-only`` — only profile rank 0 (one trace, not N).
+    - ``--pytorch-profiler-{wait,warmup,active,repeat}`` — schedule.
+    - ``--profile-memory`` / ``--record-shapes`` / ``--with-stack`` /
+      ``--with-flops`` / ``--with-modules`` — torch profiler detail
+      toggles (``BooleanOptionalAction`` → each has a ``--no-*`` form).
+    - ``--acc-events`` — accumulate events across schedule cycles.
+    """
+    parser.add_argument(
+        "--pyinstrument-profiler",
+        action="store_true",
+        help="Profile the training loop",
+    )
+    parser.add_argument(
+        "-p",
+        "--profile",
+        default=False,
+        dest="pytorch_profiler",
+        required=False,
+        action="store_true",
+        help="Use PyTorch profiler",
+    )
+    parser.add_argument(
+        "--rank-zero-only",
+        action="store_true",
+        help="Run profiler only on rank 0",
+    )
+    parser.add_argument(
+        "--pytorch-profiler-wait",
+        type=int,
+        default=1,
+        help="Wait time before starting the PyTorch profiler",
+    )
+    parser.add_argument(
+        "--pytorch-profiler-warmup",
+        type=int,
+        default=2,
+        help="Warmup iterations for the PyTorch profiler",
+    )
+    parser.add_argument(
+        "--pytorch-profiler-active",
+        type=int,
+        default=3,
+        help="Active iterations for the PyTorch profiler",
+    )
+    parser.add_argument(
+        "--pytorch-profiler-repeat",
+        type=int,
+        default=5,
+        help="Repeat iterations for the PyTorch profiler",
+    )
+    # The next five flags default to True. They were declared as
+    # `action="store_true"`, which made them unreachable as False —
+    # passing the flag and not passing it both produced True.
+    # BooleanOptionalAction generates the matching --no-* form so users
+    # can actually disable each one (e.g. `--no-with-stack`).
+    parser.add_argument(
+        "--profile-memory",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Profile memory usage",
+    )
+    parser.add_argument(
+        "--record-shapes",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Record shapes in the profiler",
+    )
+    parser.add_argument(
+        "--with-stack",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Include stack traces in the profiler",
+    )
+    parser.add_argument(
+        "--with-flops",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Include FLOPs in the profiler",
+    )
+    parser.add_argument(
+        "--with-modules",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Include module information in the profiler",
+    )
+    parser.add_argument(
+        "--acc-events",
+        default=False,
+        action="store_true",
+        help="Accumulate events in the profiler",
+    )
+    return parser
+
+
 def build_test_parser(*, prog: str | None = None) -> argparse.ArgumentParser:
     """Build the CLI argument parser for ``ezpz test`` (ezpz.examples.test)."""
     parser = argparse.ArgumentParser(
@@ -104,95 +218,15 @@ def build_test_parser(*, prog: str | None = None) -> argparse.ArgumentParser:
         default="DDP",
         help="Backend (DDP, DeepSpeed, etc.)",
     )
-    parser.add_argument(
-        "--pyinstrument-profiler",
-        action="store_true",
-        help="Profile the training loop",
-    )
-    parser.add_argument(
-        "-p",
-        "--profile",
-        default=False,
-        dest="pytorch_profiler",
-        required=False,
-        action="store_true",
-        help="Use PyTorch profiler",
-    )
-    parser.add_argument(
-        "--rank-zero-only",
-        action="store_true",
-        help="Run profiler only on rank 0",
-    )
-    parser.add_argument(
-        "--pytorch-profiler-wait",
-        type=int,
-        default=1,
-        help="Wait time before starting the PyTorch profiler",
-    )
-    parser.add_argument(
-        "--pytorch-profiler-warmup",
-        type=int,
-        default=2,
-        help="Warmup iterations for the PyTorch profiler",
-    )
-    parser.add_argument(
-        "--pytorch-profiler-active",
-        type=int,
-        default=3,
-        help="Active iterations for the PyTorch profiler",
-    )
-    parser.add_argument(
-        "--pytorch-profiler-repeat",
-        type=int,
-        default=5,
-        help="Repeat iterations for the PyTorch profiler",
-    )
-    # The next five flags default to True and were declared as
-    # `action="store_true"`, which made them unreachable as False —
-    # passing the flag and not passing it both produced True.
-    # BooleanOptionalAction generates the matching --no-* form so users
-    # can actually disable each one (e.g. `--no-with-stack`).
-    parser.add_argument(
-        "--profile-memory",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Profile memory usage",
-    )
-    parser.add_argument(
-        "--record-shapes",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Record shapes in the profiler",
-    )
+    # Shared profiler flags (--profile / --pyinstrument-profiler / etc.)
+    # live in add_profiling_args so every ezpz.examples.* module exposes
+    # an identical surface. --save-datasets below is test-specific.
+    add_profiling_args(parser)
     parser.add_argument(
         "--save-datasets",
         action="store_true",
         default=False,
         help="Save datasets",
-    )
-    parser.add_argument(
-        "--with-stack",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Include stack traces in the profiler",
-    )
-    parser.add_argument(
-        "--with-flops",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Include FLOPs in the profiler",
-    )
-    parser.add_argument(
-        "--with-modules",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Include module information in the profiler",
-    )
-    parser.add_argument(
-        "--acc-events",
-        default=False,
-        action="store_true",
-        help="Accumulate events in the profiler",
     )
     parser.add_argument(
         "--train-iters",

--- a/src/ezpz/configs.py
+++ b/src/ezpz/configs.py
@@ -986,7 +986,9 @@ class HfProfileArguments:
         metadata={"help": "Enable the pyinstrument statistical profiler."},
     )
     rank_zero_only: bool = field(
-        default=True,
+        # Match add_profiling_args' --rank-zero-only default (False) so HF
+        # profiling behavior doesn't diverge from the other examples.
+        default=False,
         metadata={"help": "Only run the profiler on global rank 0."},
     )
     pytorch_profiler_wait: int = field(

--- a/src/ezpz/configs.py
+++ b/src/ezpz/configs.py
@@ -979,7 +979,14 @@ class HfProfileArguments:
 
     pytorch_profiler: bool = field(
         default=False,
-        metadata={"help": "Enable the torch profiler (chrome traces)."},
+        # Expose the same -p/--profile spelling add_profiling_args gives the
+        # other examples. HfArgumentParser only derives --pytorch-profiler
+        # from the field name; aliases adds the documented shared flag so
+        # `--profile`/`-p` aren't rejected here.
+        metadata={
+            "help": "Enable the torch profiler (chrome traces).",
+            "aliases": ["--profile", "-p"],
+        },
     )
     pyinstrument_profiler: bool = field(
         default=False,

--- a/src/ezpz/configs.py
+++ b/src/ezpz/configs.py
@@ -964,6 +964,73 @@ class HfDataTrainingArguments:
             ], "`validation_file` should be a csv, a json or a txt file."
 
 
+@dataclass
+class HfProfileArguments:
+    """Profiler controls for the HuggingFace Trainer example.
+
+    Mirrors the subset of :func:`ezpz.cli.flags.add_profiling_args` that
+    applies to a Trainer-owned loop (no `--no-*` toggles — HF's
+    ``HfArgumentParser`` renders ``bool`` fields as a single store-true
+    flag). Field names match the argparse spellings used by the other
+    ``ezpz.examples.*`` modules so semantics carry over; consumed by
+    ``ezpz.examples.hf_trainer.ProfilerCallback`` via
+    :func:`ezpz.profile.get_profiling_context`.
+    """
+
+    pytorch_profiler: bool = field(
+        default=False,
+        metadata={"help": "Enable the torch profiler (chrome traces)."},
+    )
+    pyinstrument_profiler: bool = field(
+        default=False,
+        metadata={"help": "Enable the pyinstrument statistical profiler."},
+    )
+    rank_zero_only: bool = field(
+        default=True,
+        metadata={"help": "Only run the profiler on global rank 0."},
+    )
+    pytorch_profiler_wait: int = field(
+        default=1,
+        metadata={"help": "torch.profiler schedule: steps to wait."},
+    )
+    pytorch_profiler_warmup: int = field(
+        default=2,
+        metadata={"help": "torch.profiler schedule: warmup steps."},
+    )
+    pytorch_profiler_active: int = field(
+        default=3,
+        metadata={"help": "torch.profiler schedule: active (recorded) steps."},
+    )
+    pytorch_profiler_repeat: int = field(
+        default=5,
+        metadata={"help": "torch.profiler schedule: schedule-cycle repeats."},
+    )
+    profile_memory: bool = field(
+        default=True,
+        metadata={"help": "Record memory allocations in the torch profiler."},
+    )
+    record_shapes: bool = field(
+        default=True,
+        metadata={"help": "Record tensor shapes in the torch profiler."},
+    )
+    with_stack: bool = field(
+        default=True,
+        metadata={"help": "Record source stacks in the torch profiler."},
+    )
+    with_flops: bool = field(
+        default=True,
+        metadata={"help": "Estimate FLOPs in the torch profiler."},
+    )
+    with_modules: bool = field(
+        default=True,
+        metadata={"help": "Record module hierarchy in the torch profiler."},
+    )
+    acc_events: bool = field(
+        default=False,
+        metadata={"help": "Accumulate events across schedule cycles."},
+    )
+
+
 def print_config_tree(
     cfg: DictConfig,
     resolve: bool = True,

--- a/src/ezpz/examples/diffusion.py
+++ b/src/ezpz/examples/diffusion.py
@@ -66,7 +66,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 import time
-from typing import Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 from contextlib import nullcontext
 import ezpz
 import ezpz.distributed
@@ -79,9 +79,11 @@ import torch.functional as F
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 # from torch.distributed.fsdp import MixedPrecision
 
+from ezpz.cli.flags import add_profiling_args
 from ezpz.examples import get_example_outdir
 from ezpz.examples._presets import arg_provided as _arg_provided
 from ezpz.flops import compute_mfu, try_estimate
+from ezpz.profile import profiling_context_from_args
 
 logger = ezpz.get_logger(__name__)
 
@@ -454,8 +456,14 @@ def train(
     steps: int,
     outdir: Path | os.PathLike | str,
     lr: float = 1e-3,
+    profiler: Optional[Any] = None,
 ) -> tuple[ezpz.History, torch.nn.Module]:
-    """Train the diffusion text model for a fixed number of steps."""
+    """Train the diffusion text model for a fixed number of steps.
+
+    When ``profiler`` is non-None (from
+    :func:`ezpz.profile.profiling_context_from_args`), ``profiler.step()``
+    is called once per training step to advance the profiler schedule.
+    """
     device = ezpz.get_torch_device(as_torch_device=True)
     # if not isinstance(model, (DistributeFSDP):
     model.to(device)
@@ -498,8 +506,12 @@ def train(
         report_enabled=True,
         jsonl_path=metrics_path,
         jsonl_overwrite=True,
+        # Disable cross-rank history aggregation while profiling — the
+        # all-gather of per-rank metrics perturbs the very step times the
+        # profiler is measuring.
         distributed_history=(
-            1 < ezpz.get_world_size() <= 384  # and not config.pytorch_profiler
+            1 < ezpz.get_world_size() <= 384
+            and not getattr(args, "pytorch_profiler", False)
         ),
     )
 
@@ -546,6 +558,10 @@ def train(
         optim.zero_grad(set_to_none=True)
         t3 = time.perf_counter()
         ezpz.distributed.synchronize()
+        # Advance the torch.profiler schedule once per optimizer step.
+        # No-op when not profiling (profiler is None).
+        if profiler is not None:
+            profiler.step()
 
         if step % args.log_freq == 0 or step == steps - 1:
             train_metrics = {
@@ -765,6 +781,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "extensive kernel search — slow startup, fastest steady state."
         ),
     )
+    # Shared profiler flags (--profile / --pyinstrument-profiler / etc.),
+    # consumed by profiling_context_from_args around the training loop.
+    add_profiling_args(parser)
     args = parser.parse_args(argv)
     apply_model_preset(args, argv)
     return args
@@ -825,15 +844,18 @@ def main(args: argparse.Namespace) -> None:
     model.to(device)
 
     train_start = time.perf_counter()
-    history, wrapped_model = train(
-        model=model,
-        loader=loader,
-        schedule=schedule,
-        args=args,
-        steps=args.train_steps,
-        lr=args.lr,
-        outdir=outdir,
-    )
+    # nullcontext (prof=None) unless --profile / --pyinstrument-profiler set.
+    with profiling_context_from_args(args, outdir) as prof:
+        history, wrapped_model = train(
+            model=model,
+            loader=loader,
+            schedule=schedule,
+            args=args,
+            steps=args.train_steps,
+            lr=args.lr,
+            outdir=outdir,
+            profiler=prof,
+        )
     train_end = time.perf_counter()
 
     samples = generate_text(

--- a/src/ezpz/examples/diffusion.py
+++ b/src/ezpz/examples/diffusion.py
@@ -506,12 +506,13 @@ def train(
         report_enabled=True,
         jsonl_path=metrics_path,
         jsonl_overwrite=True,
-        # Disable cross-rank history aggregation while profiling — the
-        # all-gather of per-rank metrics perturbs the very step times the
-        # profiler is measuring.
+        # Disable cross-rank history aggregation while profiling (either
+        # profiler) — the all-gather of per-rank metrics perturbs the very
+        # step times the profiler is measuring.
         distributed_history=(
             1 < ezpz.get_world_size() <= 384
             and not getattr(args, "pytorch_profiler", False)
+            and not getattr(args, "pyinstrument_profiler", False)
         ),
     )
 

--- a/src/ezpz/examples/fsdp.py
+++ b/src/ezpz/examples/fsdp.py
@@ -437,12 +437,13 @@ def fsdp_main(args: argparse.Namespace) -> None:
         jsonl_path=metrics_path,
         project_name=WBPROJ_NAME,
         config={"args": vars(args), **ezpz.get_dist_info()},
-        # Disable cross-rank history aggregation while profiling — the
-        # all-gather of per-rank metrics perturbs the very step times the
-        # profiler is measuring.
+        # Disable cross-rank history aggregation while profiling (either
+        # profiler) — the all-gather of per-rank metrics perturbs the very
+        # step times the profiler is measuring.
         distributed_history=(
             1 < ezpz.get_world_size() <= 384
             and not getattr(args, "pytorch_profiler", False)
+            and not getattr(args, "pyinstrument_profiler", False)
         ),
     )
 

--- a/src/ezpz/examples/fsdp.py
+++ b/src/ezpz/examples/fsdp.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 import sys
 import time
+from typing import Any, Optional
 
 import ezpz
 
@@ -28,10 +29,12 @@ import torch.nn.functional as F
 import torch.optim as optim
 from torch.optim.lr_scheduler import StepLR
 
+from ezpz.cli.flags import add_profiling_args
 from ezpz.flops import compute_mfu, try_estimate
 from ezpz.models import summarize_model
 from ezpz.examples import get_example_outdir
 from ezpz.examples._presets import arg_provided as _arg_provided
+from ezpz.profile import profiling_context_from_args
 
 logger = ezpz.get_logger(__name__)
 
@@ -175,6 +178,7 @@ def train(
     optimizer: torch.optim.Optimizer,
     epoch: int,
     sampler: DistributedSampler | None = None,
+    profiler: Optional[Any] = None,
 ) -> dict:
     """One epoch of training and loss aggregation across ranks.
 
@@ -184,6 +188,10 @@ def train(
         optimizer: Optimizer instance.
         epoch: Current epoch index.
         sampler: Optional distributed sampler to set epoch.
+        profiler: Optional active profiler from
+            :func:`ezpz.profile.profiling_context_from_args`. When
+            non-None, ``profiler.step()`` is called once per batch so the
+            schedule advances across the whole (multi-epoch) run.
 
     Returns:
         Dict with epoch, wall-clock duration, and averaged train loss.
@@ -217,6 +225,10 @@ def train(
         local_loss[0] += loss.item()
         local_loss[1] += len(batch)
         num_batches += 1
+        # Advance the torch.profiler schedule once per optimizer step.
+        # No-op when not profiling (profiler is None).
+        if profiler is not None:
+            profiler.step()
     ezpz.distributed.synchronize()
     t1 = time.perf_counter()
     epoch_dt = t1 - t0
@@ -425,38 +437,47 @@ def fsdp_main(args: argparse.Namespace) -> None:
         jsonl_path=metrics_path,
         project_name=WBPROJ_NAME,
         config={"args": vars(args), **ezpz.get_dist_info()},
+        # Disable cross-rank history aggregation while profiling — the
+        # all-gather of per-rank metrics perturbs the very step times the
+        # profiler is measuring.
         distributed_history=(
-            1 < ezpz.get_world_size() <= 384  # and not config.pytorch_profiler
+            1 < ezpz.get_world_size() <= 384
+            and not getattr(args, "pytorch_profiler", False)
         ),
     )
 
     start = time.perf_counter()
-    for epoch in range(1, args.epochs + 1):
-        train_metrics = train(
-            model=model,
-            train_loader=train_loader,
-            optimizer=optimizer,
-            epoch=epoch,
-            sampler=data["train"]["sampler"],
-        )
-        test_metrics = test(model, test_loader)
-        scheduler.step()
-        merged = {**train_metrics, **test_metrics}
-        if _model_flops > 0:
-            # FSDP epoch loop reports per-epoch averages, so MFU here
-            # is averaged over the whole epoch (epoch_dt / num_batches),
-            # not per-step.  Smooths out warmup spikes but obscures
-            # straggler effects compared to the per-step MFU other
-            # examples report.
-            dt_step = merged.get("dt_per_step", 0.0)
-            if dt_step > 0:
-                merged["tflops"] = _model_flops / dt_step / 1e12
-                merged["mfu"] = compute_mfu(_model_flops, dt_step)
-        # Device memory: per-EPOCH peak (we don't reset between batches),
-        # so mem_peak_* here captures the high-water mark across the
-        # whole training+eval epoch.
-        merged |= ezpz.get_memory_metrics()
-        logger.info(history.update(merged))
+    # nullcontext (prof=None) unless --profile / --pyinstrument-profiler set.
+    # The schedule spans the whole run; train() steps it once per batch.
+    prof_ctx = profiling_context_from_args(args, outdir)
+    with prof_ctx as prof:
+        for epoch in range(1, args.epochs + 1):
+            train_metrics = train(
+                model=model,
+                train_loader=train_loader,
+                optimizer=optimizer,
+                epoch=epoch,
+                sampler=data["train"]["sampler"],
+                profiler=prof,
+            )
+            test_metrics = test(model, test_loader)
+            scheduler.step()
+            merged = {**train_metrics, **test_metrics}
+            if _model_flops > 0:
+                # FSDP epoch loop reports per-epoch averages, so MFU here
+                # is averaged over the whole epoch (epoch_dt / num_batches),
+                # not per-step.  Smooths out warmup spikes but obscures
+                # straggler effects compared to the per-step MFU other
+                # examples report.
+                dt_step = merged.get("dt_per_step", 0.0)
+                if dt_step > 0:
+                    merged["tflops"] = _model_flops / dt_step / 1e12
+                    merged["mfu"] = compute_mfu(_model_flops, dt_step)
+            # Device memory: per-EPOCH peak (we don't reset between
+            # batches), so mem_peak_* here captures the high-water mark
+            # across the whole training+eval epoch.
+            merged |= ezpz.get_memory_metrics()
+            logger.info(history.update(merged))
 
     train_end = time.perf_counter()
     logger.info(
@@ -647,6 +668,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "extensive kernel search - slow startup, fastest steady state."
         ),
     )
+    # Shared profiler flags (--profile / --pyinstrument-profiler / etc.),
+    # consumed by profiling_context_from_args around the training loop.
+    add_profiling_args(parser)
     args = parser.parse_args(argv)
     apply_model_preset(args, argv)
     return args

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -1712,12 +1712,20 @@ def train(
         # reduce-scatter tensor can exceed CCL's ~2GB-per-message MPI limit
         # (256K*2048*4B = 2.1GB) → `atl_mpi !req.is_completed`. Set
         # EZPZ_REDUCE_DTYPE=bf16 to halve the collective size (1.05GB) and
-        # stay under the limit.
-        _reduce_dtype = (
-            torch.bfloat16
-            if os.environ.get("EZPZ_REDUCE_DTYPE", "fp32").lower() in ("bf16", "bfloat16")
-            else torch.float32
-        )
+        # stay under the limit. Validated against an explicit set: a typo
+        # silently falling back to fp32 would re-trigger the very CCL
+        # failure this escape hatch exists to avoid, so raise instead.
+        _reduce_dtype_env = os.environ.get("EZPZ_REDUCE_DTYPE", "fp32")
+        _reduce_dtype_key = _reduce_dtype_env.lower()
+        if _reduce_dtype_key == "fp32":
+            _reduce_dtype = torch.float32
+        elif _reduce_dtype_key in ("bf16", "bfloat16"):
+            _reduce_dtype = torch.bfloat16
+        else:
+            raise ValueError(
+                f"Invalid EZPZ_REDUCE_DTYPE={_reduce_dtype_env!r}. Expected "
+                "one of: 'fp32', 'bf16', 'bfloat16' (case-insensitive)."
+            )
         mp_config = MixedPrecisionPolicy(
             param_dtype=torch.bfloat16,
             reduce_dtype=_reduce_dtype,
@@ -1987,12 +1995,13 @@ def train(
         report_enabled=True,
         jsonl_path=metrics_path,
         jsonl_overwrite=True,
-        # Disable cross-rank history aggregation while profiling — the
-        # all-gather of per-rank metrics perturbs the very step times the
-        # profiler is measuring.
+        # Disable cross-rank history aggregation while profiling (either
+        # profiler) — the all-gather of per-rank metrics perturbs the very
+        # step times the profiler is measuring.
         distributed_history=(
             1 < world_size <= 384
             and not getattr(args, "pytorch_profiler", False)
+            and not getattr(args, "pyinstrument_profiler", False)
         ),
     )
 

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -120,7 +120,7 @@ import logging
 import time
 from pathlib import Path
 from time import perf_counter
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from torch.utils.data import DataLoader, DistributedSampler
 
@@ -136,6 +136,8 @@ import torch.nn.functional as F
 
 from ezpz.flops import compute_mfu, try_estimate, try_estimate_fake
 from ezpz.models import summarize_model
+from ezpz.cli.flags import add_profiling_args
+from ezpz.profile import profiling_context_from_args
 from ezpz.examples import get_example_outdir
 from ezpz.examples._presets import arg_provided as _arg_provided
 
@@ -1081,6 +1083,9 @@ def parse_args(argv: Optional[list[str]] = None):
     )
     # max_batch_size: int = 32
     # max_seq_len: int = 32768
+    # Shared profiler flags (--profile / --pyinstrument-profiler / etc.),
+    # consumed by profiling_context_from_args around the training loop.
+    add_profiling_args(parser)
     args = parser.parse_args(argv)
     apply_model_preset(args, argv)
     return args
@@ -1100,7 +1105,13 @@ def _configure_fsdp_gradient_division(model: nn.Module) -> None:
 
     Safe no-op on modules that aren't FSDP2-wrapped or torch builds without
     these setters.
+
+    Set ``EZPZ_FSDP_GRAD_DIV=0`` to skip this entirely (debug escape hatch:
+    leaves FSDP2's default mean reduce-scatter in place).
     """
+    if os.environ.get("EZPZ_FSDP_GRAD_DIV", "1") == "0":
+        logger.info("Skipping FSDP gradient-division config (EZPZ_FSDP_GRAD_DIV=0)")
+        return
     force_sum_reduction = False
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         backend = str(torch.distributed.get_backend() or "")
@@ -1509,8 +1520,18 @@ def _collect_layer_grad_norms(model: nn.Module) -> list[float]:
 def train(
     args: argparse.Namespace,
     outdir: Path | str | os.PathLike,
+    profiler: Optional[Any] = None,
 ) -> int:
-    """Run TP/SP + FSDP training and optionally log metrics."""
+    """Run TP/SP + FSDP training and optionally log metrics.
+
+    Args:
+        args: Parsed CLI namespace.
+        outdir: Output directory for metrics / reports.
+        profiler: Optional active profiler (``torch.profiler.profile`` or
+            ``None``) from :func:`ezpz.profile.profiling_context_from_args`.
+            When non-None, ``profiler.step()`` is called once per training
+            step so the schedule (wait/warmup/active/repeat) advances.
+    """
     world_size = ezpz.distributed.get_world_size()
     assert world_size % args.tp == 0, "WORLD_SIZE must be divisible by TP"
     dpsize = world_size // args.tp
@@ -1686,9 +1707,20 @@ def train(
     # --fp32 is set (pure fp32 for NaN debugging).
     mp_config: Optional[MixedPrecisionPolicy] = None
     if not args.fp32:
+        # reduce_dtype: fp32 gradient reduce-scatter is more accurate, but for
+        # a large-vocab output projection (e.g. agpt's 256K) the single
+        # reduce-scatter tensor can exceed CCL's ~2GB-per-message MPI limit
+        # (256K*2048*4B = 2.1GB) → `atl_mpi !req.is_completed`. Set
+        # EZPZ_REDUCE_DTYPE=bf16 to halve the collective size (1.05GB) and
+        # stay under the limit.
+        _reduce_dtype = (
+            torch.bfloat16
+            if os.environ.get("EZPZ_REDUCE_DTYPE", "fp32").lower() in ("bf16", "bfloat16")
+            else torch.float32
+        )
         mp_config = MixedPrecisionPolicy(
             param_dtype=torch.bfloat16,
-            reduce_dtype=torch.float32,
+            reduce_dtype=_reduce_dtype,
         )
     if is_hf_model:
         # HF path: FSDP2-only wrap (no TP — the TP plan is ezpz-specific).
@@ -1955,8 +1987,12 @@ def train(
         report_enabled=True,
         jsonl_path=metrics_path,
         jsonl_overwrite=True,
+        # Disable cross-rank history aggregation while profiling — the
+        # all-gather of per-rank metrics perturbs the very step times the
+        # profiler is measuring.
         distributed_history=(
-            1 < world_size <= 384  # and not config.pytorch_profiler
+            1 < world_size <= 384
+            and not getattr(args, "pytorch_profiler", False)
         ),
     )
 
@@ -2075,6 +2111,10 @@ def train(
             ezpz.distributed.synchronize()
             t2 = perf_counter()
             global_step += 1
+            # Advance the torch.profiler schedule once per optimizer step.
+            # No-op when not profiling (profiler is None).
+            if profiler is not None:
+                profiler.step()
             metrics: dict[str, object] = {
                 "train/iter": global_step,
                 "train/epoch": epoch,
@@ -2136,6 +2176,16 @@ def train(
             if _model_flops > 0 and dt_step > 0:
                 metrics["train/tflops"] = _model_flops / dt_step / 1e12
                 metrics["train/mfu"] = compute_mfu(_model_flops, dt_step)
+            # Throughput. `--batch-size` is the PER-DP-RANK micro-batch, so
+            # tokens processed per rank per step is batch_size * seq_len.
+            #   - train/tps_per_gpu  : per-rank tokens/sec (torchtitan's `tgs`)
+            #   - train/tps          : global tokens/sec across all DP ranks
+            # (dp ranks = world_size / tp; tp ranks process the same tokens).
+            if dt_step > 0:
+                tokens_per_rank = args.batch_size * local_seq_len
+                metrics["train/tps_per_gpu"] = tokens_per_rank / dt_step
+                dp_size = max(1, world_size // args.tp)
+                metrics["train/tps"] = tokens_per_rank * dp_size / dt_step
             # Device memory: empty on CPU/MPS, 4 keys on CUDA/XPU.
             metrics |= ezpz.get_memory_metrics(prefix="train/")
             history.update(metrics, summarize=False)
@@ -2171,7 +2221,9 @@ def main(args: argparse.Namespace) -> int:
     logger.info("Outputs will be saved to %s", outdir)
     # Tracker setup is handled by History constructor (inside train())
     train_start = time.perf_counter()
-    history = train(args=args, outdir=outdir)
+    # nullcontext (prof=None) unless --profile / --pyinstrument-profiler set.
+    with profiling_context_from_args(args, outdir) as prof:
+        history = train(args=args, outdir=outdir, profiler=prof)
     train_end = time.perf_counter()
     timings = {
         "main/setup_torch": t_setup - t0,

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2185,16 +2185,21 @@ def train(
             if _model_flops > 0 and dt_step > 0:
                 metrics["train/tflops"] = _model_flops / dt_step / 1e12
                 metrics["train/mfu"] = compute_mfu(_model_flops, dt_step)
-            # Throughput. `--batch-size` is the PER-DP-RANK micro-batch, so
-            # tokens processed per rank per step is batch_size * seq_len.
-            #   - train/tps_per_gpu  : per-rank tokens/sec (torchtitan's `tgs`)
-            #   - train/tps          : global tokens/sec across all DP ranks
-            # (dp ranks = world_size / tp; tp ranks process the same tokens).
+            # Throughput. `--batch-size` is the PER-DP-RANK micro-batch and
+            # `local_seq_len` is this rank's (post-SP-slice) sequence length,
+            # so tokens processed per rank per step is batch_size *
+            # local_seq_len.
+            #   - train/tps_per_gpu : per-rank tokens/sec (torchtitan's `tgs`)
+            #   - train/tps         : global tokens/sec across ALL ranks
+            # Multiply by world_size, not dp_size: under sequence parallelism
+            # each TP rank holds a DISTINCT seq shard (labels are sliced via
+            # _slice_for_sequence_parallel), so the TP ranks process distinct
+            # tokens too. Using dp_size would undercount global tps by ~tp.
+            # At tp=1, world_size == dp_size so this is unchanged.
             if dt_step > 0:
                 tokens_per_rank = args.batch_size * local_seq_len
                 metrics["train/tps_per_gpu"] = tokens_per_rank / dt_step
-                dp_size = max(1, world_size // args.tp)
-                metrics["train/tps"] = tokens_per_rank * dp_size / dt_step
+                metrics["train/tps"] = tokens_per_rank * world_size / dt_step
             # Device memory: empty on CPU/MPS, 4 keys on CUDA/XPU.
             metrics |= ezpz.get_memory_metrics(prefix="train/")
             history.update(metrics, summarize=False)

--- a/src/ezpz/examples/hf_trainer.py
+++ b/src/ezpz/examples/hf_trainer.py
@@ -65,7 +65,7 @@ from ezpz.configs import (
     HfModelArguments,
     HfProfileArguments,
 )
-from ezpz.profile import get_profiling_context
+from ezpz.profile import profiling_context_from_args
 
 logger = ezpz.get_logger(__name__)
 
@@ -94,26 +94,11 @@ class ProfilerCallback(TrainerCallback):
         self._profiler = None
 
     def on_train_begin(self, args, state, control, **kwargs):
-        profiler_type = (
-            "torch" if self._args.pytorch_profiler else "pyinstrument"
-        )
-        self._cm = get_profiling_context(
-            profiler_type=profiler_type,
-            wait=self._args.pytorch_profiler_wait,
-            warmup=self._args.pytorch_profiler_warmup,
-            active=self._args.pytorch_profiler_active,
-            repeat=self._args.pytorch_profiler_repeat,
-            rank_zero_only=self._args.rank_zero_only,
-            record_shapes=self._args.record_shapes,
-            with_stack=self._args.with_stack,
-            with_flops=self._args.with_flops,
-            with_modules=self._args.with_modules,
-            acc_events=self._args.acc_events,
-            profile_memory=self._args.profile_memory,
-            outdir=self._outdir,
-            # pyinstrument opt-in is the flag itself, not an env var.
-            strict=self._args.pytorch_profiler,
-        )
+        # Delegate profiler-type selection + strictness/rank-zero semantics
+        # to the shared adapter (HfProfileArguments exposes the same field
+        # names the namespace adapter reads), so this stays aligned with
+        # the other examples and only owns the Trainer lifecycle.
+        self._cm = profiling_context_from_args(self._args, outdir=self._outdir)
         # __enter__ returns the torch profiler (has .step()) or the
         # pyinstrument wrapper / nullcontext target (None) — store it.
         self._profiler = self._cm.__enter__()

--- a/src/ezpz/examples/hf_trainer.py
+++ b/src/ezpz/examples/hf_trainer.py
@@ -60,9 +60,73 @@ class MemoryMetricsCallback(TrainerCallback):
 
 import ezpz
 import ezpz.configs
-from ezpz.configs import HfDataTrainingArguments, HfModelArguments
+from ezpz.configs import (
+    HfDataTrainingArguments,
+    HfModelArguments,
+    HfProfileArguments,
+)
+from ezpz.profile import get_profiling_context
 
 logger = ezpz.get_logger(__name__)
+
+
+class ProfilerCallback(TrainerCallback):
+    """Drive an ezpz profiler across a HuggingFace Trainer run.
+
+    HF Trainer owns its training loop, so there's no place to put a
+    ``with profiling_context_from_args(...)`` block + ``profiler.step()``
+    the way the other ``ezpz.examples.*`` modules do. The equivalent
+    extension points are Trainer callbacks:
+
+    - ``on_train_begin``  → enter the context manager (start profiling)
+    - ``on_step_end``     → ``profiler.step()`` (advance torch schedule)
+    - ``on_train_end``    → exit the context manager (flush traces)
+
+    Built from :class:`ezpz.configs.HfProfileArguments`, whose field
+    names match the shared profiler flag-set. Register only when a
+    profile flag is set (see ``main``); a no-op otherwise.
+    """
+
+    def __init__(self, profile_args: HfProfileArguments, outdir=None):
+        self._args = profile_args
+        self._outdir = outdir
+        self._cm = None
+        self._profiler = None
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        profiler_type = (
+            "torch" if self._args.pytorch_profiler else "pyinstrument"
+        )
+        self._cm = get_profiling_context(
+            profiler_type=profiler_type,
+            wait=self._args.pytorch_profiler_wait,
+            warmup=self._args.pytorch_profiler_warmup,
+            active=self._args.pytorch_profiler_active,
+            repeat=self._args.pytorch_profiler_repeat,
+            rank_zero_only=self._args.rank_zero_only,
+            record_shapes=self._args.record_shapes,
+            with_stack=self._args.with_stack,
+            with_flops=self._args.with_flops,
+            with_modules=self._args.with_modules,
+            acc_events=self._args.acc_events,
+            profile_memory=self._args.profile_memory,
+            outdir=self._outdir,
+            # pyinstrument opt-in is the flag itself, not an env var.
+            strict=self._args.pytorch_profiler,
+        )
+        # __enter__ returns the torch profiler (has .step()) or the
+        # pyinstrument wrapper / nullcontext target (None) — store it.
+        self._profiler = self._cm.__enter__()
+
+    def on_step_end(self, args, state, control, **kwargs):
+        if self._profiler is not None and hasattr(self._profiler, "step"):
+            self._profiler.step()
+
+    def on_train_end(self, args, state, control, **kwargs):
+        if self._cm is not None:
+            self._cm.__exit__(None, None, None)
+            self._cm = None
+            self._profiler = None
 
 
 def _as_bool(value: Any, *, default: bool = True) -> bool:
@@ -204,7 +268,12 @@ def parse_args() -> dict:
     #   We now keep distinct sets of args, for a cleaner separation of concerns.
     rank = ezpz.get_rank()
     parser = HfArgumentParser(
-        (HfModelArguments, HfDataTrainingArguments, TrainingArguments)  # type:ignore
+        (  # type:ignore
+            HfModelArguments,
+            HfDataTrainingArguments,
+            TrainingArguments,
+            HfProfileArguments,
+        )
     )
     try:
         transformers_major = int(transformers.__version__.split(".", 1)[0])
@@ -239,15 +308,15 @@ def parse_args() -> dict:
             )
             rewrites.extend(json_rewrites)
             overwrite_output_dir = json_overwrite_output_dir
-            model_args, data_args, training_args = parser.parse_dict(
-                normalized_json_args
+            model_args, data_args, training_args, profile_args = (
+                parser.parse_dict(normalized_json_args)
             )
         else:
-            model_args, data_args, training_args = parser.parse_json_file(
-                json_file=os.path.abspath(cli_args[0])
+            model_args, data_args, training_args, profile_args = (
+                parser.parse_json_file(json_file=os.path.abspath(cli_args[0]))
             )
     else:
-        model_args, data_args, training_args = (
+        model_args, data_args, training_args, profile_args = (
             parser.parse_args_into_dataclasses(args=cli_args)
         )
 
@@ -305,6 +374,7 @@ def parse_args() -> dict:
         "model": model_args,
         "data": data_args,
         "training": training_args,
+        "profile": profile_args,
         "overwrite_output_dir": overwrite_output_dir,
     }
 
@@ -473,11 +543,13 @@ def main() -> int:
 
     args = parse_args()
     t_setup = time.perf_counter()
-    # args includes model/data/training dataclasses plus overwrite_output_dir.
+    # args includes model/data/training/profile dataclasses plus
+    # overwrite_output_dir.
     assert "data" in args and "model" in args and "training" in args
     data_args: HfDataTrainingArguments = args["data"]
     model_args: HfModelArguments = args["model"]
     training_args: TrainingArguments = args["training"]
+    profile_args: HfProfileArguments = args["profile"]
     overwrite_output_dir = bool(args.get("overwrite_output_dir", False))
 
     # Initialise wandb early so console capture covers the full run.
@@ -985,6 +1057,16 @@ def main() -> int:
     # callbacks the Trainer already added by default (or that a forked
     # version of this script might want to layer on top).
     trainer.add_callback(MemoryMetricsCallback())
+    # Optional profiler, driven across the Trainer-owned loop via callback
+    # hooks. Only registered when --profile / --pyinstrument-profiler is
+    # set, so the default path is untouched.
+    if profile_args.pytorch_profiler or profile_args.pyinstrument_profiler:
+        trainer.add_callback(
+            ProfilerCallback(
+                profile_args,
+                outdir=getattr(training_args, "output_dir", None),
+            )
+        )
 
     # if wandb is not None and getattr(wandb, "run", None) is not None:
     #     # from transformers.integrations.integration_utils import W

--- a/src/ezpz/examples/minimal.py
+++ b/src/ezpz/examples/minimal.py
@@ -10,6 +10,13 @@ Running ``python3 -m ezpz.examples.minimal --help`` prints:
     usage: ezpz.examples.minimal --help
     (Set env vars such as PRINT_ITERS=100 TRAIN_ITERS=1000 INPUT_SIZE=128 OUTPUT_SIZE=128 LAYER_SIZES=\"128,256,128\" before calling ezpz launch)
 
+This example is intentionally profiler-free: it is configured purely via
+environment variables (no argparse), so it stays the smallest possible
+distributed smoke test. For ``--profile`` / ``--pyinstrument-profiler``
+support, use any of the other examples (``test``, ``fsdp_tp``, ``fsdp``,
+``vit``, ``diffusion``, ``hf_trainer``), which share the flag-set from
+:func:`ezpz.cli.flags.add_profiling_args`.
+
 """
 
 import os

--- a/src/ezpz/examples/test.py
+++ b/src/ezpz/examples/test.py
@@ -264,7 +264,9 @@ class Trainer:
             jsonl_path=metrics_path,
             jsonl_overwrite=True,
             distributed_history=(
-                1 < self.world_size <= 384 and not self.config.pytorch_profiler
+                1 < self.world_size <= 384
+                and not self.config.pytorch_profiler
+                and not self.config.pyinstrument_profiler
             ),
             project_name="ezpz.examples.test",
             config=asdict(self.config) | ezpz.get_dist_info(),

--- a/src/ezpz/examples/test.py
+++ b/src/ezpz/examples/test.py
@@ -25,7 +25,7 @@ from ezpz.configs import PathLike
 from ezpz.cli.flags import build_test_parser
 from ezpz.examples._presets import arg_provided as _arg_provided
 from ezpz.flops import compute_mfu, try_estimate
-from ezpz.profile import get_profiling_context
+from ezpz.profile import profiling_context_from_args
 
 START_TIME = time.perf_counter()  # start time
 
@@ -191,22 +191,12 @@ class TrainConfig:
         )
         dataset_root.mkdir(parents=True, exist_ok=True)
         self.dataset_root = dataset_root
-        profiler_type = "torch" if self.pytorch_profiler else "pyinstrument"
-        self.ctx = get_profiling_context(
-            profiler_type=profiler_type,
-            rank_zero_only=self.rank_zero_only,
-            record_shapes=self.record_shapes,
-            with_stack=self.with_stack,
-            with_flops=self.with_flops,
-            with_modules=self.with_modules,
-            acc_events=self.acc_events,
-            profile_memory=self.profile_memory,
-            wait=self.pytorch_profiler_wait,
-            warmup=self.pytorch_profiler_warmup,
-            active=self.pytorch_profiler_active,
-            repeat=self.pytorch_profiler_repeat,
-            outdir=self.outdir,
-        )
+        # TrainConfig exposes the shared profiler flag attributes
+        # (pytorch_profiler / pyinstrument_profiler / schedule / detail
+        # toggles), so the namespace adapter consumes `self` directly.
+        # Returns nullcontext() when no profile flag is set, so the
+        # default `with self.ctx as c` path yields c=None (no profiling).
+        self.ctx = profiling_context_from_args(self, outdir=self.outdir)
         logger.info(f"Outputs will be saved to {self.outdir}")
 
     def get_torch_dtype(self) -> torch.dtype:

--- a/src/ezpz/examples/vit.py
+++ b/src/ezpz/examples/vit.py
@@ -82,9 +82,11 @@ import ezpz
 import ezpz.distributed
 
 # from TORCH_DTYPES_MAP
+from ezpz.cli.flags import add_profiling_args
 from ezpz.data.vision import get_fake_data, get_mnist
 from ezpz.examples import get_example_outdir
 from ezpz.examples._presets import arg_provided as _arg_provided
+from ezpz.profile import profiling_context_from_args
 from ezpz.flops import compute_mfu, try_estimate
 from ezpz.models import summarize_model
 from ezpz.models.vit.attention import AttentionBlock
@@ -615,6 +617,9 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         choices=list(ezpz.distributed.FSDP_SHARDING_STRATEGIES),
         help="FSDP sharding strategy",
     )
+    # Shared profiler flags (--profile / --pyinstrument-profiler / etc.),
+    # consumed by profiling_context_from_args around the training loop.
+    add_profiling_args(parser)
     args = parser.parse_args(argv)
     apply_model_preset(args, argv)
     apply_dataset_overrides(args, argv)
@@ -641,6 +646,7 @@ def train_fn(
     block_fn: Any,
     args: argparse.Namespace,
     dataset: Optional[str] = "fake",
+    profiler: Optional[Any] = None,
 ) -> ezpz.History:
     """Train the Vision Transformer on fake or MNIST data.
 
@@ -648,6 +654,9 @@ def train_fn(
         block_fn: Attention block constructor with attn_fn injected.
         args: Training hyperparameters.
         dataset: Dataset choice, either ``fake`` or ``mnist``.
+        profiler: Optional active profiler from
+            :func:`ezpz.profile.profiling_context_from_args`. When
+            non-None, ``profiler.step()`` is called once per training step.
 
     Returns:
         History of training metrics.
@@ -886,6 +895,10 @@ def train_fn(
             lr_scheduler.step()
         ezpz.distributed.synchronize()
         t4 = time.perf_counter()
+        # Advance the torch.profiler schedule once per optimizer step.
+        # No-op when not profiling (profiler is None).
+        if profiler is not None:
+            profiler.step()
         if step >= warmup_iters:
             loss_value = float(loss.detach().item())
             acc_value = float(acc.detach().item())
@@ -1048,7 +1061,11 @@ def main(args: argparse.Namespace):
         raise ValueError(f"Unknown attention type: {args.attn_type}")
     logger.info(f"Using AttentionBlock Attention with {args.compile=}")
     train_start = time.perf_counter()
-    history, outdir = train_fn(block_fn, args=args, dataset=args.dataset)
+    # nullcontext (prof=None) unless --profile / --pyinstrument-profiler set.
+    with profiling_context_from_args(args) as prof:
+        history, outdir = train_fn(
+            block_fn, args=args, dataset=args.dataset, profiler=prof
+        )
     train_end = time.perf_counter()
     t1 = time.perf_counter()
     timings = {

--- a/src/ezpz/profile.py
+++ b/src/ezpz/profile.py
@@ -159,7 +159,15 @@ def get_profiling_context(
         )
 
     if profiler_type == "pyinstrument":
-        return get_context_manager(rank=ezpz.get_rank(), strict=strict)
+        # Forward outdir + rank_zero_only so pyinstrument honors the
+        # requested output directory and rank gating (previously dropped,
+        # so pyinstrument profiles always landed in the default dir).
+        return get_context_manager(
+            rank=ezpz.get_rank(),
+            outdir=(None if outdir is None else os.fspath(outdir)),
+            strict=strict,
+            rank_zero_only=rank_zero_only,
+        )
 
     raise ValueError(
         f"Invalid profiling type: {profiler_type}. "
@@ -390,10 +398,13 @@ class PyInstrumentProfiler:
                     pyinstrument.Profiler() if (rank is None or rank == 0) else None
                 )
         self._start = time.perf_counter_ns()
-        # outdir = os.getcwd() if outdir is None else outdir
-        # outdir = ezpz.OUTPUTS_DIR.as_posix() if outdir is None else outdir
-        self.outdir = Path(os.getcwd()).joinpath("ezpz_pyinstrument_profiles")
-        # self.outdir = Path(outdir) if outdir is None else Path(outdir)
+        # Honor the requested outdir (callers pass one through
+        # get_context_manager); fall back to cwd when none is given.
+        self.outdir = (
+            Path(outdir)
+            if outdir is not None
+            else Path(os.getcwd()).joinpath("ezpz_pyinstrument_profiles")
+        )
         self.outdir.mkdir(exist_ok=True, parents=True)
 
     def __enter__(self):

--- a/src/ezpz/profile.py
+++ b/src/ezpz/profile.py
@@ -167,6 +167,76 @@ def get_profiling_context(
     )
 
 
+def profiling_context_from_args(
+    args: Any,
+    outdir: Optional[str | Path | os.PathLike] = None,
+) -> AbstractContextManager:
+    """Build a profiling context manager from parsed CLI ``args``.
+
+    Thin adapter over :func:`get_profiling_context` that maps the shared
+    profiler flag-set (see :func:`ezpz.cli.flags.add_profiling_args`) onto
+    the context-manager call, so every ``ezpz.examples.*`` module wires
+    profiling the same way:
+
+    .. code-block:: python
+
+        with profiling_context_from_args(args, outdir) as prof:
+            train(..., profiler=prof)
+        # in the loop:  if prof is not None: prof.step()
+
+    Returns a :func:`contextlib.nullcontext` (whose ``as`` target is
+    ``None``) when neither ``--profile`` nor ``--pyinstrument-profiler``
+    was passed (and ``PYINSTRUMENT_PROFILER`` is unset), so the default
+    code path is completely unaffected.
+
+    ``getattr`` defaults mirror :func:`add_profiling_args` so this is
+    safe to call even on a namespace that only set a subset of the flags.
+
+    Backward-compatible activation: the ``PYINSTRUMENT_PROFILER`` env var
+    also turns on the pyinstrument profiler even with no flag, matching
+    the long-standing :func:`get_context_manager` ``strict`` behavior.
+
+    Args:
+        args: Parsed argparse namespace (or any object exposing the
+            profiler attributes as fields).
+        outdir: Directory for profiler output. Defaults to
+            ``get_profiling_context``'s own fallback when ``None``.
+
+    Returns:
+        AbstractContextManager: torch / pyinstrument profiler context, or
+        ``nullcontext()`` when profiling was not requested.
+    """
+    pyinstrument = bool(getattr(args, "pyinstrument_profiler", False))
+    pytorch = bool(getattr(args, "pytorch_profiler", False))
+    # Honor the legacy env-var opt-in so callers that relied on
+    # PYINSTRUMENT_PROFILER=1 (no flag) keep working.
+    if os.environ.get("PYINSTRUMENT_PROFILER") is not None:
+        pyinstrument = True
+    if not (pyinstrument or pytorch):
+        return nullcontext()
+    return get_profiling_context(
+        # torch profiler wins if both flags are somehow set: it produces
+        # the per-op chrome trace that the schedule flags are about.
+        profiler_type=("torch" if pytorch else "pyinstrument"),
+        wait=int(getattr(args, "pytorch_profiler_wait", 1)),
+        warmup=int(getattr(args, "pytorch_profiler_warmup", 2)),
+        active=int(getattr(args, "pytorch_profiler_active", 3)),
+        repeat=int(getattr(args, "pytorch_profiler_repeat", 5)),
+        rank_zero_only=bool(getattr(args, "rank_zero_only", False)),
+        record_shapes=bool(getattr(args, "record_shapes", True)),
+        with_stack=bool(getattr(args, "with_stack", True)),
+        with_flops=bool(getattr(args, "with_flops", True)),
+        with_modules=bool(getattr(args, "with_modules", True)),
+        acc_events=bool(getattr(args, "acc_events", False)),
+        profile_memory=bool(getattr(args, "profile_memory", True)),
+        outdir=outdir,
+        # The torch path ignores `strict`; for pyinstrument, passing
+        # `--pyinstrument-profiler` is itself the opt-in, so don't also
+        # require the PYINSTRUMENT_PROFILER env var.
+        strict=not pyinstrument,
+    )
+
+
 def get_context_manager(
     rank: Optional[int] = None,
     outdir: Optional[str] = None,

--- a/src/ezpz/profile.py
+++ b/src/ezpz/profile.py
@@ -56,6 +56,23 @@ logger = logging.getLogger(__name__)
 from contextlib import AbstractContextManager, nullcontext
 
 
+def _table_sort_key(device_type: str) -> str:
+    """Pick a valid ``key_averages().table(sort_by=...)`` column.
+
+    The torch profiler only records ``self_{cpu,cuda,xpu}_time_total`` (the
+    only device activities :func:`get_torch_profiler` adds).
+    :func:`ezpz.get_torch_device_type` can return ``"mps"`` (or another
+    accelerator we don't profile), for which no ``self_<dev>_time_total``
+    column exists -> ``AttributeError`` in ``key_averages().table()``. Map
+    only cuda/xpu to their column; everything else (mps, cpu, ...) sorts by
+    CPU. Pure string map (no ``is_available()`` re-probe, which can itself
+    raise on some accelerator stacks).
+    """
+    if device_type in ("cuda", "xpu"):
+        return f"self_{device_type}_time_total"
+    return "self_cpu_time_total"
+
+
 def get_profiling_context(
     profiler_type: str,
     wait: int,
@@ -119,13 +136,8 @@ def get_profiling_context(
             """
             Callback function to handle the trace when it is ready.
             """
-            logger.info(
-                "\n"
-                + p.key_averages().table(
-                    sort_by=(f"self_{ezpz.get_torch_device_type()}_time_total"),
-                    row_limit=-1,
-                )
-            )
+            sort_key = _table_sort_key(ezpz.get_torch_device_type())
+            logger.info("\n" + p.key_averages().table(sort_by=sort_key, row_limit=-1))
             fname: str = "-".join(
                 [
                     "torch-profiler",

--- a/tests/test_flags_profiling.py
+++ b/tests/test_flags_profiling.py
@@ -1,0 +1,104 @@
+"""Tests for the shared profiling CLI surface.
+
+`add_profiling_args` (ezpz.cli.flags) is the single source of truth for the
+profiler flags across all ezpz.examples.* modules, and `HfProfileArguments`
+(ezpz.configs) mirrors it for the HuggingFace Trainer example. These tests
+pin the flag set + key defaults so the shared surface can't silently drift.
+"""
+
+import argparse
+
+import pytest
+
+try:
+    from ezpz.cli.flags import add_profiling_args
+
+    FLAGS_AVAILABLE = True
+except ImportError:
+    FLAGS_AVAILABLE = False
+
+# The canonical defaults add_profiling_args must produce.
+EXPECTED_DEFAULTS = {
+    "pytorch_profiler": False,
+    "pyinstrument_profiler": False,
+    "rank_zero_only": False,
+    "pytorch_profiler_wait": 1,
+    "pytorch_profiler_warmup": 2,
+    "pytorch_profiler_active": 3,
+    "pytorch_profiler_repeat": 5,
+    "profile_memory": True,
+    "record_shapes": True,
+    "with_stack": True,
+    "with_flops": True,
+    "with_modules": True,
+    "acc_events": False,
+}
+
+
+@pytest.mark.skipif(not FLAGS_AVAILABLE, reason="ezpz.cli.flags not available")
+class TestAddProfilingArgs:
+    def _parse(self, argv):
+        p = argparse.ArgumentParser()
+        add_profiling_args(p)
+        return p.parse_args(argv)
+
+    def test_defaults(self):
+        ns = self._parse([])
+        for k, v in EXPECTED_DEFAULTS.items():
+            assert getattr(ns, k) == v, f"{k}: {getattr(ns, k)!r} != {v!r}"
+
+    def test_profile_short_and_long_flag(self):
+        # -p and --profile both set dest=pytorch_profiler.
+        assert self._parse(["-p"]).pytorch_profiler is True
+        assert self._parse(["--profile"]).pytorch_profiler is True
+
+    def test_boolean_optional_action_no_form(self):
+        # BooleanOptionalAction generates the --no-* form so True-default
+        # toggles can actually be disabled.
+        ns = self._parse(["--no-with-stack", "--no-profile-memory"])
+        assert ns.with_stack is False
+        assert ns.profile_memory is False
+
+    def test_schedule_overrides(self):
+        ns = self._parse(
+            ["--pytorch-profiler-active", "7", "--pytorch-profiler-wait", "0"]
+        )
+        assert ns.pytorch_profiler_active == 7
+        assert ns.pytorch_profiler_wait == 0
+
+    def test_returns_parser(self):
+        p = argparse.ArgumentParser()
+        assert add_profiling_args(p) is p
+
+
+try:
+    from transformers import HfArgumentParser
+
+    from ezpz.configs import HfProfileArguments
+
+    HF_AVAILABLE = True
+except Exception:  # noqa: BLE001 - transformers optional / may fail to import
+    HF_AVAILABLE = False
+
+
+@pytest.mark.skipif(not HF_AVAILABLE, reason="transformers/HfProfileArguments unavailable")
+class TestHfProfileArguments:
+    def _parse(self, argv):
+        (pr,) = HfArgumentParser((HfProfileArguments,)).parse_args_into_dataclasses(
+            args=argv
+        )
+        return pr
+
+    def test_defaults_match_cli(self):
+        pr = self._parse([])
+        # rank_zero_only must match add_profiling_args (False), not diverge.
+        assert pr.rank_zero_only is False
+        assert pr.pytorch_profiler is False
+        assert pr.pyinstrument_profiler is False
+        assert pr.pytorch_profiler_active == 3
+
+    def test_profile_alias_exposed(self):
+        # --profile / -p aliases must reach the same dest as --pytorch-profiler.
+        assert self._parse(["--profile"]).pytorch_profiler is True
+        assert self._parse(["-p"]).pytorch_profiler is True
+        assert self._parse(["--pytorch_profiler"]).pytorch_profiler is True

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -55,3 +55,72 @@ class TestProfile:
         with ctx:
             result = 1 + 1
         assert result == 2
+
+
+@pytest.mark.skipif(not PROFILE_AVAILABLE, reason="ezpz.profile not available")
+class TestProfilingContextFromArgs:
+    """Cover the namespace->context-manager adapter semantics.
+
+    These verify the contract the ezpz.examples.* modules rely on: no flag
+    => nullcontext (yields None, default path untouched); a flag => a real
+    context; and the legacy PYINSTRUMENT_PROFILER env-var opt-in.
+    """
+
+    @staticmethod
+    def _ns(**over):
+        from types import SimpleNamespace
+
+        base = dict(
+            pytorch_profiler=False,
+            pyinstrument_profiler=False,
+            rank_zero_only=False,
+            record_shapes=True,
+            with_stack=True,
+            with_flops=True,
+            with_modules=True,
+            acc_events=False,
+            profile_memory=True,
+            pytorch_profiler_wait=1,
+            pytorch_profiler_warmup=2,
+            pytorch_profiler_active=3,
+            pytorch_profiler_repeat=5,
+        )
+        base.update(over)
+        return SimpleNamespace(**base)
+
+    def test_no_flag_returns_nullcontext(self, monkeypatch):
+        from contextlib import nullcontext
+
+        monkeypatch.delenv("PYINSTRUMENT_PROFILER", raising=False)
+        cm = profile.profiling_context_from_args(self._ns(), outdir="/tmp")
+        assert isinstance(cm, nullcontext)
+        with cm as c:
+            assert c is None  # default path: profiler is None
+
+    def test_pyinstrument_flag_activates(self, monkeypatch):
+        from contextlib import nullcontext
+
+        monkeypatch.delenv("PYINSTRUMENT_PROFILER", raising=False)
+        cm = profile.profiling_context_from_args(
+            self._ns(pyinstrument_profiler=True), outdir="/tmp"
+        )
+        assert not isinstance(cm, nullcontext)
+
+    def test_env_var_activates_without_flag(self, monkeypatch):
+        from contextlib import nullcontext
+
+        monkeypatch.setenv("PYINSTRUMENT_PROFILER", "1")
+        cm = profile.profiling_context_from_args(self._ns(), outdir="/tmp")
+        # Legacy opt-in: env var alone turns on pyinstrument.
+        assert not isinstance(cm, nullcontext)
+
+    def test_missing_attrs_default_to_no_profiling(self, monkeypatch):
+        from contextlib import nullcontext
+        from types import SimpleNamespace
+
+        monkeypatch.delenv("PYINSTRUMENT_PROFILER", raising=False)
+        # An object exposing none of the profiler attrs must be safe.
+        cm = profile.profiling_context_from_args(
+            SimpleNamespace(), outdir="/tmp"
+        )
+        assert isinstance(cm, nullcontext)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -124,3 +124,30 @@ class TestProfilingContextFromArgs:
             SimpleNamespace(), outdir="/tmp"
         )
         assert isinstance(cm, nullcontext)
+
+
+@pytest.mark.skipif(not PROFILE_AVAILABLE, reason="ezpz.profile not available")
+class TestTableSortKey:
+    """Regression for the torch-profiler trace_handler sort key.
+
+    The table can only be sorted by a column the profiler records
+    (self_{cpu,cuda,xpu}_time_total). get_torch_device_type() can return
+    "mps" (or another accelerator we don't add as a ProfilerActivity), and
+    sort_by="self_mps_time_total" raised AttributeError in
+    key_averages().table() (the original crash on Apple Silicon).
+    """
+
+    def test_mps_falls_back_to_cpu(self):
+        # The exact crash case: must NOT produce self_mps_time_total.
+        assert profile._table_sort_key("mps") == "self_cpu_time_total"
+
+    def test_cpu(self):
+        assert profile._table_sort_key("cpu") == "self_cpu_time_total"
+
+    def test_cuda_and_xpu_keep_their_column(self):
+        assert profile._table_sort_key("cuda") == "self_cuda_time_total"
+        assert profile._table_sort_key("xpu") == "self_xpu_time_total"
+
+    def test_unknown_device_falls_back_to_cpu(self):
+        # Any future/unprofiled accelerator string must be safe.
+        assert profile._table_sort_key("privateuseone") == "self_cpu_time_total"


### PR DESCRIPTION
## Summary

Adds `--profile` support (PyTorch profiler + pyinstrument) to **all** `ezpz.examples.*` modules. Previously only `ezpz.examples.test` had real profiling; every other example had a long-commented `# and not config.pytorch_profiler` stub and nothing else.

The wiring is centralized in **two shared helpers** so the surface can't drift:

- **`ezpz.cli.flags.add_profiling_args(parser)`** — the 13 profiler flags (`-p`/`--profile`, `--pyinstrument-profiler`, `--rank-zero-only`, `--pytorch-profiler-{wait,warmup,active,repeat}`, `--profile-memory`/`--record-shapes`/`--with-stack`/`--with-flops`/`--with-modules` as `BooleanOptionalAction`, `--acc-events`). Extracted from the block that was inlined in `build_test_parser` (which now calls it; `--save-datasets` stays test-specific).
- **`ezpz.profile.profiling_context_from_args(args, outdir)`** — namespace→context-manager adapter over the existing `get_profiling_context`. Returns `nullcontext()` (yielding `None`) when no profile flag is set, so **default runs are completely unaffected**. Sets `strict=not pyinstrument` so `--pyinstrument-profiler` actually activates (it was a dead flag before — only `PYINSTRUMENT_PROFILER=1` worked), and still honors that env var for backward compat.

## Per-example wiring

| Module | How |
|---|---|
| `fsdp_tp`, `vit`, `diffusion` | `add_profiling_args` on the parser; `profiler.step()` after `optimizer.step()`; loop wrapped in `profiling_context_from_args` |
| `fsdp` | context created in `fsdp_main`, threaded into `train()` across the split epoch/batch loop so the schedule spans the whole run |
| `hf_trainer` | HF Trainer owns its loop, so: new `HfProfileArguments` dataclass (`configs.py`, parsed as a 4th `HfArgumentParser` dataclass) + a `ProfilerCallback(TrainerCallback)` (`on_train_begin` enters / `on_step_end` steps / `on_train_end` flushes), registered only when a profile flag is set |
| `test` | routed through the shared helper (one wiring path; also un-breaks its `--pyinstrument-profiler`) |
| `minimal` | **intentionally skipped** (env-var config, no argparse) — documented profiler-free in its docstring |

Examples that report metrics also disable `distributed_history` under `--profile`, so the per-rank metric all-gather doesn't perturb the step times being measured.

Also folds in two small `fsdp_tp` items that were in the working tree from the same investigation:
- **tokens/sec metric**: `train/tps` (global) + `train/tps_per_gpu` (per-rank, torchtitan's `tgs`).
- **debug escape hatches**: `EZPZ_FSDP_GRAD_DIV=0` and `EZPZ_REDUCE_DTYPE=bf16` (both default to current behavior).

## Verification

- All 10 touched files byte-compile; `add_profiling_args` / `profiling_context_from_args` / `HfProfileArguments` unit-tested via the repo `.venv` (defaults match, flag toggles work, `nullcontext` default + env-var path confirmed).
- `--help` shows exactly 13 profile flags on `fsdp_tp` / `fsdp` / `vit` / `diffusion`.
- **End-to-end live run** (Sunspot, 24×PVC, 2 nodes, `rc=0`): the user's target config
  ```
  ezpz launch python3 -m ezpz.examples.fsdp_tp --model=xl --hf-limit=1000 \
    --seq-len=8192 --batch-size=2 --tokenizer_name=google/gemma-7b --tp=1 \
    --sharding-strategy=hybrid_shard --compile-mode=max-autotune --compile \
    --loss-impl=compiled --act-mem-budget=0.25 --profile --rank-zero-only
  ```
  parsed the flags cleanly and wrote 4 chrome traces (schedule `wait=1,warmup=2,active=3,repeat=5`).

### Profiling finding (xl / seq=8192 / bs=2, compiled loss)

MFU ~19.7%, ~58.8 TFLOP/s/gpu, 4.04 s/step (fwd 0.70s / **bwd 3.33s**). Device-kernel self-time: **attention backward 53%**, GEMMs (lm_head+FFN+qkv) 22.7%, attention fwd 5.9%, **cross-entropy only 1.6%** (compiled CE collapsed the vocab-loss sink). At full depth the bottleneck is the vendor cutlass-sycl FA **backward** kernel — a shift from the earlier single-layer eager profile where the 256K-vocab lm_head/loss dominated.

## Notes

- No behavior change to existing runs (no flag ⇒ `nullcontext`).
- Flag spellings match `test`'s exactly, so docs/scripts/muscle-memory carry over.

## Summary by Sourcery

Introduce shared profiling CLI helpers and wire consistent profiler support across all training examples and the HuggingFace Trainer.

New Features:
- Add a shared add_profiling_args helper to expose a unified profiler flag set across ezpz.examples.*.
- Provide a profiling_context_from_args adapter to translate CLI flags into an optional profiling context manager used around training loops.
- Enable configurable profiling for the HuggingFace Trainer example via HfProfileArguments and a ProfilerCallback driving the profiler lifecycle.
- Add tokens-per-second throughput metrics to the fsdp_tp example output.

Bug Fixes:
- Fix previously non-functional pyinstrument profiler activation by making the CLI flag properly opt-in while retaining env-var support.
- Restore and standardize profiling behavior in the test example so pyinstrument and torch profiler paths work consistently.

Enhancements:
- Refactor the test example to use the shared profiling helpers while preserving its existing CLI surface and behavior.
- Update fsdp, fsdp_tp, vit, and diffusion examples to integrate the shared profiler flags and step the profiler once per optimizer step, without affecting default runs.
- Disable distributed metric history aggregation while profiling in relevant examples to avoid perturbing measured step times.
- Introduce environment-controlled escape hatches for FSDP gradient division and reduce-scatter dtype configuration in fsdp_tp.
- Ensure HuggingFace Trainer argument parsing cleanly separates model, data, training, and profiling concerns via dedicated dataclasses.