### PR TITLE
test(loss): detach ref before float conversion to silence grad warning

### DIFF
--- a/tests/test_loss_impls.py
+++ b/tests/test_loss_impls.py
@@ -299,9 +299,13 @@ def test_vocab_parallel_matches_eager_2rank(vocab):
 
     ref = F.cross_entropy(full, labels, ignore_index=-100)
     ref.backward()
+    # `full` requires grad, so `ref` tracks grad too; detach before the
+    # Python-float conversion to avoid a "converting a tensor with
+    # requires_grad=True to a scalar" UserWarning (the value is unaffected).
+    ref_val = ref.detach().item()
     s, e = ret["shard"]
-    assert abs(ret["loss"] - float(ref)) < 1e-4, (
-        f"vp loss {ret['loss']} != eager {float(ref)} (vocab={vocab})"
+    assert abs(ret["loss"] - ref_val) < 1e-4, (
+        f"vp loss {ret['loss']} != eager {ref_val} (vocab={vocab})"
     )
     # grad0 came back as a plain nested list (see _vp_worker) — rebuild a
     # tensor for the comparison, matching the eager grad's dtype and device


### PR DESCRIPTION
## Problem

Running the suite locally (`uv run --active pytest`) emits:

```
tests/test_loss_impls.py::test_vocab_parallel_matches_eager_2rank[12]
  UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to
  unexpected behavior. Consider using tensor.detach() first.
    assert abs(ret["loss"] - float(ref)) < 1e-4, (
```

## Cause

The eager reference is built as `ref = F.cross_entropy(full, ...)` where `full` has `requires_grad=True`, so `ref` tracks grad. After `ref.backward()`, `float(ref)` calls `Tensor.__float__` on a still-grad-requiring scalar → the warning. Harmless (the value is correct), just noisy.

## Fix

Detach before the Python-float conversion: `ref_val = ref.detach().item()`, and compare against `ref_val`. Value unchanged; warning gone. Verified with `pytest -W error::UserWarning` on the affected test (passes; would error if the warning still fired).

Full `tests/test_loss_impls.py`: 19 passed. Lint clean.

`release:skip`

## Summary by Sourcery

Bug Fixes:
- Prevent a spurious UserWarning in the vocab-parallel loss test by detaching the reference loss tensor before scalar conversion.