### PR TITLE
fix(history): label memory summary as cur/peak + name % denominator

### DIFF
--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -590,8 +590,9 @@ Three pieces close the gap, all matching what torchtitan does:
 
 !!! warning "Reading the memory number: allocated vs reserved"
 
-    This example's `memory=alloc/peak` line reports **peak *allocated***
-    bytes; torchtitan's `memory:` line reports **peak *reserved*** bytes,
+    This example's `memory=<cur>/<peak>GiB (cur/peak, …)` line reports
+    **current and peak *allocated*** bytes (the right-hand number is the
+    peak); torchtitan's `memory:` line reports **peak *reserved*** bytes,
     reset per step. They are different metrics, so don't compare them
     directly. The **allocated** peaks match (~44 GiB for this recipe vs
     torchtitan's ~44 GiB). This example's cumulative *reserved* peak looks

--- a/docs/history.md
+++ b/docs/history.md
@@ -121,7 +121,7 @@ collapse the noisy `loss=…  loss/mean=…  loss/max=…  loss/min=…  loss/st
 shape into a single scannable line:
 
 ```
-iter=180   loss=0.078(±0.026) accuracy=0.984(±9.9e-3) dtf=0.014(±7.4e-4) lr=0.000059 memory=0.01/0.01GiB (0%)
+iter=180   loss=0.078(±0.026) accuracy=0.984(±9.9e-3) dtf=0.014(±7.4e-4) lr=0.000059 memory=0.01/0.01GiB (cur/peak, 0% of 40.0GiB)
 ```
 
 Format rules (all handled by [`ezpz.utils.format_compact_summary`][ezpz.utils.format_compact_summary]):
@@ -166,8 +166,14 @@ The helper returns 4 keys when supported (CUDA, XPU): `mem_alloc`,
 Returns `{}` on CPU / MPS so the laptop smoke path stays clean. Opt
 out on supported devices via `EZPZ_TRACK_MEMORY=0`. The 4 memory keys
 are auto-collapsed in the console line into a single
-`memory=alloc/reserved (peak%)` token — full per-rank aggregations
-still flow to the trackers.
+`memory=<cur>/<peak>GiB (cur/peak, <pct>% of <total>GiB)` token —
+the left pair is **current / peak allocated** (`mem_alloc` /
+`mem_peak_alloc`), and the percentage is current alloc as a fraction of
+the device's physical total (spelled out so `<cur>/<peak>` isn't
+misread as a fraction). The `, <pct>% of <total>GiB` part is dropped
+when the device total is unknown. Full per-rank aggregations (including
+the `mem_reserved` / `mem_peak_reserved` keys, which aren't shown on the
+console line) still flow to the trackers.
 
 ### Distributed statistics
 

--- a/src/ezpz/utils/__init__.py
+++ b/src/ezpz/utils/__init__.py
@@ -577,10 +577,16 @@ def format_memory_summary(
     ``{prefix}mem_peak_alloc``, ``{prefix}mem_reserved``,
     ``{prefix}mem_peak_reserved``.
 
-    Output: ``"X.XX/Y.YYGiB (Z%)"`` where X is current alloc, Y is peak
-    alloc, and Z is current alloc as a percent of device total memory
-    (omitted when device total isn't available — e.g. unknown XPU, CPU
-    fallback).
+    Output: ``"X.XX/Y.YYGiB (cur/peak, Z% of T.TGiB)"`` where X is current
+    alloc, Y is peak alloc, Z is current alloc as a percent of device
+    total memory, and T is the device total. The ``cur/peak`` label names
+    the two allocation numbers; the ``Z% of T.TGiB`` names the percentage
+    denominator so the left pair isn't misread as a fraction. The
+    ``, Z% of T.TGiB`` part is omitted when the device total isn't
+    available (e.g. unknown XPU, CPU fallback), leaving
+    ``"X.XX/Y.YYGiB (cur/peak)"``. Alloc-only dicts yield
+    ``"X.XXGiB (cur[, Z% of T.TGiB])"``; peak-only yields
+    ``"Y.YYGiB (peak)"``.
 
     Args:
         metrics: dict that may contain mem_* keys.
@@ -616,7 +622,14 @@ def format_memory_summary(
     # Normalize `device` → int index where possible, so callers passing
     # `torch.device('cuda:1')` get the right device's total (not rank 0's
     # device by way of get_local_rank()).
-    pct_str = ""
+    #
+    # `pct_of` labels the current alloc as a percent of *physical device
+    # total* — e.g. "25% of 64.0GiB". It is intentionally distinct from
+    # the `alloc/peak` pair on the left (which are two allocation
+    # numbers, not a fraction): the left side is cur/peak allocated, the
+    # right side is cur ÷ device capacity. Spelling out the denominator
+    # keeps those from being misread as "16 out of 46".
+    pct_of = ""
     try:
         import ezpz
         idx: int | None
@@ -635,19 +648,24 @@ def format_memory_summary(
         if total_bytes and total_bytes > 0 and alloc is not None:
             total_gib = total_bytes / (1024 ** 3)
             pct = 100.0 * alloc / total_gib
-            pct_str = f" ({pct:.0f}%)"
+            pct_of = f", {pct:.0f}% of {total_gib:.1f}GiB"
     except Exception:
         # Any failure resolving total memory: omit the percentage rather
         # than break logging. Raw numbers still print.
-        pct_str = ""
+        pct_of = ""
 
+    # Label the numbers so the console line is self-describing:
+    #   cur/peak  → the two allocation numbers are current + peak alloc
+    #   cur       → single number is current alloc
+    #   peak      → single number is peak alloc (rare partial-dict case)
+    # The `pct_of` denominator (when present) rides inside the same parens.
     if alloc is not None and peak is not None:
-        return f"{alloc:.2f}/{peak:.2f}GiB{pct_str}"
+        return f"{alloc:.2f}/{peak:.2f}GiB (cur/peak{pct_of})"
     if alloc is not None:
-        return f"{alloc:.2f}GiB{pct_str}"
+        return f"{alloc:.2f}GiB (cur{pct_of})"
     # Only peak is present (rare — caller passed `mem_peak_alloc` without
-    # `mem_alloc`). Format matches the alloc-only branch for consistency.
-    return f"{peak:.2f}GiB{pct_str}"
+    # `mem_alloc`). No alloc → no percent (pct is computed against alloc).
+    return f"{peak:.2f}GiB (peak)"
 
 
 # Base names for the 4 memory metrics produced by get_memory_metrics().

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -675,7 +675,7 @@ class TestLogMetricsCondensation:
         assert "epoch=0" in msg
         assert "loss=10" in msg and "(±" in msg
         # Memory keys do NOT appear as `mem_alloc=0.18` in the base flow;
-        # they're summarized as `memory=0.18/0.68GiB`.
+        # they're summarized as `memory=0.18/0.68GiB (cur/peak, …)`.
         assert "mem_alloc=" not in msg
         assert "mem_peak_alloc=" not in msg
         assert "memory=" in msg

--- a/tests/test_memory_metrics.py
+++ b/tests/test_memory_metrics.py
@@ -301,7 +301,7 @@ class TestFormatMemorySummary:
         out = format_memory_summary(
             {"mem_alloc": 1.5, "mem_peak_alloc": 2.25}
         )
-        assert out == "1.50/2.25GiB"
+        assert out == "1.50/2.25GiB (cur/peak)"
         # Specifically: no parenthetical percentage when total unknown.
         assert "%" not in out
 
@@ -318,8 +318,9 @@ class TestFormatMemorySummary:
         out = format_memory_summary(
             {"mem_alloc": 8.0, "mem_peak_alloc": 10.0}
         )
-        # 8 / 16 = 50%
-        assert out == "8.00/10.00GiB (50%)"
+        # 8 / 16 = 50%; denominator (16.0GiB) is spelled out so the
+        # left pair isn't misread as a fraction.
+        assert out == "8.00/10.00GiB (cur/peak, 50% of 16.0GiB)"
 
     def test_handles_prefix(self, monkeypatch):
         """The prefix kwarg should match the keys in the dict."""
@@ -333,7 +334,7 @@ class TestFormatMemorySummary:
             {"train/mem_alloc": 1.5, "train/mem_peak_alloc": 2.0},
             prefix="train/",
         )
-        assert out == "1.50/2.00GiB"
+        assert out == "1.50/2.00GiB (cur/peak)"
 
     def test_alloc_only_when_peak_missing(self, monkeypatch):
         """If only alloc is present (e.g. partial dict), format that alone."""
@@ -344,14 +345,12 @@ class TestFormatMemorySummary:
             lambda d=None: {"name": "x", "total_memory": -1},
         )
         out = format_memory_summary({"mem_alloc": 1.5})
-        assert out == "1.50GiB"
+        assert out == "1.50GiB (cur)"
 
     def test_peak_only_uses_GiB_suffix_not_legacy_format(self, monkeypatch):
-        """When only mem_peak_alloc is present, output should be
-        `X.XXGiB` (matching the alloc-only branch), not the legacy
-        `peak X.XXGiB` form. Regression: the old code returned a
-        different prefix for this rare case, breaking the documented
-        contract."""
+        """When only mem_peak_alloc is present, output is
+        `X.XXGiB (peak)` — the number is labeled `(peak)` so it reads
+        unambiguously, not the legacy `peak X.XXGiB` prefix form."""
         import ezpz.distributed
         monkeypatch.setattr(
             ezpz.distributed,
@@ -359,9 +358,10 @@ class TestFormatMemorySummary:
             lambda d=None: {"name": "x", "total_memory": -1},
         )
         out = format_memory_summary({"mem_peak_alloc": 2.5})
-        assert out == "2.50GiB"
-        # Must NOT use the legacy "peak X.XXGiB" wording.
-        assert "peak" not in out
+        assert out == "2.50GiB (peak)"
+        # Must NOT use the legacy "peak X.XXGiB" prefix wording (label
+        # rides in parens after the value instead).
+        assert not out.startswith("peak")
 
     def test_peak_only_includes_percentage_when_total_known(self, monkeypatch):
         """The peak-only branch should still include the percentage,
@@ -376,9 +376,8 @@ class TestFormatMemorySummary:
         # alloc is missing entirely; with no alloc to %-of, pct_str should
         # remain empty (pct is computed against `alloc`, not `peak`).
         out = format_memory_summary({"mem_peak_alloc": 2.0})
-        # Format matches the consistent `X.XXGiB` shape — no percent
-        # (we'd need alloc to compute it).
-        assert out == "2.00GiB"
+        # Labeled `(peak)` — no percent (we'd need alloc to compute it).
+        assert out == "2.00GiB (peak)"
 
     def test_prefix_auto_detected_from_keys(self, monkeypatch):
         """When prefix is None (default), it's inferred from the keys."""
@@ -392,15 +391,15 @@ class TestFormatMemorySummary:
         out = format_memory_summary(
             {"train/mem_alloc": 1.5, "train/mem_peak_alloc": 2.0}
         )
-        assert out == "1.50/2.00GiB"
+        assert out == "1.50/2.00GiB (cur/peak)"
         # eval/ prefix
         out = format_memory_summary(
             {"eval/mem_alloc": 3.0, "eval/mem_peak_alloc": 4.0}
         )
-        assert out == "3.00/4.00GiB"
+        assert out == "3.00/4.00GiB (cur/peak)"
         # No prefix
         out = format_memory_summary({"mem_alloc": 5.0, "mem_peak_alloc": 6.0})
-        assert out == "5.00/6.00GiB"
+        assert out == "5.00/6.00GiB (cur/peak)"
 
     def test_explicit_prefix_overrides_auto_detect(self, monkeypatch):
         """If caller passes a prefix, it should win over inference."""
@@ -419,7 +418,7 @@ class TestFormatMemorySummary:
             },
             prefix="eval/",
         )
-        assert out == "7.00/8.00GiB"
+        assert out == "7.00/8.00GiB (cur/peak)"
 
     def test_device_int_passed_to_get_device_properties(self, monkeypatch):
         """`device=1` should be forwarded as the int index, not None."""
@@ -486,7 +485,7 @@ class TestFormatMemorySummary:
         out = format_memory_summary(
             {"mem_alloc": 1.5, "mem_peak_alloc": 2.0}
         )
-        assert out == "1.50/2.00GiB"
+        assert out == "1.50/2.00GiB (cur/peak)"
 
 
 class TestIsMemoryMetricKey:


### PR DESCRIPTION
## Problem

The compact memory token in training logs rendered as:

\`\`\`
memory=16.28/46.16GiB (25%)
\`\`\`

This reads as if **16.28 were a fraction of 46.16** — but it isn't:
- \`16.28 / 46.16\` are **current / peak *allocated*** (two allocation numbers)
- \`25%\` is **current-alloc as a fraction of the device's *physical total*** (~64GiB) — a third number that never appears on the line

Two people independently misread it the same way (the second being the impetus for this fix).

## Fix

Make the token self-describing:

\`\`\`
memory=16.28/46.16GiB (cur/peak, 25% of 64.0GiB)
\`\`\`

- \`cur/peak\` labels the two allocation numbers
- \`Z% of T.TGiB\` spells out the percentage denominator so the left pair isn't misread as a fraction
- Graceful degradation: \`(cur/peak)\` when the device total is unknown (CPU/unknown-XPU); alloc-only → \`(cur[, …])\`; peak-only → \`(peak)\`

Change is confined to \`format_memory_summary\` in \`ezpz/utils\`; the \`History\` call sites are unchanged (they still prepend \`memory=\`).

## Also fixes stale docs

\`docs/history.md\` described the token as \`memory=alloc/reserved (peak%)\` — **wrong on both counts** (it's alloc/peak-*allocated*, and the % is current-of-total, not peak). Corrected + example line updated. \`docs/examples/fsdp-tp.md\`'s allocated-vs-reserved note refreshed to the labeled shape.

## Tests

\`tests/test_memory_metrics.py\` updated to the new exact strings across all branches (alloc+peak / alloc-only / peak-only × total-known/unknown). Verified end-to-end through the real \`history.py\` render path. **101 passed** across memory/history/exports suites; the one \`test_recipes\` failure is pre-existing (missing NetCDF backend lib in the local venv, unrelated).

## Summary by Sourcery

Clarify memory usage summaries in training logs so current and peak allocations and their percentage of device total are explicitly labeled and self-describing.

New Features:
- Label memory summary outputs with cur/peak and include the percentage denominator as "% of <total>GiB" when device totals are known.

Bug Fixes:
- Correct misleading memory summary formatting that could be misread as one allocation value being a fraction of the other.
- Align documented memory token format with the actual behavior of the memory metrics, including allocated vs reserved distinctions.

Enhancements:
- Standardize alloc-only and peak-only memory formats with explicit cur/peak labels to make rare partial metric cases unambiguous.

Documentation:
- Update history logging documentation to show the new labeled memory token format and clarify what each component represents.
- Refresh the fsdp-tp example docs to clearly distinguish allocated vs reserved memory metrics using the new format.

Tests:
- Update memory metrics tests to assert the new labeled string formats across alloc+peak, alloc-only, and peak-only cases with and without known device totals.
- Adjust history tests to expect the updated memory summary token shape in the compact console line.