### PR TITLE
fix(dist): correct local-rank/device detection under ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE

### DIFF
--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -193,13 +193,15 @@ def get_local_rank() -> int:
 
     The value is resolved from well-known environment variables set by
     common MPI implementations and job schedulers.  If none are set the
-    function falls back to ``get_rank() % get_gpus_per_node()``.
+    function falls back to ``get_rank() % ranks_per_node``.
 
     Returns:
         Local rank (0-indexed within the node).
     """
     _ENV_VARS = (
         "LOCAL_RANK",
+        "PALS_LOCAL_RANKID",  # cray-pals mpiexec (Aurora / Sunspot)
+        "PMIX_LOCAL_RANK",  # PMIx layer (Aurora / Sunspot)
         "PMI_LOCAL_RANK",
         "OMPI_COMM_WORLD_LOCAL_RANK",
         "MPI_LOCALRANKID",
@@ -213,8 +215,21 @@ def get_local_rank() -> int:
     ws = get_world_size()
     if ws <= 1:
         return 0
-    gpn = get_gpus_per_node()
-    return get_rank() % gpn if gpn > 0 else 0
+    # Last-resort fallback (no launcher local-rank var found): derive the
+    # local rank from the global rank and the number of ranks placed on
+    # each node. Use ranks-per-node (world_size // num_nodes), NOT the
+    # device count — they diverge whenever a job under-subscribes a node
+    # (e.g. `-ppn 6` on a 12-device node, or COMPOSITE collapsing 12
+    # tiles into 6 GPUs), and a device-count modulo would then hand
+    # `set_device` an out-of-range index (the original COMPOSITE crash).
+    nnodes = get_num_nodes()
+    if nnodes > 0 and ws % nnodes == 0:
+        ranks_per_node = ws // nnodes
+    else:
+        # Can't cleanly determine ranks-per-node; best-effort with the
+        # device count (historical behavior).
+        ranks_per_node = get_gpus_per_node()
+    return get_rank() % ranks_per_node if ranks_per_node > 0 else 0
 
 
 def get_world_size(
@@ -287,7 +302,18 @@ def get_gpus_per_node() -> int:
     Prefers environment variables (``NGPU_PER_HOST``, ``LOCAL_WORLD_SIZE``,
     ``PMI_LOCAL_SIZE``, ``SLURM_NTASKS_PER_NODE``) then falls back to
     ``torch.{cuda,xpu}.device_count()``.
+
+    On Intel XPU the env hint is *clamped down* to the number of devices
+    the runtime actually exposes: ezpz's shell setup hardcodes
+    ``NGPU_PER_HOST=12`` (the FLAT tile count), but under
+    ``ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE`` only 6 composite GPUs exist.
+    Reporting 12 there over-counts devices and skews ``get_node_index``,
+    the per-host summary, and the local-rank fallback. Clamping is
+    one-directional (never bumps a smaller, deliberate under-subscription
+    up) and XPU-only (COMPOSITE has no CUDA analogue), so CUDA behavior
+    is unchanged.
     """
+    env_hint: int | None = None
     for var in (
         "NGPU_PER_HOST",
         "LOCAL_WORLD_SIZE",
@@ -296,16 +322,47 @@ def get_gpus_per_node() -> int:
     ):
         val = os.environ.get(var)
         if val is not None and val != "":
-            return int(val)
+            env_hint = int(val)
+            break
+
+    xpu_count = _xpu_device_count_safe()
+    if env_hint is not None:
+        # Only reconcile against XPU: clamp a stale FLAT-mode hint down to
+        # the visible composite-GPU count. Never bump up (under-
+        # subscription is intentional), never touch the CUDA path.
+        if xpu_count is not None and 0 < xpu_count < env_hint:
+            return xpu_count
+        return env_hint
+
     import torch
 
     if torch.cuda.is_available():
         return torch.cuda.device_count()
-    if torch.xpu.is_available():
-        return torch.xpu.device_count()
+    if xpu_count is not None:
+        return xpu_count
     if torch.backends.mps.is_available():
         return get_world_size_in_use()
     return 0
+
+
+def _xpu_device_count_safe() -> int | None:
+    """Return ``torch.xpu.device_count()`` or ``None`` if unavailable.
+
+    Guards against builds without ``torch.xpu`` (CPU-/CUDA-only) and
+    against login nodes where probing raises (no Level-Zero loader) —
+    ``get_gpus_per_node`` runs during launch-time topology inference
+    there, so a raised exception must degrade to "unknown", not crash.
+    """
+    import torch
+
+    if not hasattr(torch, "xpu"):
+        return None
+    try:
+        if torch.xpu.is_available():
+            return torch.xpu.device_count()
+    except Exception:
+        return None
+    return None
 
 
 def get_cpus_per_node() -> int:

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -325,11 +325,17 @@ def get_gpus_per_node() -> int:
             env_hint = int(val)
             break
 
