### PR TITLE
fix(fsdp_tp): guard HSDP _flatten against xccl split_group on XPU

### DIFF
--- a/src/ezpz/__init__.py
+++ b/src/ezpz/__init__.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
         wrap_model_for_fsdp,
         wrap_model_for_fsdp2,
         init_device_mesh_safe,
+        flatten_device_mesh_safe,
     )
     # -- utils: helpers + memory + tarball plumbing --
     from .utils import (  # noqa: F401
@@ -178,7 +179,7 @@ _STATIC_REEXPORTS: tuple[str, ...] = (
     "synchronize", "timeitlogit", "verify_wandb",
     "wrap_model", "wrap_model_for_ddp",
     "wrap_model_for_fsdp", "wrap_model_for_fsdp2",
-    "init_device_mesh_safe",
+    "init_device_mesh_safe", "flatten_device_mesh_safe",
     # utils
     "Color", "DistributedPdb", "ForkedPdb", "NoColor",
     "check_for_tarball",

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -24,6 +24,7 @@ import logging
 import os
 import socket
 import time
+from contextlib import contextmanager
 from datetime import timedelta
 from functools import wraps
 from pathlib import Path
@@ -78,6 +79,7 @@ __all__ = [
     "wrap_model_for_fsdp",
     "wrap_model_for_fsdp2",
     "init_device_mesh_safe",
+    "flatten_device_mesh_safe",
     # -- diagnostics --
     "get_dist_info",
     "get_hostname",
@@ -1985,15 +1987,13 @@ def _setup_ddp(
     return {"rank": rank, "world_size": world_size, "local_rank": local_rank}
 
 
-def init_device_mesh_safe(
-    device_type: str,
-    mesh_shape: tuple[int, ...],
-    *,
-    mesh_dim_names: tuple[str, ...] | None = None,
-) -> Any:
-    """Drop-in replacement for ``torch.distributed.init_device_mesh``.
+@contextmanager
+def _xccl_split_workaround(device_type: str):
+    """Temporarily clear the default PG's ``bound_device_id`` on XPU.
 
-    Works around xccl's missing ``ProcessGroup.split_group`` support.
+    Works around xccl's missing ``ProcessGroup.split_group`` support for
+    any torch DeviceMesh operation that would otherwise take the
+    ``split_group`` path.
 
     For FSDP2 to route ``foreach_all_gather`` correctly on XPU,
     ``_setup_ddp`` binds the default PG to a device by passing
@@ -2007,15 +2007,16 @@ def init_device_mesh_safe(
         RuntimeError: No backend for the parent process group or its
                       backend does not support splitting
 
-    We temporarily clear ``default_group.bound_device_id`` for the
-    duration of the ``init_device_mesh`` call so torch takes the
-    ``new_group`` fallback (which xccl supports), then restore it so
-    FSDP2's per-device PG resolution still works.
+    Clearing ``bound_device_id`` for the duration of the mesh op makes
+    torch take the ``new_group`` fallback (which xccl supports); the
+    original value is restored afterwards so FSDP2's per-device PG
+    resolution still works. Both ``init_device_mesh`` (mesh creation)
+    and ``DeviceMesh._flatten`` (submesh flattening, HSDP) create PGs
+    this way, so both must run inside this context.
 
     No-op on non-xpu devices and when no default PG exists yet.
     """
     import torch
-    from torch.distributed.device_mesh import init_device_mesh as _imd
 
     default_pg = None
     saved: Any = None
@@ -2030,13 +2031,65 @@ def init_device_mesh_safe(
         except (AttributeError, RuntimeError):
             needs_workaround = False
     try:
-        return _imd(device_type, mesh_shape, mesh_dim_names=mesh_dim_names)
+        yield
     finally:
         if needs_workaround and default_pg is not None:
             try:
                 default_pg.bound_device_id = saved  # type: ignore[attr-defined]
             except AttributeError:
                 pass
+
+
+def init_device_mesh_safe(
+    device_type: str,
+    mesh_shape: tuple[int, ...],
+    *,
+    mesh_dim_names: tuple[str, ...] | None = None,
+) -> Any:
+    """Drop-in replacement for ``torch.distributed.init_device_mesh``.
+
+    Works around xccl's missing ``ProcessGroup.split_group`` support by
+    running the mesh construction under :func:`_xccl_split_workaround`
+    (see there for the full mechanism). No-op on non-xpu devices and
+    when no default PG exists yet.
+    """
+    from torch.distributed.device_mesh import init_device_mesh as _imd
+
+    with _xccl_split_workaround(device_type):
+        return _imd(device_type, mesh_shape, mesh_dim_names=mesh_dim_names)
+
+
+def flatten_device_mesh_safe(
+    submesh: Any,
+    mesh_dim_name: str,
+    *,
+    device_type: str | None = None,
+) -> Any:
+    """Flatten a DeviceMesh submesh, guarded against xccl's split limits.
+
+    ``DeviceMesh._flatten`` builds the flattened process group with
+    ``split_group`` when the default PG is device-bound — which xccl
+    does not support (see :func:`_xccl_split_workaround`). This wraps
+    the ``_flatten`` call in that workaround so HSDP meshes (e.g.
+    ``mesh["dp_replicate", "dp_shard"]._flatten("dp")``) build the
+    flattened PG via the ``new_group`` fallback on XPU.
+
+    Args:
+        submesh: The (sub)mesh to flatten, e.g.
+            ``mesh["dp_replicate", "dp_shard"]``.
+        mesh_dim_name: Name for the resulting flattened dim (``"dp"``).
+        device_type: Device family; auto-detected from *submesh* (else
+            :func:`get_torch_device_type`) when ``None``.
+
+    Returns:
+        The flattened :class:`~torch.distributed.device_mesh.DeviceMesh`.
+    """
+    if device_type is None:
+        device_type = getattr(submesh, "device_type", None) or (
+            get_torch_device_type()
+        )
+    with _xccl_split_workaround(device_type):
+        return submesh._flatten(mesh_dim_name)
 
 
 def _init_deepspeed(timeout: int = 3600) -> None:

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2037,7 +2037,13 @@ def train(
         (dp_replicate, dp_shard, args.tp),
         mesh_dim_names=("dp_replicate", "dp_shard", "tp"),
     )
-    device_mesh[("dp_replicate", "dp_shard")]._flatten("dp")
+    # Flatten the two DP dims into a single "dp" dim. Must go through
+    # flatten_device_mesh_safe: `_flatten` builds the flattened PG via
+    # split_group when the default PG is device-bound, which xccl (XPU)
+    # doesn't support — the same workaround init_device_mesh_safe applies.
+    ezpz.distributed.flatten_device_mesh_safe(
+        device_mesh[("dp_replicate", "dp_shard")], "dp"
+    )
     logger.info(f"Device mesh created:\n{device_mesh=}")
 
     hf_dataset = None

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -2577,3 +2577,138 @@ class TestInitDeviceMeshSafe:
         # Must not raise from the shim itself; inner call still fires.
         dist.init_device_mesh_safe("xpu", (4,))
         called.assert_called_once()
+
+
+# ===================================================================
+# flatten_device_mesh_safe
+# ===================================================================
+
+
+class TestFlattenDeviceMeshSafe:
+    """``flatten_device_mesh_safe`` runs ``DeviceMesh._flatten`` under the
+    same ``bound_device_id`` workaround as ``init_device_mesh_safe``.
+
+    Regression for the HSDP crash (PR #186 deferred on-node
+    dp_replicate>1 validation): the bare ``._flatten("dp")`` call in
+    ``ezpz.examples.fsdp_tp`` ran *outside* the workaround, so on XPU +
+    xccl torch took the ``split_group`` path and raised
+        RuntimeError: No backend for the parent process group or its
+                      backend does not support splitting
+    even though ``init_device_mesh_safe`` had built the 3D mesh fine.
+    """
+
+    def _fake_submesh(self, bound, flat_result, observed):
+        """A submesh whose ``_flatten`` records the mid-call
+        ``bound_device_id`` of the (shared) default PG."""
+        submesh = MagicMock(name="submesh")
+        submesh.device_type = "xpu"
+
+        def _flatten(name):
+            observed["mid_call_bound_device_id"] = bound["pg"].bound_device_id
+            observed["flatten_name"] = name
+            return flat_result
+
+        submesh._flatten.side_effect = _flatten
+        return submesh
+
+    def test_xpu_clears_and_restores_around_flatten(self, monkeypatch):
+        """On xpu with a bound default PG: clear → _flatten → restore."""
+        sentinel = torch.device("xpu:2")
+        pg = MagicMock()
+        pg.bound_device_id = sentinel
+        bound = {"pg": pg}
+        observed: dict[str, Any] = {}
+        flat = MagicMock(name="flat_mesh")
+        submesh = self._fake_submesh(bound, flat, observed)
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+
+        result = dist.flatten_device_mesh_safe(submesh, "dp")
+
+        assert result is flat
+        assert observed["flatten_name"] == "dp"
+        assert observed["mid_call_bound_device_id"] is None, (
+            "Workaround failed: bound_device_id was not cleared during "
+            "_flatten. Torch takes the split_group branch and raises on "
+            "xccl."
+        )
+        assert pg.bound_device_id == sentinel, (
+            "bound_device_id was not restored after _flatten."
+        )
+
+    def test_device_type_autodetected_from_submesh(self, monkeypatch):
+        """When device_type is omitted, it comes from submesh.device_type."""
+        sentinel = torch.device("xpu:1")
+        pg = MagicMock()
+        pg.bound_device_id = sentinel
+        bound = {"pg": pg}
+        observed: dict[str, Any] = {}
+        submesh = self._fake_submesh(bound, MagicMock(), observed)
+        submesh.device_type = "xpu"
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+
+        dist.flatten_device_mesh_safe(submesh, "dp")
+        assert observed["mid_call_bound_device_id"] is None
+
+    def test_non_xpu_is_pass_through(self, monkeypatch):
+        """CUDA: no bound_device_id touching; _flatten called directly."""
+        submesh = MagicMock(name="submesh")
+        submesh.device_type = "cuda"
+        submesh._flatten.return_value = MagicMock(name="flat")
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        # CUDA path must never fetch the default PG.
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            MagicMock(
+                side_effect=AssertionError("CUDA must not touch default PG")
+            ),
+        )
+
+        out = dist.flatten_device_mesh_safe(submesh, "dp")
+        submesh._flatten.assert_called_once_with("dp")
+        assert out is submesh._flatten.return_value
+
+    def test_restores_bound_device_id_when_flatten_raises(self, monkeypatch):
+        """If ``_flatten`` raises, bound_device_id MUST be restored."""
+        sentinel = torch.device("xpu:4")
+        pg = MagicMock()
+        pg.bound_device_id = sentinel
+        submesh = MagicMock(name="submesh")
+        submesh.device_type = "xpu"
+        submesh._flatten.side_effect = RuntimeError("simulated split fail")
+
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            torch.distributed.distributed_c10d,
+            "_get_default_group",
+            lambda: pg,
+        )
+
+        with pytest.raises(RuntimeError, match="simulated"):
+            dist.flatten_device_mesh_safe(submesh, "dp")
+
+        assert pg.bound_device_id == sentinel, (
+            "Workaround leaked: bound_device_id stayed cleared after a "
+            "_flatten failure."
+        )

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -53,6 +53,7 @@ EXPECTED_STATIC_REEXPORTS = [
     ("get_world_size_in_use", "ezpz.distributed"),
     ("get_world_size_total", "ezpz.distributed"),
     ("init_device_mesh_safe", "ezpz.distributed"),
+    ("flatten_device_mesh_safe", "ezpz.distributed"),
     ("log_dict_as_bulleted_list", "ezpz.distributed"),
     ("print_dist_setup", "ezpz.distributed"),
     ("query_environment", "ezpz.distributed"),


### PR DESCRIPTION
## Problem

Running `ezpz.examples.fsdp_tp` with **real HSDP** (`--dp-replicate > 1`) crashed on Sunspot/Aurora XPU. Live repro (`dp_replicate=4 dp_shard=6 tp=2`, 48 ranks):

```
device_mesh[("dp_replicate", "dp_shard")]._flatten("dp")   # fsdp_tp.py
  → _create_flatten_mesh → _init_one_process_group → split_group(parent_pg=default_group)
  RuntimeError: No backend for the parent process group or its backend
                does not support splitting
```

The initial 3D `init_device_mesh` built fine — only the subsequent flatten crashed.

## Root cause

torch's `DeviceMesh` builds a dim's process group with `split_group` whenever the default PG is **device-bound** (`bound_device_id is not None` — device_mesh.py:552, confirmed on the live `torch 2.13.0.dev+xpu`). ezpz binds the PG on purpose (`init_process_group(device_id=...)`, needed so FSDP2's `foreach_all_gather` routes to the right XPU), and **xccl's backend can't `split_group`**.

ezpz already works around this in `init_device_mesh_safe`: it temporarily clears `bound_device_id` so torch takes the `new_group` fallback (which xccl supports), then restores it. But the `._flatten("dp")` call added for HSDP in **PR #186** (whose on-node `dp_replicate>1` validation was explicitly deferred) ran **outside** that guard. So the 3D mesh built via the fallback and the flatten hit `split_group`.

This is the "loud failure" the `distributed.py` comment predicted ("If DeviceMesh._unflatten regresses on a newer xccl, we'll see a loud failure").

> Note: the earlier COMPOSITE run (`dp_replicate=24 dp_shard=1`) didn't surface this because it crashed *earlier* — at `set_device` in `setup_torch` (the device-index bug fixed in #187), before `train()`'s `_flatten` was ever reached. (`_flatten` runs unconditionally regardless of the dp degrees — a size-1 dp dim does not skip it: the `("dp_replicate","dp_shard")` submesh is 2D, and torch's `_flatten` only short-circuits a genuinely 1D mesh.)

## Fix

- Extract the `bound_device_id` dance into a reusable `_xccl_split_workaround(device_type)` **context manager** — single source of truth.
- `init_device_mesh_safe` now uses it (behavior unchanged).
- New public `flatten_device_mesh_safe(submesh, name)` wraps `_flatten` in the same workaround; `fsdp_tp` flattens the DP dims through it.

XPU-only; the CUDA/NCCL path is a pure pass-through (NCCL splits natively). Verified against the live torch `device_mesh.py:552` branch that clearing `bound_device_id` routes `_flatten` to `new_group`.

## Tests

`tests/test_distributed.py::TestFlattenDeviceMeshSafe` (+ export test):
- clears/restores `bound_device_id` around `_flatten`; auto-detects device_type from the submesh.
- non-xpu (CUDA) pass-through never touches the default PG.
- `bound_device_id` restored even when `_flatten` raises.
- `flatten_device_mesh_safe` exported at top level.

Full suite: 1270 passed, 24 skipped (1 pre-existing unrelated failure on this box: `command_exists("python")` — no bare `python` on PATH, identical on `main`).

## Validation status

Root cause confirmed against the live node (torch source branch + xccl `supports_splitting`), and the fix reuses the exact mechanism already proven for the 3D mesh build on this stack. On-node re-run of the failing `dp_replicate=4` command is a recommended follow-up but the fix routes `_flatten` through the same code path that already succeeds for `init_device_mesh_safe`.

`release:patch`