### PR TITLE
docs(compare): fix launcher-flags framing (pass-through overrides defaults)

### DIFF
--- a/docs/compare.md
+++ b/docs/compare.md
@@ -66,10 +66,13 @@ type (`nvidia-smi` / `xpu-smi` / `rocm-smi`), picks the right launcher
 The same script runs on your laptop with `world_size=1`. See [Why
 ezpz?](./index.md) for the diff version.
 
-What you give up: complete control over launcher flags. You can pass
-launcher-specific args through with `ezpz launch -- <launcher flags> --
-python train.py`, but if you need exotic options not covered by the
-common path, raw `torchrun` is more direct.
+Launcher flags stay fully under your control. The defaults above are
+just that — defaults. Any launcher-specific args you pass through with
+`ezpz launch -- <launcher flags> -- python train.py` are appended
+*after* them, so they take precedence (the launcher applies
+last-one-wins) and let you override or extend anything the common path
+sets. Nothing is hidden or off-limits; the exotic option you need is a
+pass-through away.
 
 ## vs. HuggingFace `accelerate`
 


### PR DESCRIPTION
The `vs. torchrun` section in `docs/compare.md` claimed:

> What you give up: complete control over launcher flags. ... if you need exotic options not covered by the common path, raw `torchrun` is more direct.

That's inaccurate — **you don't give up anything.** Extra launcher args passed via `ezpz launch -- <flags> -- python train.py` are appended **after** ezpz's defaults in `build_executable` (`launch.py`):

```python
executable = [*shlex.split(launch_cmd), *extra_launch_args, *cmd_to_launch_list]
```

Under `mpiexec` / `srun` **last-one-wins** semantics, a user-supplied flag therefore **overrides** the corresponding default (and any not-covered flag just passes straight through). Nothing is hidden or off-limits.

Reworded to describe the actual behavior: defaults are just defaults, pass-through args take precedence, override-or-extend anything.

Docs-only.

## Summary by Sourcery

Documentation:
- Update compare.md to explain that pass-through launcher flags are appended after ezpz defaults, allowing users to override or extend any launcher settings without losing control.