-    xpu_count = _xpu_device_count_safe()
     if env_hint is not None:
         # Only reconcile against XPU: clamp a stale FLAT-mode hint down to
         # the visible composite-GPU count. Never bump up (under-
         # subscription is intentional), never touch the CUDA path.
+        #
+        # `_xpu_device_count_safe()` does NOT force an `import torch`: the
+        # launch/PBS topology path (`pbs._infer_topology`) calls this on a
+        # torch-less launcher/login node and must still get the env hint
+        # back. It probes only if torch is already imported (a worker
+        # process), where the COMPOSITE clamp actually matters.
+        xpu_count = _xpu_device_count_safe()
         if xpu_count is not None and 0 < xpu_count < env_hint:
             return xpu_count
         return env_hint
@@ -338,6 +344,7 @@ def get_gpus_per_node() -> int:
 
     if torch.cuda.is_available():
         return torch.cuda.device_count()
+    xpu_count = _xpu_device_count_safe()
     if xpu_count is not None:
         return xpu_count
     if torch.backends.mps.is_available():
@@ -348,13 +355,18 @@ def get_gpus_per_node() -> int:
 def _xpu_device_count_safe() -> int | None:
     """Return ``torch.xpu.device_count()`` or ``None`` if unavailable.
 
-    Guards against builds without ``torch.xpu`` (CPU-/CUDA-only) and
-    against login nodes where probing raises (no Level-Zero loader) —
-    ``get_gpus_per_node`` runs during launch-time topology inference
-    there, so a raised exception must degrade to "unknown", not crash.
+    Never forces ``import torch``: returns ``None`` when torch is not
+    already imported, so torch-less callers (the launch/PBS topology path
+    runs without torch installed) don't raise ``ModuleNotFoundError``.
+    Also guards builds without ``torch.xpu`` (CPU-/CUDA-only) and login
+    nodes where probing raises (no Level-Zero loader) — a raised
+    exception degrades to "unknown", not a crash.
     """
