### PR TITLE
refactor(pbs,slurm): drop the sh dependency (fixes intermittent qstat ImportError)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "plotext",
   "rich",
   "seaborn",
-  "sh",
   "transformers>=4.50",
   "torchinfo",
   "wandb",

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -513,7 +513,10 @@ def get_pbs_launch_cmd(
 
 def get_running_jobs_from_qstat() -> list[int]:
     """Get the running jobs from qstat"""
-    output = _run_qstat_with_retry(_qstat, "-u", os.environ.get("USER", ""))
+    # getuser() resolves the current user robustly (env vars → pwd), so we
+    # never pass an empty `-u ""` to qstat. Matches the other qstat site
+    # (get_pbs_running_jobs_for_user) which already uses getuser().
+    output = _run_qstat_with_retry(_qstat, "-u", getuser())
     return [
         int(i.split(".")[0])
         for i in output.split("\n")[2:-1]

--- a/src/ezpz/pbs.py
+++ b/src/ezpz/pbs.py
@@ -11,6 +11,8 @@ for more information.
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import time
 from pathlib import Path
 from typing import Optional, Union, Tuple
@@ -28,9 +30,40 @@ Pathish = Union[str, os.PathLike, Path]
 
 logger = ezpz.get_logger(__name__)
 
-# Suppress the sh library's INFO-level "process started" noise
-import logging as _logging
-_logging.getLogger("sh").setLevel(_logging.WARNING)
+
+def _qstat(*args: str) -> str:
+    """Run ``qstat`` via subprocess and return its stdout as a string.
+
+    Drop-in replacement for the old ``sh.qstat`` callable — same
+    ``(*args) -> str`` shape, so it plugs straight into
+    :func:`_run_qstat_with_retry`. Each argument is passed as its own
+    argv token (``qstat`` never shell-splits), so callers should pass
+    ``"-fn1wru", user`` rather than a single ``"-fn1wru {user}"`` string.
+
+    Raises ``FileNotFoundError`` if ``qstat`` isn't on ``PATH`` (mirrors
+    the old ``ImportError`` from ``from sh import qstat`` on login/compute
+    nodes that lack the PBS binaries), and ``RuntimeError`` with the
+    combined stderr on a non-zero exit — the message carries PBS's
+    "Communication failure" / "cannot connect to server" text so the
+    retry logic in :func:`_run_qstat_with_retry` still triggers.
+    """
+    if shutil.which("qstat") is None:
+        raise FileNotFoundError(
+            "qstat not found on PATH — PBS client tools unavailable"
+        )
+    proc = subprocess.run(
+        ["qstat", *args],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"qstat exited {proc.returncode}: "
+            f"{(proc.stderr or proc.stdout).strip()}"
+        )
+    return proc.stdout
+
 
 _QSTAT_MAX_RETRIES = 5
 _QSTAT_RETRY_DELAY = 2  # seconds
@@ -79,13 +112,7 @@ def get_pbs_running_jobs_for_user() -> dict[str, list[str]]:
         if time.monotonic() - ts < _PBS_JOBS_CACHE_TTL:
             return cached
 
-    try:
-        from sh import qstat  # type:ignore
-    except Exception as e:
-        logger.debug("Error importing sh.qstat: %s", e)
-        raise
-
-    output = _run_qstat_with_retry(qstat, f"-fn1wru {getuser()}")
+    output = _run_qstat_with_retry(_qstat, "-fn1wru", getuser())
     jobarr = [
         i for i in output.split("\n") if " R " in i
     ]
@@ -486,11 +513,7 @@ def get_pbs_launch_cmd(
 
 def get_running_jobs_from_qstat() -> list[int]:
     """Get the running jobs from qstat"""
-    try:
-        from sh import qstat as shqstat  # type: ignore
-    except Exception as e:
-        raise e
-    output = _run_qstat_with_retry(shqstat, "-u", os.environ.get("USER"))
+    output = _run_qstat_with_retry(_qstat, "-u", os.environ.get("USER", ""))
     return [
         int(i.split(".")[0])
         for i in output.split("\n")[2:-1]

--- a/src/ezpz/slurm.py
+++ b/src/ezpz/slurm.py
@@ -11,6 +11,8 @@ shell commands only when the env vars are absent (e.g. on a login node).
 
 import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional, Union
 
@@ -18,6 +20,32 @@ import ezpz
 from ezpz.distributed import _expand_slurm_nodelist
 
 logger = ezpz.get_logger(__name__)
+
+
+def _run_slurm_command(cmd: str, *args: str) -> str:
+    """Run a SLURM client command via subprocess and return its stdout.
+
+    Replaces the old ``from sh import <cmd>`` pattern. Raises
+    ``FileNotFoundError`` when the binary isn't on ``PATH`` (mirrors the
+    ``ImportError`` that ``sh`` raised when a command was missing — e.g.
+    off a SLURM cluster) and ``RuntimeError`` (with stderr) on a non-zero
+    exit, so existing ``try/except`` blocks around these calls behave the
+    same.
+    """
+    if shutil.which(cmd) is None:
+        raise FileNotFoundError(f"{cmd} not found on PATH")
+    proc = subprocess.run(
+        [cmd, *args],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{cmd} exited {proc.returncode}: "
+            f"{(proc.stderr or proc.stdout).strip()}"
+        )
+    return proc.stdout
 
 
 # ── job discovery ──────────────────────────────────────────────────────────
@@ -31,21 +59,21 @@ def get_slurm_running_jobs() -> list[str] | None:
     unavailable.
     """
     try:
-        from sh import sacct  # type:ignore
-    except (ImportError, ModuleNotFoundError):
-        logger.warning("sacct unavailable (sh package not installed)")
+        output = _run_slurm_command("sacct")
+    except FileNotFoundError:
+        logger.warning("sacct unavailable (not found on PATH)")
         return None
-
-    try:
-        return list(
-            {
-                i.replace(".", " ").split(" ")[0]
-                for i in [j for j in sacct().split("\n") if " RUNNING " in j]
-            }
-        )
     except Exception as e:
         logger.error("Error getting running jobs from sacct: %s", e)
         return None
+
+    return list(
+        {
+            i.replace(".", " ").split(" ")[0]
+            for i in output.split("\n")
+            if " RUNNING " in i
+        }
+    )
 
 
 def get_nodelist_from_slurm_jobid(jobid: str | int) -> list[str]:
@@ -61,12 +89,7 @@ def get_nodelist_from_slurm_jobid(jobid: str | int) -> list[str]:
 
     # Slow path: query scontrol for an arbitrary job ID.
     try:
-        from sh import scontrol  # type:ignore
-    except Exception as e:
-        logger.error("Error importing sh.scontrol: %s", e)
-        raise e
-    try:
-        output = scontrol("show", "job", str(jobid)).split("\n")
+        output = _run_slurm_command("scontrol", "show", "job", str(jobid)).split("\n")
         # scontrol can return multiple NodeList= lines; skip "(null)" entries
         # which appear for batch job wrappers before the real allocation.
         best_match: str | None = None

--- a/src/ezpz/slurm.py
+++ b/src/ezpz/slurm.py
@@ -34,7 +34,11 @@ def _run_slurm_command(cmd: str, *args: str) -> str:
     """
     if shutil.which(cmd) is None:
         raise FileNotFoundError(f"{cmd} not found on PATH")
-    proc = subprocess.run(
+    # No shell (list form), so args are passed as literal argv tokens — a
+    # value like a job ID can't inject a command. `cmd` is always an
+    # internal literal ("sacct"/"scontrol"); it's never caller/attacker
+    # supplied. Safe against command injection.
+    proc = subprocess.run(  # nosec B603  # noqa: S603
         [cmd, *args],
         capture_output=True,
         text=True,

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -193,7 +193,7 @@ class TestGetRunningJobsFromQstat:
         assert isinstance(result, list)
         assert result == [123456, 123458]
 
-    def test_qstat_failure_returns_empty(self, monkeypatch):
+    def test_qstat_nonzero_exit_raises(self, monkeypatch):
         """When qstat exits non-zero, a RuntimeError propagates."""
         monkeypatch.setenv("USER", "testuser")
         monkeypatch.setattr(pbs.shutil, "which", lambda _c: "/usr/bin/qstat")
@@ -267,8 +267,8 @@ class TestGetPbsRunningJobsForUser:
         result = pbs.get_pbs_running_jobs_for_user()
         assert result == {}
 
-    def test_qstat_import_failure_raises(self, monkeypatch):
-        """When the qstat binary isn't on PATH, the exception propagates."""
+    def test_qstat_binary_missing_raises(self, monkeypatch):
+        """When the qstat binary isn't on PATH, FileNotFoundError propagates."""
         monkeypatch.setattr(pbs.shutil, "which", lambda _c: None)
         with pytest.raises(FileNotFoundError):
             pbs.get_pbs_running_jobs_for_user()

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -182,36 +182,35 @@ class TestGetRunningJobsFromQstat:
 
     def test_happy_path(self, monkeypatch):
         """Realistic qstat -u output yields list of running job ID ints."""
-        mock_sh = MagicMock()
-        mock_sh.qstat = MagicMock(return_value=QSTAT_U_OUTPUT)
         monkeypatch.setenv("USER", "testuser")
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            result = pbs.get_running_jobs_from_qstat()
+        monkeypatch.setattr(pbs.shutil, "which", lambda _c: "/usr/bin/qstat")
+        monkeypatch.setattr(
+            pbs.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(returncode=0, stdout=QSTAT_U_OUTPUT, stderr=""),
+        )
+        result = pbs.get_running_jobs_from_qstat()
         assert isinstance(result, list)
         assert result == [123456, 123458]
 
     def test_qstat_failure_returns_empty(self, monkeypatch):
-        """When qstat raises an error, the exception propagates."""
-        mock_sh = MagicMock()
-        mock_sh.qstat = MagicMock(side_effect=RuntimeError("qstat broken"))
+        """When qstat exits non-zero, a RuntimeError propagates."""
         monkeypatch.setenv("USER", "testuser")
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            with pytest.raises(RuntimeError, match="qstat broken"):
-                pbs.get_running_jobs_from_qstat()
+        monkeypatch.setattr(pbs.shutil, "which", lambda _c: "/usr/bin/qstat")
+        monkeypatch.setattr(
+            pbs.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(returncode=1, stdout="", stderr="qstat broken"),
+        )
+        with pytest.raises(RuntimeError, match="qstat broken"):
+            pbs.get_running_jobs_from_qstat()
 
-    def test_qstat_unavailable(self):
-        """ImportError when sh.qstat is not importable propagates."""
-        import sys
-        _orig_sh = sys.modules.get("sh", _SENTINEL := object())
-        try:
-            sys.modules["sh"] = None  # type: ignore[assignment]
-            with pytest.raises((ImportError, ModuleNotFoundError)):
-                pbs.get_running_jobs_from_qstat()
-        finally:
-            if _orig_sh is _SENTINEL:
-                sys.modules.pop("sh", None)
-            else:
-                sys.modules["sh"] = _orig_sh
+    def test_qstat_unavailable(self, monkeypatch):
+        """FileNotFoundError when the qstat binary isn't on PATH propagates."""
+        monkeypatch.setenv("USER", "testuser")
+        monkeypatch.setattr(pbs.shutil, "which", lambda _c: None)
+        with pytest.raises(FileNotFoundError):
+            pbs.get_running_jobs_from_qstat()
 
 
 # ===================================================================
@@ -225,12 +224,17 @@ class TestGetPbsRunningJobsForUser:
     def setup_method(self):
         pbs._pbs_jobs_cache = None
 
-    def test_returns_jobid_to_nodelist_mapping(self):
+    def test_returns_jobid_to_nodelist_mapping(self, monkeypatch):
         """Parses qstat -fn1wru and returns {jobid: [nodes]} dict."""
-        mock_sh = MagicMock()
-        mock_sh.qstat = MagicMock(return_value=QSTAT_FN1WRU_OUTPUT)
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            result = pbs.get_pbs_running_jobs_for_user()
+        monkeypatch.setattr(pbs.shutil, "which", lambda _c: "/usr/bin/qstat")
+        monkeypatch.setattr(
+            pbs.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(
+                returncode=0, stdout=QSTAT_FN1WRU_OUTPUT, stderr=""
+            ),
+        )
+        result = pbs.get_pbs_running_jobs_for_user()
         assert isinstance(result, dict)
         assert "123456" in result
         assert "123458" in result
@@ -244,7 +248,7 @@ class TestGetPbsRunningJobsForUser:
             "x3006c0s1b0n0",
         ]
 
-    def test_no_running_jobs(self):
+    def test_no_running_jobs(self, monkeypatch):
         """Empty qstat output with only queued jobs returns empty dict."""
         qstat_no_running = (
             "                                                            Req'd  Req'd   Elap\n"
@@ -252,25 +256,22 @@ class TestGetPbsRunningJobsForUser:
             "--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----\n"
             "123457.pbs      testuser workq    myjob2      1235   1   4    --  02:00 Q   --\n"
         )
-        mock_sh = MagicMock()
-        mock_sh.qstat = MagicMock(return_value=qstat_no_running)
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            result = pbs.get_pbs_running_jobs_for_user()
+        monkeypatch.setattr(pbs.shutil, "which", lambda _c: "/usr/bin/qstat")
+        monkeypatch.setattr(
+            pbs.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(
+                returncode=0, stdout=qstat_no_running, stderr=""
+            ),
+        )
+        result = pbs.get_pbs_running_jobs_for_user()
         assert result == {}
 
-    def test_qstat_import_failure_raises(self):
-        """When sh is not importable, the exception propagates."""
-        import sys
-        _orig_sh = sys.modules.get("sh", _SENTINEL := object())
-        try:
-            sys.modules["sh"] = None  # type: ignore[assignment]
-            with pytest.raises(Exception):
-                pbs.get_pbs_running_jobs_for_user()
-        finally:
-            if _orig_sh is _SENTINEL:
-                sys.modules.pop("sh", None)
-            else:
-                sys.modules["sh"] = _orig_sh
+    def test_qstat_import_failure_raises(self, monkeypatch):
+        """When the qstat binary isn't on PATH, the exception propagates."""
+        monkeypatch.setattr(pbs.shutil, "which", lambda _c: None)
+        with pytest.raises(FileNotFoundError):
+            pbs.get_pbs_running_jobs_for_user()
 
 
 # ===================================================================

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -1,13 +1,13 @@
 """Tests for ``ezpz.slurm``.
 
-Covers all public functions with mocked ``sh.sacct``, ``sh.scontrol``,
-``socket.getfqdn``, environment variables, and filesystem operations.
+Covers all public functions with mocked ``_run_slurm_command`` (the
+subprocess seam for ``sacct`` / ``scontrol``), ``socket.getfqdn``,
+environment variables, and filesystem operations.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -65,27 +65,26 @@ def _mock_scontrol_no_nodelist(*_args, **_kwargs):
 class TestGetSlurmRunningJobs:
     """Tests for ``get_slurm_running_jobs``."""
 
-    def test_happy_path(self):
+    def test_happy_path(self, monkeypatch):
         """Parses sacct output and returns unique job IDs as strings."""
-        mock_sh = MagicMock()
-        mock_sh.sacct = _mock_sacct
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            result = slurm.get_slurm_running_jobs()
+        monkeypatch.setattr(slurm, "_run_slurm_command", _mock_sacct)
+        result = slurm.get_slurm_running_jobs()
         assert isinstance(result, list)
         assert set(result) == {"12345", "67890"}
 
-    def test_sacct_failure_returns_none(self):
-        """When sacct fails, returns None instead of raising."""
-        mock_sh = MagicMock()
-        mock_sh.sacct = _mock_sacct_failure
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            result = slurm.get_slurm_running_jobs()
+    def test_sacct_failure_returns_none(self, monkeypatch):
+        """When sacct exits non-zero, returns None instead of raising."""
+        monkeypatch.setattr(slurm, "_run_slurm_command", _mock_sacct_failure)
+        result = slurm.get_slurm_running_jobs()
         assert result is None
 
-    def test_sacct_unavailable_returns_none(self):
-        """When sh package is not installed, returns None."""
-        with patch.dict("sys.modules", {"sh": None}):
-            result = slurm.get_slurm_running_jobs()
+    def test_sacct_unavailable_returns_none(self, monkeypatch):
+        """When the sacct binary isn't on PATH, returns None."""
+        def _not_found(*_a, **_k):
+            raise FileNotFoundError("sacct not found on PATH")
+
+        monkeypatch.setattr(slurm, "_run_slurm_command", _not_found)
+        result = slurm.get_slurm_running_jobs()
         assert result is None
 
 
@@ -106,29 +105,29 @@ class TestGetNodelistFromSlurmJobid:
     def test_scontrol_fallback(self, monkeypatch):
         """Falls back to scontrol when SLURM_NODELIST is not set."""
         monkeypatch.delenv("SLURM_NODELIST", raising=False)
-        mock_sh = MagicMock()
-        mock_sh.scontrol = _mock_scontrol
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            result = slurm.get_nodelist_from_slurm_jobid("12345")
+        monkeypatch.setattr(slurm, "_run_slurm_command", _mock_scontrol)
+        result = slurm.get_nodelist_from_slurm_jobid("12345")
         assert result == ["nid001", "nid002", "nid003"]
 
     def test_missing_nodelist_raises(self, monkeypatch):
         """When NodeList line is absent in scontrol output, raises ValueError."""
         monkeypatch.delenv("SLURM_NODELIST", raising=False)
-        mock_sh = MagicMock()
-        mock_sh.scontrol = _mock_scontrol_no_nodelist
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            with pytest.raises(ValueError, match="NodeList not found"):
-                slurm.get_nodelist_from_slurm_jobid("99999")
+        monkeypatch.setattr(
+            slurm, "_run_slurm_command", _mock_scontrol_no_nodelist
+        )
+        with pytest.raises(ValueError, match="NodeList not found"):
+            slurm.get_nodelist_from_slurm_jobid("99999")
 
     def test_scontrol_failure_raises(self, monkeypatch):
-        """When scontrol call fails, raises the error."""
+        """When the scontrol call fails, raises the error."""
         monkeypatch.delenv("SLURM_NODELIST", raising=False)
-        mock_sh = MagicMock()
-        mock_sh.scontrol.side_effect = RuntimeError("scontrol broken")
-        with patch.dict("sys.modules", {"sh": mock_sh}):
-            with pytest.raises(RuntimeError, match="scontrol broken"):
-                slurm.get_nodelist_from_slurm_jobid("12345")
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("scontrol broken")
+
+        monkeypatch.setattr(slurm, "_run_slurm_command", _boom)
+        with pytest.raises(RuntimeError, match="scontrol broken"):
+            slurm.get_nodelist_from_slurm_jobid("12345")
 
 
 # ===================================================================


### PR DESCRIPTION
## Problem

`ezpz.pbs` and `ezpz.slurm` shelled out to `qstat` / `sacct` / `scontrol` via the [`sh`](https://pypi.org/project/sh/) package:

```python
from sh import qstat   # resolves the binary at IMPORT time via sh.__getattr__
```

`sh` resolves each attribute to a `$PATH` binary lazily *at import*. When a launched job's venv has `sh` installed but the PBS/SLURM client binaries aren't on `PATH` (or `sh`'s resolution hiccups), this raises a confusing:

```
ImportError: cannot import name 'qstat' from 'sh'
```

…**mid-run**, inside the drain/watchdog path — observed intermittently killing jobs on Sunspot (the traceback that prompted this).

## Fix

Replace all 4 `sh` call sites with plain `subprocess`:

- **`pbs.py`** → `_qstat(*args) -> str` — subprocess-backed, keeps the exact `(*args) -> str` shape so it drops into the existing `_run_qstat_with_retry` unchanged.
- **`slurm.py`** → `_run_slurm_command(cmd, *args) -> str` for `sacct` / `scontrol`.

Both:
- check `shutil.which(binary)` first → raise **`FileNotFoundError`** when absent (catchable + predictable, vs `sh`'s import-time crash),
- raise **`RuntimeError` carrying stderr** on non-zero exit — so the existing `"Communication failure"` / `"cannot connect to server"` **retry detection still fires** (verified),
- pass `errors="replace"` (defends against the same non-UTF-8 issue as #163).

Also fixes a **latent arg bug**: `sh` never shell-splits, so `qstat("-fn1wru {user}")` was passing one combined argv token; subprocess uses the correct `["-fn1wru", user]`.

`sh` removed from `[project.dependencies]`.

## Verification

- **284 tests pass** (pbs, slurm, kill, distributed suites).
- Test mocks converted from `patch.dict(sys.modules, {"sh": ...})` to the subprocess seams; import-failure cases now assert `FileNotFoundError`.
- **Adversarial end-to-end** (real subprocess, not mocked): confirmed missing-binary → `FileNotFoundError`, stdout capture, and non-zero-exit → `RuntimeError` that carries the `Communication failure` text the retry logic keys on.

## Summary by Sourcery

Replace PBS and SLURM job discovery commands that depended on the `sh` package with explicit subprocess-based helpers, making cluster client binaries a runtime concern instead of an import-time dependency.

Bug Fixes:
- Eliminate intermittent ImportError failures when `qstat`/`sacct`/`scontrol` are missing or not resolvable at import time, replacing them with predictable runtime FileNotFoundError or RuntimeError paths.

Enhancements:
- Introduce `_qstat` and `_run_slurm_command` helpers that wrap PBS/SLURM client binaries with subprocess, preserving existing retry and error-handling behavior.
- Tighten argument handling for `qstat` invocations so flags and usernames are passed as distinct argv tokens, avoiding latent shell-splitting issues.

Build:
- Remove the `sh` dependency from project runtime dependencies.

Tests:
- Update PBS and SLURM tests to mock the new subprocess-based seams instead of the `sh` module, and validate the new FileNotFoundError and RuntimeError behaviors.