### PR TITLE
fix(fsdp_tp): localize Replicate DTensor logits before eager CE at tp>1

### DIFF
--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2684,6 +2684,32 @@ def train(
                     tp_group=tp_group,
                 )
             else:
+                # tp>1 non-loss-parallel: the output ColwiseParallel uses
+                # output_layouts=Replicate(), use_local_output=False, so
+                # `pred` is a REPLICATED DTensor while `labels` is a plain
+                # tensor. Plain F.cross_entropy(DTensor, Tensor) raises
+                # "got mixed torch.Tensor and DTensor". Localize pred to a
+                # plain tensor first (torchtitan components/loss.py does the
+                # same). to_local() on a Replicate DTensor is a data no-op
+                # (full logits already on every tp rank) and is
+                # differentiable — its backward re-wraps the grad as a
+                # Replicate DTensor, so grads still reach the sharded output
+                # weight correctly. No-op at tp=1 / HF (pred is already a
+                # plain tensor, so hasattr(...) is False).
+                if hasattr(pred, "to_local"):
+                    # Guard the invariant this localization relies on: only a
+                    # Replicate DTensor holds the full vocab locally. A
+                    # Shard(-1) pred would mean vocab-parallel logits and must
+                    # go through the loss-parallel branch instead — localizing
+                    # it here would silently compute CE on a partial vocab.
+                    assert all(
+                        isinstance(p, Replicate) for p in pred.placements
+                    ), (
+                        "non-loss-parallel loss expects Replicate logits; got "
+                        f"placements={pred.placements}. Vocab-sharded logits "
+                        "must use --loss-impl=loss-parallel."
+                    )
+                    pred = pred.to_local()
                 loss = _compute_loss(
                     pred,
                     labels,

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -877,6 +877,40 @@ def _cross_entropy_compiled(
     return _COMPILED_CE(logits, labels, ignore_index=ignore_index)
 
 
+def _localize_logits_for_loss(logits: "torch.Tensor") -> "torch.Tensor":
+    """Return a plain tensor of logits for non-loss-parallel CE.
+
+    At tp>1 the output ColwiseParallel uses ``output_layouts=Replicate()``,
+    ``use_local_output=False``, so ``logits`` is a REPLICATED ``DTensor``
+    while ``labels`` is a plain tensor. Plain ``F.cross_entropy(DTensor,
+    Tensor)`` raises "got mixed torch.Tensor and DTensor". Localizing to
+    the per-rank tensor (which, being Replicate, holds the full vocab)
+    fixes it with no numeric change; ``to_local()`` is differentiable so
+    grads still reach the sharded output weight. Mirrors torchtitan
+    ``components/loss.py``.
+
+    No-op for a plain tensor (tp=1 / HF path), so it is always safe to call.
+
+    Raises:
+        RuntimeError: if ``logits`` is a vocab-SHARDED ``DTensor``
+            (``Shard(-1)``). That is vocab-parallel logits and must go
+            through ``--loss-impl=loss-parallel``; localizing here would
+            silently compute CE on a partial vocab. Explicit raise (not
+            ``assert``) so it survives ``python -O``.
+    """
+    if not hasattr(logits, "to_local"):
+        return logits
+    from torch.distributed._tensor import Replicate as _Replicate
+
+    if not all(isinstance(p, _Replicate) for p in logits.placements):
+        raise RuntimeError(
+            "non-loss-parallel loss expects Replicate logits; got "
+            f"placements={logits.placements}. Vocab-sharded logits must "
+            "use --loss-impl=loss-parallel."
+        )
+    return logits.to_local()
+
+
 def _compute_loss(
     logits: torch.Tensor,
     labels: torch.Tensor,
@@ -2684,34 +2718,14 @@ def train(
                     tp_group=tp_group,
                 )
             else:
-                # tp>1 non-loss-parallel: the output ColwiseParallel uses
-                # output_layouts=Replicate(), use_local_output=False, so
-                # `pred` is a REPLICATED DTensor while `labels` is a plain
-                # tensor. Plain F.cross_entropy(DTensor, Tensor) raises
-                # "got mixed torch.Tensor and DTensor". Localize pred to a
-                # plain tensor first (torchtitan components/loss.py does the
-                # same). to_local() on a Replicate DTensor is a data no-op
-                # (full logits already on every tp rank) and is
-                # differentiable — its backward re-wraps the grad as a
-                # Replicate DTensor, so grads still reach the sharded output
-                # weight correctly. No-op at tp=1 / HF (pred is already a
-                # plain tensor, so hasattr(...) is False).
-                if hasattr(pred, "to_local"):
-                    # Guard the invariant this localization relies on: only a
-                    # Replicate DTensor holds the full vocab locally. A
-                    # Shard(-1) pred would mean vocab-parallel logits and must
-                    # go through the loss-parallel branch instead — localizing
-                    # it here would silently compute CE on a partial vocab.
-                    assert all(
-                        isinstance(p, Replicate) for p in pred.placements
-                    ), (
-                        "non-loss-parallel loss expects Replicate logits; got "
-                        f"placements={pred.placements}. Vocab-sharded logits "
-                        "must use --loss-impl=loss-parallel."
-                    )
-                    pred = pred.to_local()
+                # tp>1 non-loss-parallel: `pred` is a REPLICATED DTensor
+                # (output ColwiseParallel output_layouts=Replicate,
+                # use_local_output=False) but `labels` is plain, so plain CE
+                # would raise "mixed torch.Tensor and DTensor". Localize to a
+                # plain tensor first (no-op at tp=1/HF). See
+                # _localize_logits_for_loss for the full rationale + guard.
                 loss = _compute_loss(
-                    pred,
+                    _localize_logits_for_loss(pred),
                     labels,
                     impl=args.loss_impl,
                     ignore_index=-100,

--- a/tests/test_loss_impls.py
+++ b/tests/test_loss_impls.py
@@ -313,3 +313,99 @@ def test_vocab_parallel_matches_eager_2rank(vocab):
     assert torch.allclose(grad0, full.grad[:, s:e], atol=1e-4), (
         f"vocab-parallel grad shard != eager grad shard (vocab={vocab})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Replicate-DTensor loss localization: at tp>1 (non-loss-parallel), the output
+# projection returns a REPLICATED DTensor. The train loop must localize it
+# (pred.to_local()) before eager/chunked/compiled CE, else F.cross_entropy
+# raises "got mixed torch.Tensor and DTensor". This builds a real Replicate
+# DTensor on a 1-rank gloo mesh and asserts to_local() -> plain CE matches
+# plain eager (loss + grad), and that the differentiable to_local() routes the
+# grad back to the DTensor. Skipped if gloo/DeviceMesh aren't usable.
+# ---------------------------------------------------------------------------
+
+
+def _replicate_dtensor_worker(rank, world_size, master_port, ret):
+    import os
+
+    import torch
+    import torch.distributed as dist
+    import torch.nn.functional as F
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import DTensor, Replicate
+
+        n, vocab = 6, 16
+        torch.manual_seed(7)
+        full = torch.randn(n, vocab, dtype=torch.float32)
+        labels = torch.randint(0, vocab, (n,))
+        labels[::3] = -100
+
+        mesh = init_device_mesh("cpu", (world_size,), mesh_dim_names=("tp",))
+        # Replicated DTensor built from a differentiable local leaf, mirroring
+        # the non-loss-parallel output projection (output_layouts=Replicate(),
+        # use_local_output=False). from_local (not distribute_tensor) keeps the
+        # autograd chain to `leaf` so we can assert grad routes back through
+        # to_local().
+        leaf = full.clone().detach().requires_grad_(True)
+        dpred = DTensor.from_local(leaf, mesh, [Replicate()], run_check=False)
+
+        # This is exactly what the train loop now does before _compute_loss.
+        assert hasattr(dpred, "to_local")
+        assert all(isinstance(p, Replicate) for p in dpred.placements)
+        local = dpred.to_local()
+        loss = F.cross_entropy(
+            local.reshape(-1, local.size(-1)),
+            labels.reshape(-1),
+            ignore_index=-100,
+        )
+        loss.backward()
+
+        ret["loss"] = float(loss.detach().item())
+        # grad flowed back through to_local() into the DTensor -> local leaf.
+        ret["has_grad"] = leaf.grad is not None
+        ret["grad"] = leaf.grad.tolist() if leaf.grad is not None else None
+    finally:
+        dist.destroy_process_group()
+
+
+def test_replicate_dtensor_to_local_matches_eager_1rank():
+    import torch
+    import torch.multiprocessing as mp
+    import torch.nn.functional as F
+
+    port = _free_port()
+    mgr = mp.Manager()
+    ret = mgr.dict()
+    try:
+        mp.spawn(
+            _replicate_dtensor_worker, args=(1, port, ret), nprocs=1, join=True
+        )
+    except Exception as exc:  # noqa: BLE001 - gloo/DeviceMesh may be unavailable
+        pytest.skip(f"1-rank gloo/DeviceMesh unavailable: {exc}")
+
+    assert "loss" in ret, "worker did not report"
+    assert ret["has_grad"], (
+        "to_local() must be differentiable so grad reaches the DTensor"
+    )
+
+    # Reference: plain eager CE on the same seeded data (no DTensor).
+    torch.manual_seed(7)
+    full = torch.randn(6, 16, dtype=torch.float32, requires_grad=True)
+    labels = torch.randint(0, 16, (6,))
+    labels[::3] = -100
+    ref = F.cross_entropy(full, labels, ignore_index=-100)
+    ref.backward()
+
+    assert abs(ret["loss"] - ref.detach().item()) < 1e-5, (
+        f"Replicate-DTensor localized loss {ret['loss']} != eager {ref.item()}"
+    )
+    grad = torch.tensor(ret["grad"], dtype=full.grad.dtype)
+    assert torch.allclose(grad, full.grad, atol=1e-5), (
+        "grad through to_local() != eager grad"
+    )

--- a/tests/test_loss_impls.py
+++ b/tests/test_loss_impls.py
@@ -337,6 +337,7 @@ def _replicate_dtensor_worker(rank, world_size, master_port, ret):
     os.environ["MASTER_PORT"] = str(master_port)
     dist.init_process_group("gloo", rank=rank, world_size=world_size)
     try:
+        import ezpz.examples.fsdp_tp as fsdp_tp
         from torch.distributed.device_mesh import init_device_mesh
         from torch.distributed.tensor import DTensor, Replicate
 
@@ -355,10 +356,14 @@ def _replicate_dtensor_worker(rank, world_size, master_port, ret):
         leaf = full.clone().detach().requires_grad_(True)
         dpred = DTensor.from_local(leaf, mesh, [Replicate()], run_check=False)
 
-        # This is exactly what the train loop now does before _compute_loss.
-        assert hasattr(dpred, "to_local")
-        assert all(isinstance(p, Replicate) for p in dpred.placements)
-        local = dpred.to_local()
+        # Exercise the ACTUAL production helper the train loop calls, so a
+        # revert of the fix (e.g. dropping the to_local localization) fails
+        # this test rather than silently passing.
+        local = fsdp_tp._localize_logits_for_loss(dpred)
+        assert not hasattr(local, "to_local"), (
+            "_localize_logits_for_loss must return a plain tensor for a "
+            "Replicate DTensor"
+        )
         loss = F.cross_entropy(
             local.reshape(-1, local.size(-1)),
             labels.reshape(-1),
@@ -374,6 +379,9 @@ def _replicate_dtensor_worker(rank, world_size, master_port, ret):
         dist.destroy_process_group()
 
 
+@pytest.mark.skipif(
+    not LOSS_AVAILABLE, reason="ezpz.examples.fsdp_tp not importable"
+)
 def test_replicate_dtensor_to_local_matches_eager_1rank():
     import torch
     import torch.multiprocessing as mp
@@ -386,8 +394,18 @@ def test_replicate_dtensor_to_local_matches_eager_1rank():
         mp.spawn(
             _replicate_dtensor_worker, args=(1, port, ret), nprocs=1, join=True
         )
-    except Exception as exc:  # noqa: BLE001 - gloo/DeviceMesh may be unavailable
-        pytest.skip(f"1-rank gloo/DeviceMesh unavailable: {exc}")
+    except (RuntimeError, OSError) as exc:
+        # Only skip for genuine infra/unavailability (gloo transport,
+        # DeviceMesh init, spawn). Real regressions in the worker surface as
+        # AssertionError (from the in-worker asserts) or other exceptions and
+        # must NOT be swallowed — re-raise those.
+        msg = str(exc).lower()
+        if any(
+            k in msg
+            for k in ("gloo", "process group", "devicemesh", "backend", "connect")
+        ):
+            pytest.skip(f"1-rank gloo/DeviceMesh unavailable: {exc}")
+        raise
 
     assert "loss" in ret, "worker did not report"
     assert ret["has_grad"], (
@@ -409,3 +427,33 @@ def test_replicate_dtensor_to_local_matches_eager_1rank():
     assert torch.allclose(grad, full.grad, atol=1e-5), (
         "grad through to_local() != eager grad"
     )
+
+
+@pytest.mark.skipif(
+    not LOSS_AVAILABLE, reason="ezpz.examples.fsdp_tp not importable"
+)
+def test_localize_logits_plain_tensor_is_noop():
+    """Fast CPU unit test (no process group): a plain tensor passes through
+    _localize_logits_for_loss unchanged. Locks the tp=1 / HF no-op contract."""
+    x = torch.randn(4, 8)
+    out = fsdp_tp._localize_logits_for_loss(x)
+    assert out is x  # identity, no copy, no wrap
+
+
+@pytest.mark.skipif(
+    not LOSS_AVAILABLE, reason="ezpz.examples.fsdp_tp not importable"
+)
+def test_localize_logits_rejects_vocab_sharded_dtensor():
+    """A Shard(-1) (vocab-parallel) DTensor must be rejected, not silently
+    localized to a partial-vocab tensor. Uses a lightweight stub with the
+    DTensor duck-type (to_local + placements) so no process group is needed."""
+    from torch.distributed.tensor import Shard
+
+    class _FakeShardedDT:
+        placements = (Shard(-1),)
+
+        def to_local(self):  # pragma: no cover - must raise before this
+            raise AssertionError("to_local must not be reached for Shard(-1)")
+
+    with pytest.raises(RuntimeError, match="loss-parallel"):
+        fsdp_tp._localize_logits_for_loss(_FakeShardedDT())


### PR DESCRIPTION
## Problem

At `tp>1` with a non-loss-parallel `--loss-impl` (the default `eager`, or `chunked`/`chunked-backward`/`compiled`), training crashed at the first loss step on Sunspot/Aurora XPU:

```
RuntimeError: aten.nll_loss_forward.default got mixed torch.Tensor and DTensor,
need to convert all torch.Tensor to DTensor before calling distributed operators!
```

(Confirmed live: `tp=2 --dp-replicate=4 --dp-shard=6`.)

## Root cause

With tensor parallelism, the `output` projection is `ColwiseParallel(output_layouts=Replicate(), use_local_output=False)`, so `pred` comes out as a **replicated DTensor** while `labels` is a plain tensor. `_cross_entropy_eager` then calls `F.cross_entropy(DTensor, plain_tensor)` → mixed-type error. Only `loss-parallel` handled the TP case (it uses `use_local_output=True`); the four logit-based impls did not. The help text already documented this ("at tp>1 plain CE hits a Tensor/DTensor mismatch on Replicate logits") but `eager` was still the default.

## Fix

In the `else` branch of the loss dispatch, localize `pred` with `pred.to_local()` when it's a DTensor, before `_compute_loss`. This mirrors torchtitan (`components/loss.py`).

- `to_local()` on a **Replicate** DTensor is a **data no-op** — the full logits already sit on every tp rank — so the loss is numerically identical to tp=1 eager.
- It's **differentiable**: backward re-wraps the grad as a Replicate DTensor, which slices to the sharded `output.weight` grad correctly (no double-count, no missing reduce).
- A `Replicate`-placement **assert** guards against a future parallelize-plan edit silently feeding vocab-**sharded** logits (which must use `--loss-impl=loss-parallel`) into plain CE.

**No-op at tp=1 / HF** (pred is already a plain tensor, `hasattr(pred, "to_local")` is False). `loss-parallel` and `fused-linear` are untouched (different branches). Fixes all four logit-based impls at tp>1, not just eager.

## How this was chosen

Investigated via a fan-out/adversarial-verify workflow over three candidates (`use_local_output=True` on the projection; `.to_local()` at the loss boundary; DTensor-aware `_compute_loss`). The loss-boundary conversion was selected: it survived adversarial verification and it's the torchtitan reference approach, keeping the `parallelize()` plan byte-identical.

## Tests

`tests/test_loss_impls.py::test_replicate_dtensor_to_local_matches_eager_1rank` — builds a real Replicate DTensor on a 1-rank gloo mesh (`DTensor.from_local`, which keeps the autograd chain), localizes + runs eager CE, and asserts both **loss and grad** match plain eager. Skips cleanly if gloo/DeviceMesh are unavailable.

Suites: 33 passed (test_loss_impls + fsdp_tp_datasets + fsdp_tp_dp_degrees). Lint clean.

## Notes

- Independent of #189 (`_flatten`/xccl) and #190 (`drop_last`/compile-OOM). This is the tp>1 loss-type fix.
- `--loss-impl=loss-parallel` remains the memory-efficient TP path at large vocab; this fix makes the default `eager` (and chunked/compiled) merely *work* at tp>1.

`release:patch`

## Summary by Sourcery

Handle replicated DTensor logits in FSDP+TP training by localizing them before non-loss-parallel cross-entropy to avoid Tensor/DTensor mismatches at tp>1.

Bug Fixes:
- Prevent runtime errors when computing eager/chunked/compiled cross-entropy with replicated DTensor logits and plain label tensors at tp>1 by converting logits to local tensors.

Tests:
- Add a distributed test that verifies localizing replicated DTensor logits before eager cross-entropy matches plain eager loss and gradients and that gradients flow correctly through to_local().