### PR TITLE
test(yeet): fix footer tests failing under /tmp on Linux

### DIFF
--- a/tests/test_yeet_env.py
+++ b/tests/test_yeet_env.py
@@ -853,8 +853,14 @@ class TestRun:
     @patch("ezpz.utils.yeet_env._get_worker_nodes", return_value=["node01"])
     def test_generic_source_skips_venv_footer(
         self, _nodes, _host, mock_rsync, mock_patch_venv, tmp_path, capsys,
+        monkeypatch,
     ):
         """A non-venv directory source uses the generic 'Synced to ...' footer."""
+        # Force needs_local_copy=True so total_nodes>0 and the sync (+ footer)
+        # actually runs. Without this, `tmp_path` under /tmp on Linux makes
+        # _needs_local_copy() False → total_nodes==0 → early return, no footer
+        # (the platform trap _needs_local_copy was extracted to let tests avoid).
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: True)
         # Make a plain dir source (no bin/activate, no conda-meta)
         src = tmp_path / "data"
         src.mkdir()
@@ -875,9 +881,13 @@ class TestRun:
     @patch("ezpz.utils.yeet_env._get_current_hostname", return_value="node01")
     @patch("ezpz.utils.yeet_env._get_worker_nodes", return_value=["node01"])
     def test_venv_source_uses_venv_footer(
-        self, _nodes, _host, mock_rsync, tmp_path, capsys,
+        self, _nodes, _host, mock_rsync, tmp_path, capsys, monkeypatch,
     ):
         """A directory with bin/activate triggers the venv footer."""
+        # Force needs_local_copy=True (see sibling test) so the sync + footer
+        # run regardless of whether tmp_path is under /tmp (Linux) or
+        # /var/folders (macOS).
+        monkeypatch.setattr(yeet, "_needs_local_copy", lambda src: True)
         src = tmp_path / "myenv"
         (src / "bin").mkdir(parents=True)
         (src / "bin" / "activate").write_text("# fake venv")


### PR DESCRIPTION
## Symptom

On Sunspot (Linux) the full suite reported 2 failures that **pass on macOS**:

```
FAILED tests/test_yeet_env.py::TestRun::test_generic_source_skips_venv_footer - assert 'Synced to' in ''
FAILED tests/test_yeet_env.py::TestRun::test_venv_source_uses_venv_footer   - assert 'To use this environment' in ''
```

Captured stdout is **empty** — `run()` returns 0 but prints nothing.

## Root cause (platform-dependent)

Neither test patched `_needs_local_copy()`:

```python
def _needs_local_copy(src): return not str(src).startswith("/tmp")
```

- **Linux:** pytest's `tmp_path` = `/tmp/pytest-of-.../...` → `_needs_local_copy` **False** → with `_get_worker_nodes → ["node01"]` filtered to the current host, `total_nodes == 0` → `run()` hits `if total_nodes == 0: return 0` **before** the guidance footer → empty stdout → assertions fail.
- **macOS:** `tmp_path` = `/var/folders/...` → `_needs_local_copy` **True** → `total_nodes == 1` → footer prints → tests pass.

This is exactly the trap the helper's own docstring warns about ("tests using `tmp_path` as `src` silently exercise different branches on different platforms") — these two tests just didn't opt into the guard.

## Fix

Force `_needs_local_copy → True` in both tests via `monkeypatch` — the deterministic pattern **4 sibling tests already use**. Now platform-independent.

Pre-existing bug (identical to `main`); not related to any in-flight feature branch — surfaced by running the full suite on Linux.

## Verification

Both tests pass; verified the fix holds regardless of the `tmp_path` prefix.

## Summary by Sourcery

Tests:
- Update generic and venv source footer tests to explicitly enable local-copy mode via monkeypatch so they no longer depend on platform-specific tmp_path prefixes.