### PR TITLE
fix(launch): errors=replace on child stdout readers

### DIFF
--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -85,6 +85,7 @@ def _run_with_watchdog(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        errors="replace",  # ezpz#163: tolerate non-utf8 child bytes
         bufsize=1,  # line-buffered on our side; child uses PYTHONUNBUFFERED
         env=child_env,
     )
@@ -252,6 +253,7 @@ def run_bash_command(command: str) -> subprocess.CompletedProcess[str]:
         shell=True,
         check=False,
         text=True,
+        errors="replace",  # ezpz#163: tolerate non-utf8 child bytes
         capture_output=True,
     )
 
@@ -318,6 +320,7 @@ def _mpirun_supports_flag(flag: str) -> bool:
             check=False,
             capture_output=True,
             text=True,
+            errors="replace",  # ezpz#163: tolerate non-utf8 child bytes
         )
     except Exception:
         return False
@@ -389,6 +392,7 @@ def run_command(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        errors="replace",  # ezpz#163: tolerate non-utf8 child bytes
         bufsize=1,
         close_fds=True,
     ) as process:


### PR DESCRIPTION
Closes #163.

## Problem

`subprocess.Popen(text=True)` with no `errors=` handler uses a **strict** utf-8 `TextIOWrapper`. A multibyte char (tqdm progress bars, arrows — byte `0xe2` etc.) split across a line-buffer boundary raises `UnicodeDecodeError` in the `_drain` reader thread. That thread dies silently → the auto-retry watchdog sees no output → it fires a spurious `SIGTERM` and kills an otherwise-healthy job (rc=1). Observed killing multi-hour SFT jobs on Sunspot XPU.

## Fix

Add `errors="replace"` to the 4 `text=True` `Popen`/`run` sites in `launch.py`, so undecodable bytes become the replacement char (`�`) instead of crashing the drain thread. Purely defensive — no behavior change on clean utf-8 output.

## Provenance

This fix was written earlier but accidentally committed onto the already-merged `feat/torchcomms-backend` branch (`0ac8932`), stranding it off `main`. Cherry-picked here onto a clean branch off `main` so it lands properly with its own release note. The stray commit on the dead branch can be ignored.

## Verification

Diff is 4 one-line additions; `launch.py` byte-compiles. No conflict with current `main`.

## Summary by Sourcery

Bug Fixes:
- Prevent UnicodeDecodeError crashes in stdout reader threads by using a tolerant text decoding mode for subprocess calls in launch utilities.