### PR TITLE
fix(fsdp_tp): drop_last=True on HF dataloader to avoid compiled-backward OOM

### DIFF
--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -1989,6 +1989,67 @@ def _collect_layer_grad_norms(model: nn.Module) -> list[float]:
     return [(layer_sumsq.get(i, 0.0) ** 0.5) for i in range(max_layer + 1)]
 
 
+def _build_hf_dataloader(
+    dataset,
+    *,
+    batch_size: int,
+    dpsize: int,
+    dp_rank: int,
+    world_size: int,
+):
+    """Build the (sampler, DataLoader) for the HF-text training path.
+
+    Both the ``DistributedSampler`` and the ``DataLoader`` use
+    ``drop_last=True`` so every batch has a static batch dimension. A
+    ragged final batch (e.g. batch_size 2 -> 1) makes torch.compile mark
+    the batch dim dynamic and recompile at the epoch boundary; under
+    symbolic shapes inductor can no longer fuse log_softmax+NLL+backward,
+    so the ``compiled`` CE materializes the full (B*T, vocab) logits grad
+    (agpt-2b 256K vocab, seq 8192: ~15.6 GiB) and OOMs at the first step
+    of epoch 1. Static shapes avoid the recompile. Matches the ``random``
+    branch and torchtitan; the dropped tail is at most (batch_size - 1)
+    samples per dp rank per epoch (negligible for LM pretraining).
+
+    Extracted from ``train`` so the drop_last invariant + the too-small
+    guard below are unit-testable without launching a run.
+
+    Raises:
+        ValueError: if ``drop_last=True`` would leave zero batches for this
+            rank (dataset too small for ``batch_size`` * dp degree). Without
+            this, training would run zero optimizer steps yet exit 0 — a
+            smoke test would falsely "pass". Callers should reduce
+            ``--batch-size`` / ``--dp-*`` or raise ``--hf-limit``.
+    """
+    sampler = (
+        DistributedSampler(
+            dataset=dataset,
+            num_replicas=dpsize,
+            rank=dp_rank,
+            drop_last=True,
+        )
+        if world_size > 1
+        else None
+    )
+    # Per-rank sample count after DistributedSampler shards + drops the tail.
+    per_rank = (len(dataset) // dpsize) if sampler is not None else len(dataset)
+    if per_rank // batch_size < 1:
+        raise ValueError(
+            "HF dataloader with drop_last=True yields 0 full batches for this "
+            f"rank: {per_rank} samples/rank < batch_size={batch_size} "
+            f"(dataset={len(dataset)}, dp={dpsize}). Training would run zero "
+            "steps. Lower --batch-size / --dp-shard / --dp-replicate or raise "
+            "--hf-limit."
+        )
+    dataloader = DataLoader(
+        dataset,
+        sampler=sampler,
+        batch_size=batch_size,
+        shuffle=(sampler is None),
+        drop_last=True,
+    )
+    return sampler, dataloader
+
+
 @ezpz.timeitlogit(rank=ezpz.get_rank())
 def train(
     args: argparse.Namespace,
@@ -2508,32 +2569,15 @@ def train(
 
         assert hf_dataset is not None
         dataset = hf_dataset
-        # drop_last=True on BOTH the sampler and the loader. A ragged final
-        # batch (e.g. batch_size 2 -> 1) makes torch.compile mark the batch
-        # dim dynamic and recompile at the epoch boundary; under symbolic
-        # shapes inductor can no longer fuse log_softmax+NLL+backward, so the
-        # `compiled` CE materializes the full (B*T, vocab) logits grad
-        # (agpt-2b 256K vocab, seq 8192: ~15.6 GiB) and OOMs at the first
-        # step of epoch 1. Static batch shapes avoid the recompile entirely.
-        # Matches the `random` branch above and torchtitan. The dropped tail
-        # is at most (batch_size - 1) samples per dp rank per epoch —
-        # negligible for LM pretraining.
-        sampler = (
-            DistributedSampler(
-                dataset=dataset,
-                num_replicas=dpsize,
-                rank=device_mesh.get_local_rank("dp"),
-                drop_last=True,
-            )
-            if ezpz.get_world_size() > 1
-            else None
-        )
-        dataloader = DataLoader(
+        # drop_last=True (both sampler + loader) so every batch has a static
+        # batch dim — a ragged tail triggers a torch.compile recompile at the
+        # epoch boundary that OOMs the compiled CE. See _build_hf_dataloader.
+        sampler, dataloader = _build_hf_dataloader(
             dataset,
-            sampler=sampler,
             batch_size=args.batch_size,
-            shuffle=(sampler is None),
-            drop_last=True,
+            dpsize=dpsize,
+            dp_rank=device_mesh.get_local_rank("dp"),
+            world_size=ezpz.get_world_size(),
         )
         if args.tp > 1:
             dataloader = TPBroadcastDataLoader(dataloader, tp_group)

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2508,11 +2508,22 @@ def train(
 
         assert hf_dataset is not None
         dataset = hf_dataset
+        # drop_last=True on BOTH the sampler and the loader. A ragged final
+        # batch (e.g. batch_size 2 -> 1) makes torch.compile mark the batch
+        # dim dynamic and recompile at the epoch boundary; under symbolic
+        # shapes inductor can no longer fuse log_softmax+NLL+backward, so the
+        # `compiled` CE materializes the full (B*T, vocab) logits grad
+        # (agpt-2b 256K vocab, seq 8192: ~15.6 GiB) and OOMs at the first
+        # step of epoch 1. Static batch shapes avoid the recompile entirely.
+        # Matches the `random` branch above and torchtitan. The dropped tail
+        # is at most (batch_size - 1) samples per dp rank per epoch —
+        # negligible for LM pretraining.
         sampler = (
             DistributedSampler(
                 dataset=dataset,
                 num_replicas=dpsize,
                 rank=device_mesh.get_local_rank("dp"),
+                drop_last=True,
             )
             if ezpz.get_world_size() > 1
             else None
@@ -2522,7 +2533,7 @@ def train(
             sampler=sampler,
             batch_size=args.batch_size,
             shuffle=(sampler is None),
-            drop_last=False,
+            drop_last=True,
         )
         if args.tp > 1:
             dataloader = TPBroadcastDataLoader(dataloader, tp_group)

--- a/tests/test_fsdp_tp_datasets.py
+++ b/tests/test_fsdp_tp_datasets.py
@@ -68,3 +68,51 @@ def test_fsdp_tp_dataset_hf_loss_is_finite():
     batch = next(iter(dataloader))
     model = _build_tiny_model(vocab_size=len(vocab), seq_len=seq_len)
     assert _loss_is_finite(model, batch)
+
+
+def test_hf_dataloader_drop_last_yields_static_batch_shape():
+    """Every batch must have a static batch dim under ``drop_last=True``.
+
+    Regression for the ``--loss-impl=compiled`` step-53 OOM: a ragged
+    final batch (batch_size 2 -> 1) makes torch.compile mark the batch
+    dim dynamic and recompile at the epoch boundary; the recompiled
+    backward drops the fused CE and materializes the full (B*T, vocab)
+    logits grad (~15.6 GiB for agpt-2b) -> XPU OOM. The fsdp_tp HF loader
+    now sets drop_last=True, so no ragged batch reaches the compiled step.
+
+    Dataset size (5) is deliberately NOT a multiple of batch_size (2):
+    with drop_last=False the last batch would be size 1 (the recompile
+    trigger); with drop_last=True it must be dropped.
+    """
+
+    class _TinyDS(torch.utils.data.Dataset):
+        def __init__(self, n, seq_len):
+            self.data = torch.arange(n * seq_len).reshape(n, seq_len)
+
+        def __len__(self):
+            return len(self.data)
+
+        def __getitem__(self, i):
+            return self.data[i]
+
+    batch_size = 2
+    seq_len = 8
+    dataset = _TinyDS(5, seq_len)  # 5 % 2 == 1 -> ragged tail without drop_last
+
+    # drop_last=True (the fix): only full-size batches, none ragged.
+    dl_fixed = torch.utils.data.DataLoader(
+        dataset, batch_size=batch_size, shuffle=False, drop_last=True
+    )
+    batches = list(dl_fixed)
+    assert len(batches) == 2  # floor(5 / 2)
+    assert all(b.shape[0] == batch_size for b in batches), (
+        "drop_last=True must yield only full-size batches (static batch dim)"
+    )
+
+    # Sanity: the pre-fix config (drop_last=False) DID produce the ragged
+    # size-1 tail batch that triggered the recompile. Locks the root cause.
+    dl_ragged = torch.utils.data.DataLoader(
+        dataset, batch_size=batch_size, shuffle=False, drop_last=False
+    )
+    ragged = list(dl_ragged)
+    assert len(ragged) == 3 and ragged[-1].shape[0] == 1

--- a/tests/test_fsdp_tp_datasets.py
+++ b/tests/test_fsdp_tp_datasets.py
@@ -70,49 +70,86 @@ def test_fsdp_tp_dataset_hf_loss_is_finite():
     assert _loss_is_finite(model, batch)
 
 
+class _TinyDS(torch.utils.data.Dataset):
+    """Tiny integer dataset with a controllable, non-divisible length."""
+
+    def __init__(self, n, seq_len):
+        self.data = torch.arange(n * seq_len).reshape(n, seq_len)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, i):
+        return self.data[i]
+
+
+def _import_fsdp_tp():
+    import importlib
+
+    try:
+        return importlib.import_module("ezpz.examples.fsdp_tp")
+    except Exception as exc:  # heavy optional deps may be missing
+        pytest.skip(f"could not import ezpz.examples.fsdp_tp: {exc}")
+
+
 def test_hf_dataloader_drop_last_yields_static_batch_shape():
-    """Every batch must have a static batch dim under ``drop_last=True``.
+    """The fsdp_tp HF loader must yield only full, static-shape batches.
 
     Regression for the ``--loss-impl=compiled`` step-53 OOM: a ragged
     final batch (batch_size 2 -> 1) makes torch.compile mark the batch
     dim dynamic and recompile at the epoch boundary; the recompiled
     backward drops the fused CE and materializes the full (B*T, vocab)
-    logits grad (~15.6 GiB for agpt-2b) -> XPU OOM. The fsdp_tp HF loader
-    now sets drop_last=True, so no ragged batch reaches the compiled step.
+    logits grad (~15.6 GiB for agpt-2b) -> XPU OOM.
 
-    Dataset size (5) is deliberately NOT a multiple of batch_size (2):
-    with drop_last=False the last batch would be size 1 (the recompile
-    trigger); with drop_last=True it must be dropped.
+    This drives the ACTUAL production helper ``_build_hf_dataloader`` (not
+    a hand-rolled DataLoader), so a revert to drop_last=False fails here.
+    Dataset size (5) is deliberately NOT a multiple of batch_size (2).
     """
+    m = _import_fsdp_tp()
+    batch_size, seq_len = 2, 8
+    dataset = _TinyDS(5, seq_len)  # 5 % 2 == 1 -> ragged tail w/o drop_last
 
-    class _TinyDS(torch.utils.data.Dataset):
-        def __init__(self, n, seq_len):
-            self.data = torch.arange(n * seq_len).reshape(n, seq_len)
-
-        def __len__(self):
-            return len(self.data)
-
-        def __getitem__(self, i):
-            return self.data[i]
-
-    batch_size = 2
-    seq_len = 8
-    dataset = _TinyDS(5, seq_len)  # 5 % 2 == 1 -> ragged tail without drop_last
-
-    # drop_last=True (the fix): only full-size batches, none ragged.
-    dl_fixed = torch.utils.data.DataLoader(
-        dataset, batch_size=batch_size, shuffle=False, drop_last=True
+    # world_size=1 -> sampler is None, loader still drop_last=True.
+    sampler, dataloader = m._build_hf_dataloader(
+        dataset,
+        batch_size=batch_size,
+        dpsize=1,
+        dp_rank=0,
+        world_size=1,
     )
-    batches = list(dl_fixed)
-    assert len(batches) == 2  # floor(5 / 2)
-    assert all(b.shape[0] == batch_size for b in batches), (
-        "drop_last=True must yield only full-size batches (static batch dim)"
+    assert sampler is None
+    batches = list(dataloader)
+    assert len(batches) == 2  # floor(5 / 2); ragged tail dropped
+    # Full shape, not just batch dim (Sourcery): guards against silent
+    # extra/changed dims too.
+    assert all(b.shape == (batch_size, seq_len) for b in batches), (
+        "drop_last=True must yield only full-size, static-shape batches"
     )
 
-    # Sanity: the pre-fix config (drop_last=False) DID produce the ragged
-    # size-1 tail batch that triggered the recompile. Locks the root cause.
+    # Root-cause lock: the pre-fix drop_last=False config DID produce the
+    # ragged size-1 tail that triggered the recompile.
     dl_ragged = torch.utils.data.DataLoader(
         dataset, batch_size=batch_size, shuffle=False, drop_last=False
     )
     ragged = list(dl_ragged)
     assert len(ragged) == 3 and ragged[-1].shape[0] == 1
+
+
+def test_hf_dataloader_raises_when_too_small_for_a_full_batch():
+    """A dataset too small to yield one full batch (after drop_last) must
+    fail loudly, not silently run zero steps and exit 0.
+
+    e.g. 3 samples, batch_size 4 -> floor(3/4) == 0 batches. Without the
+    guard, training would complete with no optimizer steps and a smoke
+    test would falsely pass.
+    """
+    m = _import_fsdp_tp()
+    dataset = _TinyDS(3, 8)
+    with pytest.raises(ValueError, match="0 full batches|zero steps"):
+        m._build_hf_dataloader(
+            dataset,
+            batch_size=4,
+            dpsize=1,
+            dp_rank=0,
+            world_size=1,
+        )


### PR DESCRIPTION
## Problem

`fsdp_tp --loss-impl=compiled --compile` OOM'd **deterministically at the first step of epoch 1** (e.g. step 53) on Sunspot XPU, *regardless of `--dataset`*, after training cleanly through epoch 0:

```
buf2 = empty_strided_xpu((16384, 256000), (256000, 1), torch.float32)   # 15.62 GiB
torch.OutOfMemoryError: XPU out of memory. Tried to allocate 15.62 GiB.
```

That tensor is the full `(B*T, vocab)` logits gradient (`2*8192 × 256000 × 4B`) — exactly the buffer the `compiled` CE exists to fuse away.

## Root cause (confirmed on-node)

Reproduced with `TORCH_LOGS=recompiles_verbose` on a 4-node Sunspot job. The HF text dataloader used `drop_last=False`, so the **final batch of each epoch is ragged** (batch_size 2 → 1). At the epoch boundary that ragged batch trips torch.compile's automatic-dynamic guard:

```
Recompiling forward (llama.py:539):           tensor 'x' size mismatch: expected 2, actual 1
Recompiling _cross_entropy_eager (fsdp_tp.py:471): tensor 'labels' size mismatch: expected 2, actual 1
```

Once the batch dim is marked **dynamic (symbolic)**, inductor can no longer prove the shapes static and drops the log_softmax+NLL+backward fusion — so the compiled CE materializes the full logits gradient and OOMs.

This explains every symptom:
- **Deterministic step** — the ragged tail lands at the same place each run (`ceil` of dataset/global-batch).
- **Dataset-independent** — it's the row *count* not the content.
- **`--compile-mode=max-autotune` escaping it** — its autotuner still selects a fused kernel under dynamic shapes.

## Fix

`drop_last=True` on **both** the HF `DataLoader` and its `DistributedSampler`, matching the sibling `random` branch (which already did this) and torchtitan. Static batch shapes ⇒ no epoch-boundary recompile ⇒ the compiled CE stays fused. The dropped tail is at most `(batch_size - 1)` samples per dp rank per epoch — negligible for LM pretraining.

## Tests

`tests/test_fsdp_tp_datasets.py::test_hf_dataloader_drop_last_yields_static_batch_shape` — a dataset whose size isn't a multiple of `batch_size` yields only full-size batches under `drop_last=True`, and (as a root-cause lock) the pre-fix `drop_last=False` config is asserted to produce the ragged size-1 tail.

fsdp_tp suites: 37 passed. Lint clean.

## Notes

- Independent of the two other in-flight fsdp_tp fixes (#189 `_flatten`/xccl; the tp>1 DTensor-loss fix). This one is `tp=1`, `--compile`-specific.
- Workarounds that already work without this patch: `--compile-mode=max-autotune`, or `--loss-impl=fused-linear` (structurally never builds the full logits tensor).

`release:patch`

## Summary by Sourcery

Ensure Hugging Face FSDP/TP training uses static batch sizes to keep compiled cross-entropy fused and avoid XPU OOMs at epoch boundaries.

Bug Fixes:
- Configure the Hugging Face FSDP/TP dataloader and distributed sampler to drop incomplete final batches, preventing dynamic batch shapes that break cross-entropy fusion and cause XPU OOMs under torch.compile.

Tests:
- Add a dataset test verifying that drop_last=True on the HF dataloader yields only full-size batches and that the previous drop_last=False behavior produced a ragged tail batch.