-    import torch
+    import sys
 
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return None
     if not hasattr(torch, "xpu"):
         return None
     try:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -65,7 +65,8 @@ def fake_comm(monkeypatch):
     for var in (
         "WORLD_SIZE", "PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS",
         "RANK", "PMI_RANK", "OMPI_COMM_WORLD_RANK", "SLURM_PROCID",
-        "LOCAL_RANK", "PMI_LOCAL_RANK", "OMPI_COMM_WORLD_LOCAL_RANK",
+        "LOCAL_RANK", "PALS_LOCAL_RANKID", "PMIX_LOCAL_RANK",
+        "PMI_LOCAL_RANK", "OMPI_COMM_WORLD_LOCAL_RANK",
         "MPI_LOCALRANKID", "MPICH_LOCALRANKID", "SLURM_LOCAL_ID",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -237,10 +238,61 @@ class TestGetLocalRank:
         monkeypatch.setenv("SLURM_LOCAL_ID", "4")
         assert dist.get_local_rank() == 4
 
+    def test_from_PALS_LOCAL_RANKID(self, fake_comm, monkeypatch):
+        """cray-pals mpiexec (Aurora/Sunspot) sets ``PALS_LOCAL_RANKID``.
+
+        Regression for the COMPOSITE device-index crash: without this
+        var recognized, ``get_local_rank`` fell through to the modulo
+        fallback and computed an out-of-range device index.
+        """
+        for v in ("LOCAL_RANK", "PMI_LOCAL_RANK"):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("PALS_LOCAL_RANKID", "5")
+        assert dist.get_local_rank() == 5
+
+    def test_from_PMIX_LOCAL_RANK(self, fake_comm, monkeypatch):
+        """PMIx layer (Aurora/Sunspot) sets ``PMIX_LOCAL_RANK``.
+
+        ezpz's own ``affinity.sh`` reads this var, confirming it is
+        exported per-rank on the ALCF XPU systems.
+        """
+        for v in ("LOCAL_RANK", "PMI_LOCAL_RANK", "PALS_LOCAL_RANKID"):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("PMIX_LOCAL_RANK", "3")
+        assert dist.get_local_rank() == 3
+
+    def test_pals_beats_modulo_fallback_under_composite(
+        self, monkeypatch
+    ):
+        """The real-world COMPOSITE crash: -ppn 6 on a 12-device node.
+
+        ``NGPU_PER_HOST`` is a stale 12 (FLAT-mode constant), device
+        count is 6 (COMPOSITE), and this is rank 11's process. The old
+        modulo fallback would return ``11 % 12 == 11`` (out of range for
+        ``xpu.set_device`` on 6 composite GPUs). With PALS_LOCAL_RANKID
+        recognized, we get the launcher's authoritative local rank (5).
+        """
+        for v in (
+            "LOCAL_RANK",
+            "PMI_LOCAL_RANK",
+            "OMPI_COMM_WORLD_LOCAL_RANK",
+            "MPI_LOCALRANKID",
+            "MPICH_LOCALRANKID",
+            "SLURM_LOCAL_ID",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("NGPU_PER_HOST", "12")  # stale FLAT constant
+        monkeypatch.setenv("PALS_LOCAL_RANKID", "5")  # true local rank
+        comm = _FakeComm(rank=11, size=24)
+        dist._MPI_COMM = comm
+        assert dist.get_local_rank() == 5
+
     def test_fallback_world_size_1(self, monkeypatch):
         """world_size == 1 ⇒ local_rank = 0."""
         for v in (
             "LOCAL_RANK",
+            "PALS_LOCAL_RANKID",
+            "PMIX_LOCAL_RANK",
             "PMI_LOCAL_RANK",
             "OMPI_COMM_WORLD_LOCAL_RANK",
             "MPI_LOCALRANKID",
@@ -253,9 +305,11 @@ class TestGetLocalRank:
         assert dist.get_local_rank() == 0
 
     def test_fallback_modulo(self, monkeypatch):
-        """No env vars, world_size > 1 ⇒ rank % gpus_per_node."""
+        """No env vars, world_size > 1 ⇒ rank % ranks_per_node."""
         for v in (
             "LOCAL_RANK",
+            "PALS_LOCAL_RANKID",
+            "PMIX_LOCAL_RANK",
             "PMI_LOCAL_RANK",
             "OMPI_COMM_WORLD_LOCAL_RANK",
             "MPI_LOCALRANKID",
@@ -274,13 +328,85 @@ class TestGetLocalRank:
         monkeypatch.setenv("NGPU_PER_HOST", "4")
         comm = _FakeComm(rank=5, size=8)
         dist._MPI_COMM = comm
-        # 5 % 4 == 1
-        assert dist.get_local_rank() == 1
+        # ranks_per_node = world_size(8) // num_nodes(2) == 4; 5 % 4 == 1
+        with patch.object(dist, "get_num_nodes", return_value=2):
+            assert dist.get_local_rank() == 1
 
-    def test_fallback_gpus_per_node_zero(self, monkeypatch):
-        """gpus_per_node == 0 ⇒ local_rank = 0 (avoid ZeroDivisionError)."""
+    def test_fallback_ranks_per_node_not_device_count(self, monkeypatch):
+        """Fallback uses ranks-per-node, not device-count.
+
+        Regression for the COMPOSITE crash's *second* defect: when no
+        local-rank env var is set and ranks-per-node (6) is less than
+        the device count / NGPU_PER_HOST (12), the modulo must use the
+        actual ranks-per-node so the result stays in ``[0, ppn)``.
+        Rank 23 of a ``-n 24 -ppn 6`` (4-node) run is local rank 5, not
+        ``23 % 12 == 11`` (out of range).
+        """
         for v in (
             "LOCAL_RANK",
+            "PALS_LOCAL_RANKID",
+            "PMIX_LOCAL_RANK",
+            "PMI_LOCAL_RANK",
+            "OMPI_COMM_WORLD_LOCAL_RANK",
+            "MPI_LOCALRANKID",
+            "MPICH_LOCALRANKID",
+            "SLURM_LOCAL_ID",
+            "RANK",
+            "PMI_RANK",
+            "OMPI_COMM_WORLD_RANK",
+            "SLURM_PROCID",
+            "WORLD_SIZE",
+            "PMI_SIZE",
+            "OMPI_COMM_WORLD_SIZE",
+            "SLURM_NTASKS",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("NGPU_PER_HOST", "12")  # stale FLAT constant
+        comm = _FakeComm(rank=23, size=24)
+        dist._MPI_COMM = comm
+        # ranks_per_node = 24 // 4 == 6; 23 % 6 == 5 (in range [0,6))
+        with patch.object(dist, "get_num_nodes", return_value=4):
+            assert dist.get_local_rank() == 5
+
+    def test_fallback_cpu_single_node_uses_ranks_per_node(self, monkeypatch):
+        """CPU-only, no devices: ranks-per-node still gives distinct ranks.
+
+        ``mpirun -n 4`` on one CPU node (no accelerators, no local-rank
+        env var) should yield local ranks 0..3, not 0 for everyone. The
+        ranks-per-node fallback (world_size // num_nodes) delivers this
+        even when device probing returns 0.
+        """
+        for v in (
+            "LOCAL_RANK",
+            "PALS_LOCAL_RANKID",
+            "PMIX_LOCAL_RANK",
+            "PMI_LOCAL_RANK",
+            "OMPI_COMM_WORLD_LOCAL_RANK",
+            "MPI_LOCALRANKID",
+            "MPICH_LOCALRANKID",
+            "SLURM_LOCAL_ID",
+            "NGPU_PER_HOST",
+            "LOCAL_WORLD_SIZE",
+            "PMI_LOCAL_SIZE",
+            "SLURM_NTASKS_PER_NODE",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        comm = _FakeComm(rank=3, size=4)
+        dist._MPI_COMM = comm
+        with patch.object(dist, "get_num_nodes", return_value=1):
+            assert dist.get_local_rank() == 3  # 3 % (4 // 1)
+
+    def test_fallback_indeterminate_returns_zero(self, monkeypatch):
+        """No env var, can't determine nnodes, no devices ⇒ 0 (no crash).
+
+        When ranks-per-node can't be derived (``get_num_nodes`` returns 0)
+        and device probing yields 0, the modulo guard returns 0 rather
+        than raising ``ZeroDivisionError``.
+        """
+        for v in (
+            "LOCAL_RANK",
+            "PALS_LOCAL_RANKID",
+            "PMIX_LOCAL_RANK",
             "PMI_LOCAL_RANK",
             "OMPI_COMM_WORLD_LOCAL_RANK",
             "MPI_LOCALRANKID",
@@ -296,6 +422,7 @@ class TestGetLocalRank:
         dist._MPI_COMM = comm
         # torch hardware probing returns 0 on CPU-only machines
         with (
+            patch.object(dist, "get_num_nodes", return_value=0),
             patch.object(torch.cuda, "is_available", return_value=False),
             patch.object(torch.xpu, "is_available", return_value=False),
             patch.object(
@@ -410,6 +537,71 @@ class TestGetGpusPerNode:
             ),
         ):
             assert dist.get_gpus_per_node() == 0
+
+    def test_composite_clamps_stale_ngpu_per_host(self, monkeypatch):
+        """Stale ``NGPU_PER_HOST=12`` (FLAT) clamps to XPU count under COMPOSITE.
+
+        Regression for the COMPOSITE device-index skew: ezpz's shell sets
+        ``NGPU_PER_HOST=12`` (FLAT tile count), but under
+        ``ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE`` only 6 composite GPUs
+        exist. ``get_gpus_per_node`` must not over-report devices — that
+        would skew ``get_node_index`` and the per-host summary line.
+        """
+        monkeypatch.setenv("NGPU_PER_HOST", "12")
+        with (
+            patch.object(torch.xpu, "is_available", return_value=True),
+            patch.object(torch.xpu, "device_count", return_value=6),
+        ):
+            assert dist.get_gpus_per_node() == 6
+
+    def test_flat_no_clamp_when_env_matches_devices(self, monkeypatch):
+        """FLAT mode: ``NGPU_PER_HOST=12`` == device count ⇒ unchanged."""
+        monkeypatch.setenv("NGPU_PER_HOST", "12")
+        with (
+            patch.object(torch.xpu, "is_available", return_value=True),
+            patch.object(torch.xpu, "device_count", return_value=12),
+        ):
+            assert dist.get_gpus_per_node() == 12
+
+    def test_under_subscription_not_bumped_up(self, monkeypatch):
+        """A smaller env hint is a deliberate under-subscription — keep it.
+
+        ``-ppn 4`` on a 12-device node sets ``NGPU_PER_HOST=4``; we must
+        never bump it *up* to the device count. Only clamp down.
+        """
+        monkeypatch.setenv("NGPU_PER_HOST", "4")
+        with (
+            patch.object(torch.xpu, "is_available", return_value=True),
+            patch.object(torch.xpu, "device_count", return_value=12),
+        ):
+            assert dist.get_gpus_per_node() == 4
+
+    def test_login_node_probe_error_keeps_env_hint(self, monkeypatch):
+        """XPU probe errors (login node, no Level-Zero loader) ⇒ keep env.
+
+        ``get_gpus_per_node`` runs during launch-time topology inference
+        on the login node, where ``torch.xpu.is_available()`` may raise.
+        The env hint must survive so we don't clamp it to 0.
+        """
+        monkeypatch.setenv("NGPU_PER_HOST", "12")
+        with patch.object(
+            torch.xpu, "is_available", side_effect=RuntimeError("no libze")
+        ):
+            assert dist.get_gpus_per_node() == 12
+
+    def test_cuda_env_hint_not_clamped(self, monkeypatch):
+        """Clamp is XPU-only: CUDA env-hint behavior is byte-identical.
+
+        COMPOSITE is an Intel/XPU concept; CUDA has no equivalent split,
+        so a CUDA env hint is returned verbatim even if it exceeds the
+        visible CUDA device count (e.g. a single-GPU CI box).
+        """
+        monkeypatch.setenv("NGPU_PER_HOST", "8")
+        with (
+            patch.object(torch.cuda, "is_available", return_value=True),
+            patch.object(torch.cuda, "device_count", return_value=1),
+        ):
+            assert dist.get_gpus_per_node() == 8
 
 
 class TestGetNodeIndex:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import random
 import socket
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -600,6 +601,31 @@ class TestGetGpusPerNode:
         monkeypatch.setenv("NGPU_PER_HOST", "8")
         monkeypatch.delattr(torch, "xpu", raising=False)
         assert dist.get_gpus_per_node() == 8
+
+    def test_env_hint_honored_without_torch(self, monkeypatch):
+        """Torch-less launcher/login env: env hint returned, no import.
+
+        ``get_gpus_per_node`` is called by ``pbs._infer_topology`` during
+        launch-time topology inference, which is designed to run without
+        torch installed. When an env hint is present the function must
+        NOT force ``import torch`` (which would raise ModuleNotFoundError
+        on a torch-less launcher) — it must return the hint directly.
+        Regression for PR #187 review (Codex P1 / Copilot).
+        """
+        import builtins
+
+        monkeypatch.setenv("NGPU_PER_HOST", "12")
+        # Hide torch from import machinery for the duration of the call.
+        monkeypatch.setitem(sys.modules, "torch", None)
+        real_import = builtins.__import__
+
+        def _no_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                raise ModuleNotFoundError("No module named 'torch'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_torch)
+        assert dist.get_gpus_per_node() == 12
 
     def test_cuda_env_hint_not_clamped(self, monkeypatch):
         """Clamp is XPU-only: CUDA env-hint behavior is byte-identical.

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -589,6 +589,18 @@ class TestGetGpusPerNode:
         ):
             assert dist.get_gpus_per_node() == 12
 
+    def test_no_xpu_attribute_keeps_env_hint(self, monkeypatch):
+        """Non-XPU torch builds (no ``torch.xpu``) don't crash the clamp.
+
+        CPU-/CUDA-only / ROCm builds may lack ``torch.xpu`` entirely.
+        ``_xpu_device_count_safe`` guards this with ``hasattr`` and
+        returns ``None``, so the env hint is returned verbatim rather
+        than raising ``AttributeError``.
+        """
+        monkeypatch.setenv("NGPU_PER_HOST", "8")
+        monkeypatch.delattr(torch, "xpu", raising=False)
+        assert dist.get_gpus_per_node() == 8
+
     def test_cuda_env_hint_not_clamped(self, monkeypatch):
         """Clamp is XPU-only: CUDA env-hint behavior is byte-identical.
 


### PR DESCRIPTION
## Problem

Running `ezpz launch` with `ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE` on Sunspot/Aurora crashed:

```
RuntimeError: The device index is out of range. It must be in [0, 6), but got 11.
```

Repro command (24 ranks, 6 per node, COMPOSITE collapses 12 tiles → 6 composite GPUs):

```bash
ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ezpz launch -n 24 -ppn 6 \
  python3 -m ezpz.examples.fsdp_tp --model=agpt-2b ... --tp=1 --dp-replicate=24 ...
```

## Root cause

Two independent defects combined:

1. **Unrecognized launcher env var.** `get_local_rank()` checked `LOCAL_RANK, PMI_LOCAL_RANK, OMPI_…, MPI_LOCALRANKID, MPICH_LOCALRANKID, SLURM_LOCAL_ID` — but the cray-pals `mpiexec` used on Aurora/Sunspot sets **`PALS_LOCAL_RANKID`** / **`PMIX_LOCAL_RANK`**, neither of which was in the list. Confirmed from the live system's `libpals.so.0.0.0` (`strings`) and ezpz's own `affinity.sh` (which reads `PMIX_LOCAL_RANK`). So it fell through to the modulo fallback.

2. **Device-count modulo with a stale GPU count.** The fallback was `get_rank() % get_gpus_per_node()`, and `get_gpus_per_node()` prefers the shell-exported `NGPU_PER_HOST=12` (a **FLAT-mode** tile constant hardcoded in `utils.sh`/`ezpz.sh`). Under COMPOSITE only 6 composite GPUs exist, so rank 23 computed `23 % 12 = 11` → `torch.xpu.set_device(11)` → out of range `[0, 6)`.

Confirmed by the workaround `NGPU_PER_HOST=6 ezpz launch ...` fixing it — which changed the *fallback* result (`23 % 6 = 5`), proving the fallback path was being taken.

## Fix

- **Recognize the real launcher vars.** Add `PALS_LOCAL_RANKID` and `PMIX_LOCAL_RANK` to `get_local_rank()`'s list, so the launcher's authoritative local rank is used in every FLAT/COMPOSITE/`-ppn` configuration (this alone fixes the crash; the fallback is no longer reached on these systems).
- **Fix the fallback math.** Use ranks-per-node (`world_size // num_nodes`) instead of the device count, so the result stays in `[0, ppn)` whenever ranks-per-node ≠ device-count — this also fixes plain `-ppn N` under-subscription on any node, independent of COMPOSITE. Degrades to the historical device-count behavior when nnodes can't be determined; guarded against `ZeroDivisionError`.
- **Reconcile `get_gpus_per_node()` with reality.** Clamp a stale FLAT env hint *down* to the visible XPU device count (via a new login-node-safe `_xpu_device_count_safe()`), so `get_node_index()` and the per-host summary line stop over-counting under COMPOSITE. Clamping is **one-directional** (never bumps a deliberate under-subscription up) and **XPU-only** (COMPOSITE has no CUDA analogue) — CUDA behavior is byte-identical.

## Tests

`tests/test_distributed.py` (+10 tests, 199 pass):
- `get_local_rank()` reads `PALS_LOCAL_RANKID` / `PMIX_LOCAL_RANK`; PALS var beats the modulo fallback under a stale `NGPU_PER_HOST=12`.
- Fallback uses ranks-per-node: rank 23 of `-n 24 -ppn 6` → local 5 (not 11); CPU single-node yields distinct ranks; indeterminate topology → 0 (no crash).
- `get_gpus_per_node()` clamps `12 → 6` under COMPOSITE; leaves FLAT (`12 == 12`), under-subscription (`4`), and CUDA hints untouched; survives a login-node XPU probe error.

Full suite: 1264 passed, 24 skipped (1 pre-existing unrelated failure on this box: `command_exists("python")` — no bare `python` on PATH, fails identically on `main`).

## Validation status

Root cause confirmed empirically at every layer (libpals strings on the live node, `affinity.sh`, the `NGPU_PER_HOST=6` workaround, and the crash's own `[0, 6)` bound proving `xpu.device_count()==6` under COMPOSITE). On-node re-run of the original command is a recommended follow-up but not required to prove correctness — the fix removes both the wrong-var and wrong-math paths deterministically.

`release:patch`

## Summary by Sourcery

Fix local rank and GPU-per-node detection to prevent out-of-range device indices under Intel XPU COMPOSITE topology and other under-subscribed configurations.

Bug Fixes:
- Recognize PALS_LOCAL_RANKID and PMIX_LOCAL_RANK environment variables so get_local_rank uses the launcher-provided local rank on Aurora/Sunspot instead of falling back to incorrect modulo logic.
- Change the local-rank fallback to compute rank modulo ranks-per-node (derived from world size and node count) and guard against indeterminate topologies to avoid ZeroDivisionError and out-of-range device indices.
- Clamp stale NGPU_PER_HOST values down to the visible Intel XPU device count under COMPOSITE while preserving intentional under-subscription and CUDA behavior.

Tests:
- Add comprehensive distributed tests covering new local-rank env vars, ranks-per-node fallback behavior across GPU and CPU-only scenarios, and XPU-specific clamping of NGPU_PER_HOST including error and CUDA edge cases.