### PR TITLE
test(loss): fix macOS hang in 2-rank vocab-parallel CE test

### DIFF
--- a/tests/test_loss_impls.py
+++ b/tests/test_loss_impls.py
@@ -304,8 +304,12 @@ def test_vocab_parallel_matches_eager_2rank(vocab):
         f"vp loss {ret['loss']} != eager {float(ref)} (vocab={vocab})"
     )
     # grad0 came back as a plain nested list (see _vp_worker) — rebuild a
-    # tensor for the comparison.
-    grad0 = torch.tensor(ret["grad0"], dtype=torch.float32)
+    # tensor for the comparison, matching the eager grad's dtype and device
+    # so the check stays accurate if the reference ever runs in another
+    # precision / on an accelerator.
+    grad0 = torch.tensor(
+        ret["grad0"], dtype=full.grad.dtype, device=full.grad.device
+    )
     assert torch.allclose(grad0, full.grad[:, s:e], atol=1e-4), (
         f"vocab-parallel grad shard != eager grad shard (vocab={vocab})"
     )

--- a/tests/test_loss_impls.py
+++ b/tests/test_loss_impls.py
@@ -250,9 +250,17 @@ def _vp_worker(rank, world_size, vocab, n_rows, master_port, ret):
         )
         loss.backward()
         # rank 0 reports loss + its grad shard for comparison to eager.
+        # NOTE: store grad0 as a plain nested list, NOT a torch.Tensor.
+        # Putting a Tensor into a multiprocessing.Manager().dict() routes
+        # it through torch's shared-memory / file-descriptor reducer, and
+        # handing that FD to the Manager server process HANGS under the
+        # `spawn` start method (default on macOS) — gloo then sits at its
+        # 30-min rendezvous timeout, looking like the whole suite froze.
+        # `.tolist()` serializes as pure Python; the parent rebuilds a
+        # tensor for the allclose check.
         if rank == 0:
             ret["loss"] = float(loss.detach())
-            ret["grad0"] = local.grad.detach().clone()
+            ret["grad0"] = local.grad.detach().tolist()
             ret["shard"] = (s, e)
     finally:
         dist.destroy_process_group()
@@ -295,6 +303,9 @@ def test_vocab_parallel_matches_eager_2rank(vocab):
     assert abs(ret["loss"] - float(ref)) < 1e-4, (
         f"vp loss {ret['loss']} != eager {float(ref)} (vocab={vocab})"
     )
-    assert torch.allclose(ret["grad0"], full.grad[:, s:e], atol=1e-4), (
+    # grad0 came back as a plain nested list (see _vp_worker) — rebuild a
+    # tensor for the comparison.
+    grad0 = torch.tensor(ret["grad0"], dtype=torch.float32)
+    assert torch.allclose(grad0, full.grad[:, s:e], atol=1e-4), (
         f"vocab-parallel grad shard != eager grad shard (vocab={vocab})"
     )


### PR DESCRIPTION
## Symptom

`uv run pytest` hangs indefinitely on `tests/test_loss_impls.py` — specifically `test_vocab_parallel_matches_eager_2rank` (the 2-rank gloo test from #178). On macOS the whole suite appears frozen; `timeout` confirms exit 124.

## Root cause

The gloo worker (`_vp_worker`) reports its result by storing values into a `multiprocessing.Manager().dict()`, including:

```python
ret["grad0"] = local.grad.detach().clone()   # a torch.Tensor
```

Torch's tensor pickle reducer moves cross-process tensors via **shared-memory file descriptors**. Handing that FD to the Manager's *server* process **stalls under the `spawn` start method** (the default on macOS). gloo then blocks on its **default 30-minute rendezvous timeout**, which is indistinguishable from a hang.

Isolated with minimal repros: bare 2-rank gloo works (~seconds), gloo + `_cross_entropy_vocab_parallel` works (~1.5s), but the moment a **Tensor** goes into the `Manager().dict()` it hangs; swapping `.clone()` → `.tolist()` drops it back to ~2.8s.

## Fix

Store `grad0` as a plain nested list (`.tolist()`) through the Manager, and rebuild a tensor in the parent for the `allclose` comparison. Pure-Python serialization avoids the FD hand-off entirely. No change to what's being asserted.

## Verification

`tests/test_loss_impls.py` now runs in **~9s** (was: indefinite hang). Both `vocab` params (12, 13) pass; **19/19** in the file.

Pre-existing bug (came in with #178); not related to any in-flight branch — surfaced running the full suite on macOS.

## Summary by Sourcery

Prevent macOS hangs in the 2-rank vocab-parallel cross-entropy loss test by changing how gradients are passed between processes.

Bug Fixes:
- Fix indefinite hang on macOS when running the 2-rank vocab-parallel cross-entropy gloo test due to Tensor serialization through multiprocessing.Manager().dict().

Tests:
- Adjust the vocab-parallel loss test to send gradients as plain Python lists through the multiprocessing manager and reconstruct tensors in the parent before comparison.