### PR TITLE
feat(fsdp_tp): add --dp-shard / --dp-replicate (HSDP)

### DIFF
--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -69,6 +69,25 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
   **Note**: HF mode forces `--tp 1` (the TP plan is hardcoded to ezpz's own
   Transformer module names; doesn't apply to HF's `LlamaDecoderLayer`). See
   [HuggingFace models](#huggingface-models) for details.
+- **HSDP (replicate + shard)** — split the data-parallel dim into a
+  replicate × shard mesh with `--dp-replicate` / `--dp-shard`. Weights are
+  **replicated** across `dp_replicate` groups and **sharded** within each
+  `dp_shard` group — e.g. shard within a node, replicate across nodes to
+  cut inter-node all-gather traffic:
+
+  ```bash
+  # 16 ranks: shard within groups of 4, replicate across 4 groups (tp=1)
+  ezpz launch python3 -m ezpz.examples.fsdp_tp \
+    --model agpt-2b --dp-replicate 4 --dp-shard 4 --tp 1
+  ```
+
+  Constraint: `dp_replicate * dp_shard * tp == WORLD_SIZE`. Defaults
+  (`--dp-replicate 1 --dp-shard -1`) give a single flat sharded dp dim
+  (pure FSDP), identical to the pre-HSDP behavior — `--dp-shard -1` means
+  "use all remaining ranks" = `WORLD_SIZE / (dp_replicate * tp)`. Mirrors
+  torchtitan's `data_parallel_replicate_degree` / `data_parallel_shard_degree`.
+  (The legacy `--sharding-strategy hybrid_shard*` names do **not** do real
+  HSDP under FSDP2 — use these flags instead.)
 - **Activation checkpointing** — `--ac {none,block,full,selective}` (or
   `--activation-checkpoint`) trades compute for memory during training.
   `block`/`full` wraps each TransformerBlock (~30-40 pct activation-memory

--- a/docs/superpowers/specs/2026-07-19-fsdp-tp-dp-shard-replicate-design.md
+++ b/docs/superpowers/specs/2026-07-19-fsdp-tp-dp-shard-replicate-design.md
@@ -1,0 +1,193 @@
+# `--dp-shard` / `--dp-replicate` (HSDP) for `fsdp_tp.py`
+
+**Date:** 2026-07-19
+**Status:** Design — approved (pending spec review)
+**Scope:** Single-file feature (`src/ezpz/examples/fsdp_tp.py`) + tests + a docs note.
+
+## Goal
+
+Add explicit control over the data-parallel topology in
+`ezpz.examples.fsdp_tp` via two CLI flags — `--dp-replicate` and
+`--dp-shard` — enabling **HSDP** (Hybrid Sharded Data Parallel): replicate
+model weights across `dp_replicate` groups, shard within each `dp_shard`
+group. Mirrors torchtitan's `data_parallel_replicate_degree` /
+`data_parallel_shard_degree` so configs port 1:1.
+
+## Background / current state
+
+- `fsdp_tp` builds a **2D device mesh** `("dp", "tp")` at
+  `fsdp_tp.py:1934`, where `dp = world_size // tp` — a single flat
+  data-parallel dim.
+- FSDP2 (`fully_shard`) is applied over the full `dp` mesh → pure ZeRO-style
+  sharding. There is no way to request replication (HSDP) today.
+- The legacy `--sharding-strategy hybrid_shard` / `hybrid_shard_zero2`
+  names exist but a code comment (`fsdp_tp.py:1243-1246`) states FSDP1
+  hybrid has no one-flag FSDP2 equivalent — they only map to
+  `reshard_after_forward`, i.e. they do **not** actually do HSDP.
+- torchtitan precedent (`torchtitan/distributed/parallel_dims.py`):
+  `dp_replicate` (default 1), `dp_shard` (default -1 = use all remaining),
+  constraint `dp_replicate * dp_shard * cp * tp * pp == world_size`, mesh
+  dims split into `("dp_replicate", "dp_shard")`. FSDP2 reads a 2D DP
+  submesh as HSDP automatically.
+- Verified in the pinned torch (2.12.1): `DeviceMesh._flatten` exists and
+  `init_device_mesh_safe` forwards N-D `mesh_shape` generically.
+
+## Decisions (locked)
+
+1. **Full HSDP** — split the flat `dp` dim into a 2D
+   `(dp_replicate, dp_shard)` submesh; use FSDP2's native HSDP.
+2. **Defaults:** `--dp-replicate 1`, `--dp-shard -1` (auto = all
+   remaining). This reproduces today's behavior *exactly* when neither is
+   passed (replicate=1 → pure FSDP shard over the whole DP dim). Matches
+   torchtitan.
+3. **Mesh shape:** always build a 3D mesh
+   `("dp_replicate", "dp_shard", "tp")` and **flatten** the two DP dims
+   into a single named `"dp"` dim, so every existing `dp` consumer
+   (DistributedSampler, loss group) keeps working unchanged with correct
+   rank math from torch's tested flattening. Only the `fully_shard` mesh
+   arg changes to use the DP submesh.
+
+## Architecture
+
+### CLI surface (new args, near `--tp` at `fsdp_tp.py:1217`)
+
+```
+--dp-replicate  int  default 1   # replicate weights across N groups (HSDP outer dim)
+--dp-shard      int  default -1  # shard within groups; -1 = world_size // (dp_replicate * tp)
+```
+
+Help text names them as the real HSDP knobs; add a one-line pointer from
+`--sharding-strategy`'s help to `--dp-replicate`/`--dp-shard` for HSDP.
+
+### Degree resolution + validation (replaces `dpsize = world_size // args.tp` at 1923)
+
+```python
+dp_replicate = args.dp_replicate
+dp_shard = args.dp_shard
+if dp_shard < 0:  # -1 → use all remaining ranks
+    dp_shard = world_size // (dp_replicate * args.tp)
+assert dp_replicate >= 1, "--dp-replicate must be >= 1"
+assert dp_shard >= 1, "--dp-shard must be >= 1 (or -1 for auto)"
+assert dp_replicate * dp_shard * args.tp == world_size, (
+    f"dp_replicate({dp_replicate}) * dp_shard({dp_shard}) * tp({args.tp}) "
+    f"!= WORLD_SIZE({world_size})"
+)
+dpsize = dp_replicate * dp_shard  # == flattened "dp" size; keeps all downstream math correct
+```
+
+### Mesh construction (replaces `fsdp_tp.py:1934`)
+
+```python
+device_mesh = ezpz.init_device_mesh_safe(
+    str(ezpz.get_torch_device()),
+    (dp_replicate, dp_shard, args.tp),
+    mesh_dim_names=("dp_replicate", "dp_shard", "tp"),
+)
+# Flatten the two DP dims into one named "dp" dim so existing consumers
+# (device_mesh["dp"], get_group("dp"), get_local_rank("dp"),
+# num_replicas=dpsize) work unchanged with correct rank arithmetic.
+device_mesh[("dp_replicate", "dp_shard")]._flatten("dp")
+```
+
+### `fully_shard` mesh selection (in `parallelize`, around `fsdp_tp.py:1638`)
+
+The `fsdp_kwargs["mesh"]` currently uses `dp_mesh = device_mesh["dp"]`
+(1543). Change to select based on replication:
+
+```python
+if dp_replicate > 1:
+    fsdp_dp_mesh = device_mesh[("dp_replicate", "dp_shard")]  # 2D → HSDP
+else:
+    fsdp_dp_mesh = device_mesh["dp_shard"]                    # 1D → plain FSDP
+```
+
+- `dp_replicate == 1` → 1D `dp_shard` mesh → **byte-identical to today**
+  (a 1-sized replicate dim would otherwise be a needless HSDP wrap).
+- `dp_replicate > 1` → 2D submesh → FSDP2 HSDP.
+
+`parallelize()` (signature at 1525) already receives `device_mesh`, so it
+reads `device_mesh["dp_replicate"].size()` to branch — **no new
+parameter**. The `dp_mesh = device_mesh["dp"]` line (1543) stays for the
+non-FSDP dp uses; only the `fsdp_kwargs["mesh"]` selection branches on the
+replicate size.
+
+### The single flattened-`dp` invariant
+
+Every other DP consumer stays as-is because they read the flattened dim:
+- `device_mesh["dp"]` (the FSDP2 optimizer/loss-dp uses at 2175)
+- `num_replicas=dpsize` + `rank=device_mesh.get_local_rank("dp")`
+  (DistributedSampler, 2372-2373 and 2406-2407)
+- `device_mesh.get_group("dp")` (loss dp_group, 2389)
+
+These are semantically correct only against the *flattened* dp (a data
+sample shards/replicates across the entire dp product, not one sub-dim),
+which is exactly what `_flatten("dp")` provides.
+
+## Data flow
+
+```
+args.dp_replicate, args.dp_shard, args.tp
+   └─ resolve dp_shard (-1 → auto) + assert product == world_size
+   └─ init_device_mesh_safe((dp_replicate, dp_shard, tp), names=(dp_replicate, dp_shard, tp))
+   └─ mesh[(dp_replicate, dp_shard)]._flatten("dp")
+        ├─ fully_shard: mesh = dp_shard (1D) if dp_replicate==1 else (dp_replicate,dp_shard) (2D→HSDP)
+        └─ everything else: device_mesh["dp"] / get_group("dp") / get_local_rank("dp") / dpsize (unchanged)
+```
+
+## Error handling
+
+- Non-divisible config → `AssertionError` with the exact
+  `dp_replicate * dp_shard * tp != WORLD_SIZE` message (fail fast at setup).
+- `dp_replicate < 1` or `dp_shard < 1` (after -1 resolution) → assert with
+  a clear message.
+- HF-model branch already forces `args.tp = 1` (2015-2024); dp flags are
+  independent of that and need no special-casing (the product check just
+  uses the final `args.tp`).
+
+## Testing
+
+CPU-only, no accelerator (match existing `fsdp_tp` test style —
+`tests/test_fsdp_tp_*.py` parse args / assert topology without launching):
+
+1. **Defaults reproduce today:** `--dp-replicate` default 1, `--dp-shard`
+   default -1; resolved `dp_shard == world_size // tp`, `dpsize` unchanged.
+2. **-1 auto-fill math:** for a mocked `world_size` and `tp`,
+   `dp_shard = world_size // (dp_replicate * tp)`.
+3. **Product validation:** a config where
+   `dp_replicate * dp_shard * tp != world_size` raises AssertionError with
+   the documented message.
+4. **fully_shard mesh selection:** `dp_replicate == 1` → 1D `dp_shard`
+   mesh path; `dp_replicate > 1` → 2D submesh path. (Assert on the mesh
+   dim(s) passed, mocking `init_device_mesh_safe` / `fully_shard` so no
+   real process group is needed.)
+5. **Arg parsing:** `--dp-replicate`/`--dp-shard` parse as ints; `--help`
+   lists them.
+
+Where a real mesh is impractical CPU-side, mock `init_device_mesh_safe`
+to return a stub whose `[...]`/`_flatten`/`size()` are inspectable — the
+same mocking approach the existing fsdp_tp tests use for topology.
+
+## Documentation
+
+- Update `docs/examples/fsdp-tp.md` with an HSDP example
+  (`--dp-replicate 2 --dp-shard 4 --tp ...`) and the product constraint.
+- Update the module docstring's mesh description (`fsdp_tp.py:20-21`,
+  which says "Data Parallel (dp) across hosts / Tensor Parallel (tp)")
+  to mention the replicate/shard split.
+- Docs updated in the same pass as code (project convention).
+
+## Out of scope (YAGNI)
+
+- No changes to `--pp` / `--cp` (fsdp_tp doesn't expose them as active
+  dims today; dp flags compose with `tp` only, matching current mesh).
+- No `ezpz.tp` / `distributed.py` HSDP plumbing — this is confined to the
+  `fsdp_tp` example's own mesh build.
+- No removal/renaming of the legacy `--sharding-strategy hybrid_shard*`
+  values (kept for back-compat; just cross-referenced).
+
+## Release
+
+Single `release:patch` PR (additive; default behavior unchanged when the
+flags aren't set). Merge as a merge commit, not squash (project convention).
+On-node HSDP validation (dp_replicate>1 across real nodes) is a follow-up;
+unit tests cover the topology math + mesh selection.

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -20,6 +20,11 @@ separate parallel dimensions:
     Data Parallel ("dp") across hosts
     Tensor Parallel ("tp") within each host
 
+The data-parallel dim can itself be split for HSDP via --dp-replicate /
+--dp-shard: weights are replicated across `dp_replicate` groups and
+sharded within each `dp_shard` group (dp = dp_replicate * dp_shard). The
+defaults (dp_replicate=1, dp_shard=-1) give a single flat sharded dp dim.
+
 We use a simple diagram to illustrate below:
 
 +-----.-----+-----+-----+
@@ -341,6 +346,46 @@ def _reshard_after_forward(sharding_strategy: Optional[str]) -> bool:
     if sharding_strategy is None:
         return True
     return SHARDING_STRATEGIES.get(sharding_strategy, True)
+
+
+def _resolve_dp_degrees(
+    *, world_size: int, tp: int, dp_replicate: int, dp_shard: int
+) -> tuple[int, int]:
+    """Resolve the (dp_replicate, dp_shard) data-parallel degrees.
+
+    Mirrors torchtitan's semantics:
+
+    - ``dp_shard == -1`` means "use all remaining ranks", i.e.
+      ``world_size // (dp_replicate * tp)``.
+    - The product ``dp_replicate * dp_shard * tp`` must equal
+      ``world_size``.
+
+    With the defaults (``dp_replicate=1``, ``dp_shard=-1``) this yields
+    ``dp_shard = world_size // tp`` and ``dp_replicate = 1`` — i.e. a single
+    flat data-parallel dim (pure FSDP sharding), identical to the behavior
+    before HSDP support was added.
+
+    Returns the resolved ``(dp_replicate, dp_shard)`` tuple. Raises
+    ``AssertionError`` with an explicit message on an invalid configuration.
+    """
+    assert dp_replicate >= 1, (
+        f"--dp-replicate must be >= 1 (got {dp_replicate})"
+    )
+    assert dp_shard == -1 or dp_shard >= 1, (
+        f"--dp-shard must be >= 1, or -1 for auto (got {dp_shard})"
+    )
+    if dp_shard < 0:
+        denom = dp_replicate * tp
+        assert world_size % denom == 0, (
+            f"cannot auto-resolve --dp-shard: WORLD_SIZE({world_size}) is not "
+            f"divisible by dp_replicate({dp_replicate}) * tp({tp}) = {denom}"
+        )
+        dp_shard = world_size // denom
+    assert dp_replicate * dp_shard * tp == world_size, (
+        f"dp_replicate({dp_replicate}) * dp_shard({dp_shard}) * tp({tp}) "
+        f"= {dp_replicate * dp_shard * tp} != WORLD_SIZE({world_size})"
+    )
+    return dp_replicate, dp_shard
 
 
 def _slice_for_sequence_parallel(
@@ -1226,6 +1271,33 @@ def parse_args(argv: Optional[list[str]] = None):
         ),
     )
     parser.add_argument(
+        "--dp-replicate",
+        type=int,
+        default=1,
+        help=(
+            "Data-parallel REPLICATE degree (HSDP outer dim). Weights are "
+            "replicated across this many groups; within each group they are "
+            "sharded across --dp-shard ranks. Default 1 = no replication "
+            "(pure FSDP sharding, i.e. today's behavior). Set >1 for HSDP "
+            "(e.g. shard within a node, replicate across nodes). Mirrors "
+            "torchtitan's data_parallel_replicate_degree. Constraint: "
+            "dp_replicate * dp_shard * tp == WORLD_SIZE."
+        ),
+    )
+    parser.add_argument(
+        "--dp-shard",
+        type=int,
+        default=-1,
+        help=(
+            "Data-parallel SHARD degree (FSDP inner dim). Weights are "
+            "sharded across this many ranks within each replicate group. "
+            "Default -1 = 'use all remaining ranks' = "
+            "WORLD_SIZE / (dp_replicate * tp), which reproduces today's "
+            "flat data-parallel behavior. Mirrors torchtitan's "
+            "data_parallel_shard_degree."
+        ),
+    )
+    parser.add_argument(
         "--sharding-strategy",
         type=str,
         default="full_shard",
@@ -1243,7 +1315,9 @@ def parse_args(argv: Optional[list[str]] = None):
             "per-module no-shard). `hybrid_shard`/`hybrid_shard_zero2`: "
             "FSDP1 hybrid has no one-flag FSDP2 equivalent — `hybrid_shard` "
             "maps to reshard-after-forward, `hybrid_shard_zero2` to "
-            "keep-unsharded (mirroring their ZeRO-3/ZeRO-2 variants)."
+            "keep-unsharded (mirroring their ZeRO-3/ZeRO-2 variants). "
+            "For actual HSDP (replicate + shard), use --dp-replicate / "
+            "--dp-shard, which build a 2D data-parallel mesh."
         ),
     )
     parser.add_argument(
@@ -1540,7 +1614,20 @@ def parallelize(
     sharded unit (torchtitan's ordering).
     """
     tp_mesh = device_mesh["tp"]
-    dp_mesh = device_mesh["dp"]
+    dp_mesh = device_mesh["dp"]  # flattened (dp_replicate*dp_shard) — used by
+    # non-FSDP dp consumers below and elsewhere in the module.
+
+    # Choose the mesh fully_shard shards over:
+    #   dp_replicate > 1 -> 2D (dp_replicate, dp_shard) submesh; FSDP2 reads a
+    #                       2D DP mesh as HSDP (replicate across the outer dim,
+    #                       shard within the inner) automatically.
+    #   dp_replicate == 1 -> 1D dp_shard mesh; plain FSDP sharding, identical
+    #                        to the pre-HSDP behavior (avoids a needless
+    #                        size-1 replicate wrap).
+    if device_mesh["dp_replicate"].size() > 1:
+        fsdp_dp_mesh = device_mesh["dp_replicate", "dp_shard"]
+    else:
+        fsdp_dp_mesh = device_mesh["dp_shard"]
 
     reshard = _reshard_after_forward(sharding_strategy)
 
@@ -1635,7 +1722,7 @@ def parallelize(
 
     # FSDP2: shard each module group on the dp sub-mesh. Per-module sharding
     # (vs FSDP1's one flat param) is what keeps backward memory bounded.
-    fsdp_kwargs = {"mesh": dp_mesh, "reshard_after_forward": reshard}
+    fsdp_kwargs = {"mesh": fsdp_dp_mesh, "reshard_after_forward": reshard}
     if mixed_precision is not None:
         fsdp_kwargs["mp_policy"] = mixed_precision
 
@@ -1920,7 +2007,16 @@ def train(
     """
     world_size = ezpz.distributed.get_world_size()
     assert world_size % args.tp == 0, "WORLD_SIZE must be divisible by TP"
-    dpsize = world_size // args.tp
+    # Resolve the data-parallel topology: dp_replicate (HSDP outer) x
+    # dp_shard (FSDP inner). Defaults (replicate=1, shard=-1) reproduce the
+    # flat FSDP dp dim exactly.
+    dp_replicate, dp_shard = _resolve_dp_degrees(
+        world_size=world_size,
+        tp=args.tp,
+        dp_replicate=args.dp_replicate,
+        dp_shard=args.dp_shard,
+    )
+    dpsize = dp_replicate * dp_shard  # == flattened "dp" size
     # fused-linear (Liger/Cut-CE): needs the model's hidden states + output
     # weight, so only the ezpz Transformer (not HF models) and — for now —
     # only tp=1 (tp>1 needs vocab-shard composition, gated to a follow-up).
@@ -1931,11 +2027,17 @@ def train(
     # LATER (after the HF branch may force args.tp=1), so an HF model launched
     # with --tp>1 --loss-impl=loss-parallel doesn't enter vocab-parallel CE
     # with a stale TP group. See the resolution just before parallelize().
+    # 3D mesh: (dp_replicate, dp_shard, tp). We then flatten the two DP dims
+    # into a single named "dp" dim so all existing dp consumers
+    # (DistributedSampler num_replicas/rank, loss dp_group) keep working with
+    # correct rank arithmetic. fully_shard picks the DP submesh explicitly
+    # (2D -> HSDP when dp_replicate > 1, else 1D dp_shard == today's FSDP).
     device_mesh = ezpz.init_device_mesh_safe(
         str(ezpz.get_torch_device()),
-        (dpsize, args.tp),
-        mesh_dim_names=("dp", "tp"),
+        (dp_replicate, dp_shard, args.tp),
+        mesh_dim_names=("dp_replicate", "dp_shard", "tp"),
     )
+    device_mesh[("dp_replicate", "dp_shard")]._flatten("dp")
     logger.info(f"Device mesh created:\n{device_mesh=}")
 
     hf_dataset = None
@@ -2171,8 +2273,14 @@ def train(
                     deepest_len = len(module)
                     deepest_modlist = module
 
+        # Same HSDP mesh selection as parallelize(): 2D DP submesh when
+        # replicating, else the 1D shard mesh (identical to pre-HSDP).
+        if device_mesh["dp_replicate"].size() > 1:
+            hf_dp_mesh = device_mesh["dp_replicate", "dp_shard"]
+        else:
+            hf_dp_mesh = device_mesh["dp_shard"]
         hf_fsdp_kwargs = {
-            "mesh": device_mesh["dp"],
+            "mesh": hf_dp_mesh,
             "reshard_after_forward": _reshard_after_forward(
                 args.sharding_strategy
             ),

--- a/tests/test_fsdp_tp_dp_degrees.py
+++ b/tests/test_fsdp_tp_dp_degrees.py
@@ -1,0 +1,116 @@
+"""Tests for HSDP data-parallel degree resolution in ezpz.examples.fsdp_tp.
+
+Covers the ``--dp-replicate`` / ``--dp-shard`` CLI flags and the pure
+``_resolve_dp_degrees`` helper that turns them into concrete
+(dp_replicate, dp_shard) degrees. Mirrors torchtitan semantics:
+dp_shard == -1 means "use all remaining ranks", and the product
+dp_replicate * dp_shard * tp must equal WORLD_SIZE.
+
+CPU-only: the helper is pure arithmetic, and arg parsing needs no
+accelerator or process group.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _import_fsdp_tp():
+    try:
+        return importlib.import_module("ezpz.examples.fsdp_tp")
+    except Exception as exc:  # heavy optional deps may be missing
+        pytest.skip(f"could not import ezpz.examples.fsdp_tp: {exc}")
+
+
+class TestResolveDpDegrees:
+    """Pure ``_resolve_dp_degrees`` arithmetic + validation."""
+
+    def test_defaults_reproduce_flat_dp(self):
+        """replicate=1, shard=-1 → flat dp = world_size // tp, replicate=1.
+
+        This is the pre-HSDP behavior and MUST be preserved exactly.
+        """
+        m = _import_fsdp_tp()
+        assert m._resolve_dp_degrees(
+            world_size=8, tp=2, dp_replicate=1, dp_shard=-1
+        ) == (1, 4)
+        # tp=1 → whole world is the (flat) shard dim
+        assert m._resolve_dp_degrees(
+            world_size=8, tp=1, dp_replicate=1, dp_shard=-1
+        ) == (1, 8)
+
+    def test_shard_auto_fill(self):
+        """dp_shard=-1 fills as world_size // (dp_replicate * tp)."""
+        m = _import_fsdp_tp()
+        # 16 ranks, tp=2, replicate=2 → shard = 16/(2*2) = 4
+        assert m._resolve_dp_degrees(
+            world_size=16, tp=2, dp_replicate=2, dp_shard=-1
+        ) == (2, 4)
+
+    def test_explicit_hsdp(self):
+        """Explicit replicate+shard that satisfies the product constraint."""
+        m = _import_fsdp_tp()
+        assert m._resolve_dp_degrees(
+            world_size=8, tp=2, dp_replicate=2, dp_shard=2
+        ) == (2, 2)
+
+    def test_product_must_equal_world_size(self):
+        """A config whose product != world_size raises with a clear message."""
+        m = _import_fsdp_tp()
+        with pytest.raises(AssertionError, match="!= WORLD_SIZE"):
+            m._resolve_dp_degrees(
+                world_size=8, tp=2, dp_replicate=2, dp_shard=3
+            )
+
+    def test_auto_shard_requires_divisibility(self):
+        """dp_shard=-1 when (dp_replicate*tp) doesn't divide world_size fails."""
+        m = _import_fsdp_tp()
+        with pytest.raises(AssertionError, match="not\n?.*divisible|divisible"):
+            m._resolve_dp_degrees(
+                world_size=6, tp=4, dp_replicate=1, dp_shard=-1
+            )
+
+    def test_replicate_must_be_positive(self):
+        m = _import_fsdp_tp()
+        with pytest.raises(AssertionError, match="dp-replicate must be >= 1"):
+            m._resolve_dp_degrees(
+                world_size=8, tp=1, dp_replicate=0, dp_shard=-1
+            )
+
+    def test_shard_must_be_positive_or_auto(self):
+        m = _import_fsdp_tp()
+        with pytest.raises(AssertionError, match="dp-shard must be >= 1"):
+            m._resolve_dp_degrees(
+                world_size=8, tp=1, dp_replicate=1, dp_shard=0
+            )
+
+    def test_single_rank(self):
+        """world_size=1, tp=1 → (1, 1) (laptop path)."""
+        m = _import_fsdp_tp()
+        assert m._resolve_dp_degrees(
+            world_size=1, tp=1, dp_replicate=1, dp_shard=-1
+        ) == (1, 1)
+
+
+class TestDpArgParsing:
+    """The --dp-replicate / --dp-shard CLI flags parse correctly."""
+
+    def test_defaults(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args([])
+        assert args.dp_replicate == 1
+        assert args.dp_shard == -1
+
+    def test_explicit_values(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--dp-replicate", "2", "--dp-shard", "4"])
+        assert args.dp_replicate == 2
+        assert args.dp_shard == 4
+
+    def test_flags_are_ints(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--dp-replicate", "3"])
+        assert isinstance(args.dp_replicate, int)
+        assert isinstance(args.dp_shard, int)


### PR DESCRIPTION
Add explicit control of the data-parallel topology in `ezpz.examples.fsdp_tp` via `--dp-replicate` / `--dp-shard`, enabling **HSDP** (Hybrid Sharded Data Parallel).

## What

- **`--dp-replicate`** (default `1`): replicate weights across N groups (HSDP outer dim).
- **`--dp-shard`** (default `-1`): shard within each group; `-1` = "use all remaining ranks" = `WORLD_SIZE / (dp_replicate * tp)`.
- Constraint: `dp_replicate * dp_shard * tp == WORLD_SIZE` (asserted with a clear message).

Mirrors torchtitan's `data_parallel_replicate_degree` / `data_parallel_shard_degree` so configs port 1:1.

## How

- **`_resolve_dp_degrees()`** — pure helper: resolves the `-1` auto-fill and validates the product constraint (fails fast).
- **Mesh** — build a 3D `(dp_replicate, dp_shard, tp)` mesh and `_flatten` the two DP dims into a single named `"dp"` dim. Every existing dp consumer (`DistributedSampler` num_replicas/rank, loss `dp_group`, `device_mesh["dp"]`) keeps working unchanged with correct rank arithmetic from torch's tested flattening.
- **`fully_shard`** (both ezpz-Transformer and HF paths) receives the 2D `(dp_replicate, dp_shard)` submesh when `dp_replicate > 1` (→ FSDP2 HSDP), else the 1D `dp_shard` mesh (**byte-identical to pre-HSDP**).

## Backward compatibility

Defaults (`replicate=1, shard=-1`) reproduce the previous flat-dp behavior **exactly** — verified: `ws=8, tp=2` still yields effective `dp=4`, and `dp_replicate==1` takes the plain-FSDP 1D-mesh branch (no needless HSDP wrap).

## Tests

11 new unit tests (`tests/test_fsdp_tp_dp_degrees.py`): default reproduction, `-1` auto-fill, explicit HSDP, product/divisibility/positivity validation, single-rank, arg parsing. Full `fsdp_tp` suite: **94 passed**. Adversarially verified the mesh dims + fully_shard branch selection.

## Not yet done
On-node HSDP validation (`dp_replicate > 1` across real nodes) is a follow-up; unit tests cover the topology math + mesh-selection logic (the runtime HSDP semantics are FSDP2's, driven by the 2D submesh).

Spec: `docs/superpowers/specs/2026-07-19-fsdp-tp-dp-shard-replicate-design.md`

## Summary by Sourcery

Add explicit control over data-parallel topology in the fsdp_tp example to support HSDP while preserving existing default behavior.

New Features:
- Introduce --dp-replicate and --dp-shard CLI flags to configure data-parallel replicate and shard degrees for FSDP/HSDP.
- Add a helper to resolve data-parallel degrees and validate world size/product constraints, enabling safe topology configuration.

Enhancements:
- Build a 3D device mesh (dp_replicate, dp_shard, tp) and flatten the data-parallel dims for compatibility with existing dp consumers while routing FSDP to the appropriate submesh.
- Clarify sharding-strategy documentation and fsdp-tp docs with HSDP usage guidance and examples, aligned with torchtitan semantics.

Documentation:
- Document HSDP usage in fsdp-tp examples and add a design spec describing dp-replicate/dp-shard semantics and topology.
- Update the fsdp_tp module docs to describe the split data-parallel dimension for HSDP.

Tests:
- Add unit tests for dp degree resolution arithmetic, validation, and CLI parsing, including default and HSDP-specific configurations.