### PR TITLE
feat(fsdp_tp): replace --sharding-strategy with --reshard-after-forward

### DIFF
--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -86,8 +86,8 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
   (pure FSDP), identical to the pre-HSDP behavior — `--dp-shard -1` means
   "use all remaining ranks" = `WORLD_SIZE / (dp_replicate * tp)`. Mirrors
   torchtitan's `data_parallel_replicate_degree` / `data_parallel_shard_degree`.
-  (The legacy `--sharding-strategy hybrid_shard*` names do **not** do real
-  HSDP under FSDP2 — use these flags instead.)
+  (The legacy `--sharding-strategy hybrid_shard*` names have been **removed**
+  — they now hard-error. Use `--dp-replicate` / `--dp-shard` for HSDP.)
 - **Activation checkpointing** — `--ac {none,block,full,selective}` (or
   `--activation-checkpoint`) trades compute for memory during training.
   `block`/`full` wraps each TransformerBlock (~30-40 pct activation-memory
@@ -330,15 +330,24 @@ memory for each doubling) or use a smaller preset.
 
 </details>
 
-<details closed markdown><summary><strong>Sharding Strategies</strong></summary>
+<details closed markdown><summary><strong>Reshard-after-forward policy</strong></summary>
 
-Maps the legacy FSDP1 strategy names (kept as the CLI surface so existing
-scripts don't break) to FSDP2's `reshard_after_forward` policy: `True`
-reshards params after forward (ZeRO-3-like), `False` keeps them gathered
-(ZeRO-2-like).
+`--reshard-after-forward {always,never}` (and its shorthand
+`--no-reshard-after-forward`) map directly to FSDP2's `reshard_after_forward`
+bool: `always` -> `True` (ZeRO-3: reshard params after forward — lowest
+memory, re-all-gathers params in backward), `never` -> `False` (ZeRO-2: keep
+params gathered after forward — more memory, skips the backward all-gather).
+Bare `--reshard-after-forward` == `always` (the default);
+`--no-reshard-after-forward` == `never`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:327:333"
---8<-- "src/ezpz/examples/fsdp_tp.py:327:333"
+The legacy `--sharding-strategy` flag is a deprecated hidden alias (kept so
+existing scripts don't break, but suppressed from `--help`): `full_shard`
+maps to `always`, `shard_grad_op`/`no_shard` map to `never` (with a
+deprecation warning). The `hybrid_shard`/`hybrid_shard_zero2` names have been
+removed and now hard-error — use `--dp-replicate` / `--dp-shard` for HSDP.
+
+```python title="src/ezpz/examples/fsdp_tp.py:329:338"
+--8<-- "src/ezpz/examples/fsdp_tp.py:329:338"
 ```
 
 </details>
@@ -574,13 +583,13 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp --model agpt-2b --tp 2 --compile
 
 This example targets parity with [torchtitan](https://github.com/pytorch/torchtitan)
 on the same AuroraGPT model. On Sunspot (Intel PVC), agpt-2b at
-`--batch-size 2 --seq-len 7320 --tp 1`, full-shard, 2 nodes (dp=24), the
-recipe below reproduces torchtitan's throughput within noise:
+`--batch-size 2 --seq-len 7320 --tp 1`, default reshard-after-forward
+(ZeRO-3), 2 nodes (dp=24), the recipe below reproduces torchtitan's
+throughput within noise:
 
 ```bash
 ezpz launch python3 -m ezpz.examples.fsdp_tp \
   --model agpt-2b --seq-len 7320 --batch-size 2 --tp 1 \
-  --sharding-strategy full_shard \
   --compile --loss-impl compiled --act-mem-budget 0.5
 ```
 
@@ -619,8 +628,8 @@ Three pieces close the gap, all matching what torchtitan does:
     high-water mark that torchtitan's per-step reset discards — it is not
     extra real usage.
 
-Verified batch/loss/budget sweep (agpt-2b, seq=8192, tp=1, full_shard,
-dp=48, `--compile`):
+Verified batch/loss/budget sweep (agpt-2b, seq=8192, tp=1, default
+reshard-after-forward (ZeRO-3), dp=48, `--compile`):
 
 | batch | `--loss-impl` | `--act-mem-budget` | result |
 |---|---|---|---|
@@ -647,8 +656,8 @@ vocab_size from 256128 to tokenizer vocab_size=128000`).
 
 Setup: agpt-2b (`dim=2048`, `n_layers=12`, `hidden_dim=11008`),
 `--tokenizer_name meta-llama/Llama-3.2-1B` (vocab 128,000), `--seq-len 8192`,
-`--batch-size 2`, `--tp 1`, `--sharding-strategy full_shard`, 2× Sunspot nodes
-(dp=24), dataset `eliplutchok/fineweb-small-sample`. Each config runs ~31
+`--batch-size 2`, `--tp 1`, default reshard-after-forward (ZeRO-3), 2× Sunspot
+nodes (dp=24), dataset `eliplutchok/fineweb-small-sample`. Each config runs ~31
 iters; metrics are the steady-state mean over 26 iters (warmup + the final
 eval-pass step dropped).
 
@@ -656,13 +665,13 @@ eval-pass step dropped).
 # compiled (fastest that fits)
 ezpz launch python3 -m ezpz.examples.fsdp_tp \
   --model agpt-2b --tokenizer_name meta-llama/Llama-3.2-1B \
-  --seq-len 8192 --batch-size 2 --tp 1 --sharding-strategy full_shard \
+  --seq-len 8192 --batch-size 2 --tp 1 \
   --compile --loss-impl compiled --act-mem-budget 0.5
 
 # fused-linear (lowest memory)
 ezpz launch python3 -m ezpz.examples.fsdp_tp \
   --model agpt-2b --tokenizer_name meta-llama/Llama-3.2-1B \
-  --seq-len 8192 --batch-size 2 --tp 1 --sharding-strategy full_shard \
+  --seq-len 8192 --batch-size 2 --tp 1 \
   --loss-impl fused-linear
 ```
 
@@ -745,8 +754,9 @@ realistically large)** with a shorter **seq-len 2048** does it: the
 fits with headroom and every mode produces steady-state steps.
 
 Setup: agpt-2b arch, `--tokenizer_name google/gemma-7b` (vocab 256,000),
-`--seq-len 2048`, `--batch-size 2`, `--tp 1`, `--sharding-strategy full_shard`,
-2× Sunspot nodes (dp=24), `eliplutchok/fineweb-small-sample`. Steady-state mean
+`--seq-len 2048`, `--batch-size 2`, `--tp 1`, default reshard-after-forward
+(ZeRO-3), 2× Sunspot nodes (dp=24), `eliplutchok/fineweb-small-sample`.
+Steady-state mean
 over 26 iters (warmup + final eval-pass step dropped).
 
 | `--loss-impl` | extra flags | MFU | TFLOP/s/rank | tokens/s | alloc mem | peak mem |
@@ -810,7 +820,8 @@ usage: fsdp_tp.py [-h] [--dim DIM] [--n-layers N_LAYERS]
                   [--test-batch-size TEST_BATCH_SIZE]
                   [--num-workers NUM_WORKERS]
                   [--seed SEED] [--tp TP]
-                  [--sharding-strategy {no_shard,full_shard,shard_grad_op,hybrid_shard,hybrid_shard_zero2}]
+                  [--reshard-after-forward [{always,never}]]
+                  [--no-reshard-after-forward]
                   [--activation-checkpoint {none,block,full,selective}]
                   [--max-grad-norm MAX_GRAD_NORM]
                   [--outdir OUTDIR] [--dataset DATASET]
@@ -905,23 +916,19 @@ options:
                         dimension (WORLD_SIZE / --tp) is used for FSDP data
                         parallelism. Set to 1 for FSDP-only. Forced to 1 when
                         --model is a HF repo id. (default: 2)
-  --sharding-strategy {no_shard,full_shard,shard_grad_op,hybrid_shard,hybrid_shard_zero2}
-                        FSDP sharding behavior. The model uses FSDP2
-                        (`fully_shard`), which controls sharding via
-                        `reshard_after_forward` rather than a strategy enum;
-                        the legacy FSDP1 names below are kept as the CLI
-                        surface and mapped to the nearest FSDP2 policy.
-                        `full_shard` (default, ZeRO-3): reshard params after
-                        forward — lowest memory, params re-all-gathered in
-                        backward. `shard_grad_op` (ZeRO-2): keep params
-                        unsharded after forward — more memory, avoids the
-                        backward all-gather. `no_shard`: mapped to keep-
-                        unsharded (FSDP2 has no true per-module no-shard).
-                        `hybrid_shard`/`hybrid_shard_zero2`: FSDP1 hybrid has
-                        no one-flag FSDP2 equivalent — `hybrid_shard` maps to
-                        reshard-after-forward, `hybrid_shard_zero2` to keep-
-                        unsharded (mirroring their ZeRO-3/ZeRO-2 variants).
-                        (default: full_shard)
+  --reshard-after-forward [{always,never}]
+                        FSDP2 reshard_after_forward policy (memory vs. comm
+                        tradeoff). `always` (default, ZeRO-3): reshard params
+                        after forward — lowest memory, re-all-gathers params
+                        in backward. `never` (ZeRO-2): keep params gathered
+                        after forward — more memory, skips the backward all-
+                        gather. Bare `--reshard-after-forward` == `always`;
+                        `--no-reshard-after-forward` == `never`. For HSDP
+                        (replicate + shard) use --dp-replicate / --dp-shard.
+                        (default: always)
+  --no-reshard-after-forward
+                        Alias for --reshard-after-forward never (ZeRO-2).
+                        (default: None)
   --activation-checkpoint, --ac {none,block,full,selective}
                         Activation checkpointing strategy. `none` (default)
                         keeps all forward activations in memory. `block`

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -358,8 +358,8 @@ When sequence parallelism is active, each TP rank only sees a slice of
 the sequence dimension. This helper narrows the label tensor to match
 the local shard so `cross_entropy` computes the correct loss.
 
-```python title="src/ezpz/examples/fsdp_tp.py:343:399"
---8<-- "src/ezpz/examples/fsdp_tp.py:343:399"
+```python title="src/ezpz/examples/fsdp_tp.py:452:507"
+--8<-- "src/ezpz/examples/fsdp_tp.py:452:507"
 ```
 
 </details>
@@ -370,8 +370,8 @@ the local shard so `cross_entropy` computes the correct loss.
 from `MODEL_PRESETS`; any flag the user provides explicitly takes
 precedence over the preset via `apply_model_preset`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:690:1086"
---8<-- "src/ezpz/examples/fsdp_tp.py:690:1086"
+```python title="src/ezpz/examples/fsdp_tp.py:1185:1656"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1185:1656"
 ```
 
 </details>
@@ -382,8 +382,8 @@ This is the core of the 2D parallelism setup. It takes the model and
 device mesh, applies tensor/sequence parallelism along the `"tp"` mesh
 dimension, then wraps the result with FSDP along the `"dp"` dimension.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1130:1147"
---8<-- "src/ezpz/examples/fsdp_tp.py:1130:1147"
+```python title="src/ezpz/examples/fsdp_tp.py:1706:1724"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1706:1724"
 ```
 
 **Top-level TP plan.** Applied only when `--tp > 1` (at `--tp 1` the whole
@@ -391,8 +391,8 @@ TP plan is skipped — no SequenceParallel overhead). The embedding is
 row-sharded, the final output projection is column-sharded, and the RMS
 norm between them uses `SequenceParallel`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1148:1198"
---8<-- "src/ezpz/examples/fsdp_tp.py:1148:1198"
+```python title="src/ezpz/examples/fsdp_tp.py:1725:1771"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1725:1771"
 ```
 
 **Per-layer TP plan.** Each transformer block's attention and FFN
@@ -400,8 +400,8 @@ sub-modules are parallelized: Q/K/V projections are column-sharded,
 output projections are row-sharded, and norms use `SequenceParallel`.
 Attention head counts are divided by the TP mesh size.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1200:1230"
---8<-- "src/ezpz/examples/fsdp_tp.py:1200:1230"
+```python title="src/ezpz/examples/fsdp_tp.py:1773:1802"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1773:1802"
 ```
 
 **FSDP2 wrapping.** After TP is applied, each module group is sharded
@@ -410,8 +410,8 @@ each TransformerBlock, then `[norm, output]`, then the root last. A final
 `_configure_fsdp_gradient_division` call forces SUM reduction for gradient
 comms on CCL/XPU (matching torchtitan).
 
-```python title="src/ezpz/examples/fsdp_tp.py:1239:1264"
---8<-- "src/ezpz/examples/fsdp_tp.py:1239:1264"
+```python title="src/ezpz/examples/fsdp_tp.py:1812:1837"
+--8<-- "src/ezpz/examples/fsdp_tp.py:1812:1837"
 ```
 
 </details>
@@ -424,28 +424,28 @@ loads data, then runs the epoch loop.
 **Device mesh creation.** World size is split into `dp` x `tp`
 dimensions.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1517:1522"
---8<-- "src/ezpz/examples/fsdp_tp.py:1517:1522"
+```python title="src/ezpz/examples/fsdp_tp.py:2185:2197"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2185:2197"
 ```
 
 **HuggingFace dataset loading.** If `--dataset` is not `"mnist"` or
 `"random"`, a tokenized HF text dataset is loaded and the vocab size is
 synced to the tokenizer.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1524:1546"
---8<-- "src/ezpz/examples/fsdp_tp.py:1524:1546"
+```python title="src/ezpz/examples/fsdp_tp.py:2199:2220"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2199:2220"
 ```
 
 **Model construction and parallelization.** A `Transformer` is built
 from `ModelArgs`, moved to the device, optionally given a
 `MixedPrecision` config, and then handed to `parallelize`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1552:1632"
---8<-- "src/ezpz/examples/fsdp_tp.py:1552:1632"
+```python title="src/ezpz/examples/fsdp_tp.py:2227:2306"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2227:2306"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:1743:1749"
---8<-- "src/ezpz/examples/fsdp_tp.py:1743:1749"
+```python title="src/ezpz/examples/fsdp_tp.py:2461:2468"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2461:2468"
 ```
 
 **DataLoader setup.** Three branches: MNIST, random synthetic data, or
@@ -453,15 +453,15 @@ HuggingFace datasets. For HF data, a `DistributedSampler` partitions
 across the DP dimension, and `TPBroadcastDataLoader` replicates batches
 within each TP group.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1879:1939"
---8<-- "src/ezpz/examples/fsdp_tp.py:1879:1939"
+```python title="src/ezpz/examples/fsdp_tp.py:2623:2676"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2623:2676"
 ```
 
 **Metric tracking.** An `ezpz.history.History` object is created for
 JSONL metric logging and optional distributed aggregation.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1950:1962"
---8<-- "src/ezpz/examples/fsdp_tp.py:1950:1962"
+```python title="src/ezpz/examples/fsdp_tp.py:2688:2704"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2688:2704"
 ```
 
 **Training loop.** Each batch is moved to device, split into
@@ -469,30 +469,30 @@ JSONL metric logging and optional distributed aggregation.
 `cross_entropy`. Labels are narrowed for sequence parallelism when
 needed. Gradient clipping is applied before `optimizer.step()`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:1970:2148"
---8<-- "src/ezpz/examples/fsdp_tp.py:1970:2148"
+```python title="src/ezpz/examples/fsdp_tp.py:2713:2965"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2713:2965"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2067:2074"
---8<-- "src/ezpz/examples/fsdp_tp.py:2067:2074"
+```python title="src/ezpz/examples/fsdp_tp.py:2863:2870"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2863:2870"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2078:2090"
---8<-- "src/ezpz/examples/fsdp_tp.py:2078:2090"
+```python title="src/ezpz/examples/fsdp_tp.py:2878:2890"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2878:2890"
 ```
 
 After each step, timing and loss metrics are collected into a dict and
 passed to `history.update` and `history.log_metrics`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2141:2148"
---8<-- "src/ezpz/examples/fsdp_tp.py:2141:2148"
+```python title="src/ezpz/examples/fsdp_tp.py:2956:2963"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2956:2963"
 ```
 
 At the end of training, activation hooks are removed, a barrier syncs
 all ranks, and `history.finalize` writes the summary dataset on rank 0.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2151:2156"
---8<-- "src/ezpz/examples/fsdp_tp.py:2151:2156"
+```python title="src/ezpz/examples/fsdp_tp.py:2966:2971"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2966:2971"
 ```
 
 </details>
@@ -503,15 +503,15 @@ all ranks, and `history.finalize` writes the summary dataset on rank 0.
 distributed backend (including TP groups), determines the output
 directory, and dispatches to `train`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2160:2198"
---8<-- "src/ezpz/examples/fsdp_tp.py:2160:2198"
+```python title="src/ezpz/examples/fsdp_tp.py:2975:3015"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2975:3015"
 ```
 
 The `if __name__ == "__main__"` block parses args, runs `main`, cleans
 up distributed state, and exits.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2201:2206"
---8<-- "src/ezpz/examples/fsdp_tp.py:2201:2206"
+```python title="src/ezpz/examples/fsdp_tp.py:3018:3022"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3018:3022"
 ```
 
 </details>

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -368,7 +368,8 @@ def _resolve_reshard_after_forward(args: argparse.Namespace) -> None:
     - `hybrid_shard` / `hybrid_shard_zero2` -> hard error (SystemExit),
       pointing at --dp-replicate / --dp-shard for real HSDP.
     - `full_shard` -> always; `shard_grad_op` / `no_shard` -> never, with a
-      one-time deprecation warning.
+      deprecation warning (emitted on rank 0 only — parse_args runs on every
+      rank, and AGENTS.md gates per-rank log lines to local_rank 0).
     - If both `--sharding-strategy` and the new flag are passed, the
       deprecated value is applied last (documented precedence).
     """
@@ -385,20 +386,26 @@ def _resolve_reshard_after_forward(args: argparse.Namespace) -> None:
     if ss not in _LEGACY_SHARDING_TO_RESHARD:
         raise SystemExit(f"unknown --sharding-strategy={ss!r}")
     mapped = _LEGACY_SHARDING_TO_RESHARD[ss]
-    logger.warning(
-        "--sharding-strategy is deprecated; use --reshard-after-forward. "
-        "Mapping --sharding-strategy=%s -> --reshard-after-forward=%s.",
-        ss,
-        mapped,
-    )
-    if ss == "no_shard":
+    # parse_args() runs on every rank before setup_torch; gate the warnings
+    # to rank 0 so a large launch doesn't emit N duplicate lines (AGENTS.md
+    # "Logging at scale"). get_rank() reads the launcher's env vars, which
+    # are already set at parse time.
+    if ezpz.get_rank() == 0:
         logger.warning(
-            "--sharding-strategy=no_shard does NOT give replicated "
-            "(ZeRO-0/DDP) params under FSDP2: parameters, gradients, and "
-            "optimizer state are still sharded across the dp mesh. Only "
-            "post-forward resharding is disabled (== --reshard-after-forward "
-            "never). Use plain DDP if you need truly replicated parameters."
+            "--sharding-strategy is deprecated; use --reshard-after-forward. "
+            "Mapping --sharding-strategy=%s -> --reshard-after-forward=%s.",
+            ss,
+            mapped,
         )
+        if ss == "no_shard":
+            logger.warning(
+                "--sharding-strategy=no_shard does NOT give replicated "
+                "(ZeRO-0/DDP) params under FSDP2: parameters, gradients, and "
+                "optimizer state are still sharded across the dp mesh. Only "
+                "post-forward resharding is disabled (== "
+                "--reshard-after-forward never). Use plain DDP if you need "
+                "truly replicated parameters."
+            )
     args.reshard_after_forward = mapped
 
 

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -333,8 +333,15 @@ def _reshard_arg(policy: str) -> bool:
     """Map a --reshard-after-forward policy to the FSDP2 bool.
 
     Only two behaviors exist under FSDP2: ``always`` -> True, ``never`` ->
-    False.
+    False. Validates against RESHARD_POLICIES so a bad programmatic value
+    (the CLI already restricts via ``choices``) raises instead of silently
+    resolving to True.
     """
+    if policy not in RESHARD_POLICIES:
+        raise ValueError(
+            f"invalid reshard_after_forward policy {policy!r}; "
+            f"expected one of {RESHARD_POLICIES}"
+        )
     return policy != "never"
 
 

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -319,33 +319,80 @@ MODEL_PRESET_FLAGS = {
 
 
 # FSDP2 (`fully_shard`) has no `sharding_strategy` enum — sharding behavior
-# is controlled by `reshard_after_forward` (bool). We keep the legacy
-# FSDP1 strategy NAMES as the CLI surface (so existing scripts don't break)
-# and map each to the closest FSDP2 reshard policy:
-#   - full_shard  (ZeRO-3): reshard params after forward -> lowest memory  -> True
-#   - shard_grad_op (ZeRO-2): keep params unsharded after forward          -> False
-#   - no_shard    (ZeRO-0 / replicate): also keep unsharded (closest FSDP2 -> False;
-#       true no-shard = don't shard at all, not expressible per-module here)
-#   - hybrid_shard (ZeRO-3-like): FSDP1 inter/intra-node hybrid has no
-#       direct one-flag FSDP2 equivalent (needs an explicit 2D mesh); map
-#       to reshard-after-forward                                     -> True
-#   - hybrid_shard_zero2 (ZeRO-2-like): same caveat, but keep params
-#       unsharded after forward to mirror the zero2 variant          -> False
-# This is the set of valid `--sharding-strategy` values.
-SHARDING_STRATEGIES = {
-    "no_shard": False,
-    "full_shard": True,
-    "shard_grad_op": False,
-    "hybrid_shard": True,
-    "hybrid_shard_zero2": False,
+# is a single knob, `reshard_after_forward` (bool). The CLI surface is
+# `--reshard-after-forward {always,never}` (+ `--no-reshard-after-forward`),
+# which names exactly that. Two behaviors exist:
+#   - always (ZeRO-3, default): reshard params after forward  -> True
+#       lowest memory, re-all-gathers params in backward.
+#   - never  (ZeRO-2):          keep params gathered after fwd -> False
+#       more memory, skips the backward all-gather.
+RESHARD_POLICIES = ("always", "never")
+
+
+def _reshard_arg(policy: str) -> bool:
+    """Map a --reshard-after-forward policy to the FSDP2 bool.
+
+    Only two behaviors exist under FSDP2: ``always`` -> True, ``never`` ->
+    False.
+    """
+    return policy != "never"
+
+
+# Legacy `--sharding-strategy` values -> the new reshard policy. Kept only
+# for the hidden, deprecated `--sharding-strategy` alias (see parse_args).
+# `hybrid_shard*` are intentionally absent: they never did real HSDP under
+# FSDP2 (use --dp-replicate / --dp-shard), so they hard-error instead of
+# silently mapping to a reshard bool.
+_LEGACY_SHARDING_TO_RESHARD = {
+    "full_shard": "always",
+    "shard_grad_op": "never",
+    "no_shard": "never",
 }
+_LEGACY_HYBRID_SHARDING = ("hybrid_shard", "hybrid_shard_zero2")
 
 
-def _reshard_after_forward(sharding_strategy: Optional[str]) -> bool:
-    """Map a legacy --sharding-strategy name to FSDP2 reshard_after_forward."""
-    if sharding_strategy is None:
-        return True
-    return SHARDING_STRATEGIES.get(sharding_strategy, True)
+def _resolve_reshard_after_forward(args: argparse.Namespace) -> None:
+    """Fold the deprecated `--sharding-strategy` alias into `reshard_after_forward`.
+
+    Mutates *args* in place. Called from ``parse_args`` so the module
+    entrypoint and tests both see the normalized value. No-op when
+    `--sharding-strategy` wasn't passed (the common path).
+
+    - `hybrid_shard` / `hybrid_shard_zero2` -> hard error (SystemExit),
+      pointing at --dp-replicate / --dp-shard for real HSDP.
+    - `full_shard` -> always; `shard_grad_op` / `no_shard` -> never, with a
+      one-time deprecation warning.
+    - If both `--sharding-strategy` and the new flag are passed, the
+      deprecated value is applied last (documented precedence).
+    """
+    ss = getattr(args, "sharding_strategy", None)
+    if ss is None:
+        return
+    if ss in _LEGACY_HYBRID_SHARDING:
+        raise SystemExit(
+            f"--sharding-strategy={ss} is removed: it never performed real "
+            "HSDP under FSDP2. Use --dp-replicate / --dp-shard for hybrid "
+            "sharding, and --reshard-after-forward {always,never} for the "
+            "ZeRO-3/ZeRO-2 reshard policy."
+        )
+    if ss not in _LEGACY_SHARDING_TO_RESHARD:
+        raise SystemExit(f"unknown --sharding-strategy={ss!r}")
+    mapped = _LEGACY_SHARDING_TO_RESHARD[ss]
+    logger.warning(
+        "--sharding-strategy is deprecated; use --reshard-after-forward. "
+        "Mapping --sharding-strategy=%s -> --reshard-after-forward=%s.",
+        ss,
+        mapped,
+    )
+    if ss == "no_shard":
+        logger.warning(
+            "--sharding-strategy=no_shard does NOT give replicated "
+            "(ZeRO-0/DDP) params under FSDP2: parameters, gradients, and "
+            "optimizer state are still sharded across the dp mesh. Only "
+            "post-forward resharding is disabled (== --reshard-after-forward "
+            "never). Use plain DDP if you need truly replicated parameters."
+        )
+    args.reshard_after_forward = mapped
 
 
 def _resolve_dp_degrees(
@@ -1332,27 +1379,38 @@ def parse_args(argv: Optional[list[str]] = None):
         ),
     )
     parser.add_argument(
-        "--sharding-strategy",
-        type=str,
-        default="full_shard",
-        choices=list(SHARDING_STRATEGIES.keys()),
+        "--reshard-after-forward",
+        dest="reshard_after_forward",
+        nargs="?",
+        const="always",
+        default="always",
+        choices=list(RESHARD_POLICIES),
         help=(
-            "FSDP sharding behavior. The model uses FSDP2 (`fully_shard`), "
-            "which controls sharding via `reshard_after_forward` rather than "
-            "a strategy enum; the legacy FSDP1 names below are kept as the "
-            "CLI surface and mapped to the nearest FSDP2 policy. "
-            "`full_shard` (default, ZeRO-3): reshard params after forward — "
-            "lowest memory, params re-all-gathered in backward. "
-            "`shard_grad_op` (ZeRO-2): keep params unsharded after forward — "
-            "more memory, avoids the backward all-gather. "
-            "`no_shard`: mapped to keep-unsharded (FSDP2 has no true "
-            "per-module no-shard). `hybrid_shard`/`hybrid_shard_zero2`: "
-            "FSDP1 hybrid has no one-flag FSDP2 equivalent — `hybrid_shard` "
-            "maps to reshard-after-forward, `hybrid_shard_zero2` to "
-            "keep-unsharded (mirroring their ZeRO-3/ZeRO-2 variants). "
-            "For actual HSDP (replicate + shard), use --dp-replicate / "
-            "--dp-shard, which build a 2D data-parallel mesh."
+            "FSDP2 reshard_after_forward policy (memory vs. comm tradeoff). "
+            "`always` (default, ZeRO-3): reshard params after forward — "
+            "lowest memory, re-all-gathers params in backward. `never` "
+            "(ZeRO-2): keep params gathered after forward — more memory, "
+            "skips the backward all-gather. Bare `--reshard-after-forward` "
+            "== `always`; `--no-reshard-after-forward` == `never`. For HSDP "
+            "(replicate + shard) use --dp-replicate / --dp-shard."
         ),
+    )
+    parser.add_argument(
+        "--no-reshard-after-forward",
+        dest="reshard_after_forward",
+        action="store_const",
+        const="never",
+        help="Alias for --reshard-after-forward never (ZeRO-2).",
+    )
+    # Deprecated legacy alias, hidden from --help. Resolved post-parse by
+    # _resolve_reshard_after_forward: full_shard->always, shard_grad_op/
+    # no_shard->never (with a deprecation warning), hybrid_shard*->hard error.
+    parser.add_argument(
+        "--sharding-strategy",
+        dest="sharding_strategy",
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--activation-checkpoint",
@@ -1578,6 +1636,9 @@ def parse_args(argv: Optional[list[str]] = None):
     add_profiling_args(parser)
     args = parser.parse_args(argv)
     apply_model_preset(args, argv)
+    # Fold the deprecated --sharding-strategy alias into reshard_after_forward
+    # (and hard-error the removed hybrid_shard* values).
+    _resolve_reshard_after_forward(args)
     return args
 
 
@@ -1632,7 +1693,7 @@ def parallelize(
     model: nn.Module,
     device_mesh: DeviceMesh,
     mixed_precision: Optional[MixedPrecisionPolicy],
-    sharding_strategy: Optional[str] = None,
+    reshard_after_forward: str = "always",
     activation_checkpoint: str = "none",
     loss_parallel: bool = False,
 ) -> nn.Module:
@@ -1648,8 +1709,6 @@ def parallelize(
     sharded unit (torchtitan's ordering).
     """
     tp_mesh = device_mesh["tp"]
-    dp_mesh = device_mesh["dp"]  # flattened (dp_replicate*dp_shard) — used by
-    # non-FSDP dp consumers below and elsewhere in the module.
 
     # Choose the mesh fully_shard shards over:
     #   dp_replicate > 1 -> 2D (dp_replicate, dp_shard) submesh; FSDP2 reads a
@@ -1663,25 +1722,7 @@ def parallelize(
     else:
         fsdp_dp_mesh = device_mesh["dp_shard"]
 
-    reshard = _reshard_after_forward(sharding_strategy)
-
-    # `no_shard` is NOT a true ZeRO-0 / DDP replicate under FSDP2: every
-    # module group below still gets `fully_shard`, so params, grads, and
-    # optimizer state are sharded across the dp mesh regardless. The
-    # strategy name only controls `reshard_after_forward` (False here =
-    # keep params gathered after forward). There is no per-module "don't
-    # shard at all" knob in FSDP2 — that would require skipping fully_shard
-    # entirely (plain DDP). Warn so a multi-rank run that asked for
-    # replicated params/checkpoints isn't silently sharded.
-    if sharding_strategy == "no_shard" and dp_mesh.size() > 1:
-        logger.warning(
-            "--sharding-strategy=no_shard does NOT give replicated "
-            "(ZeRO-0/DDP) params under FSDP2: parameters, gradients, and "
-            "optimizer state are still sharded across the %d-rank dp mesh. "
-            "Only post-forward resharding is disabled. Use plain DDP if you "
-            "need truly replicated parameters.",
-            dp_mesh.size(),
-        )
+    reshard = _reshard_arg(reshard_after_forward)
 
     model.init_weights()  # type: ignore
 
@@ -2382,9 +2423,7 @@ def train(
             hf_dp_mesh = device_mesh["dp_shard"]
         hf_fsdp_kwargs = {
             "mesh": hf_dp_mesh,
-            "reshard_after_forward": _reshard_after_forward(
-                args.sharding_strategy
-            ),
+            "reshard_after_forward": _reshard_arg(args.reshard_after_forward),
         }
         if mp_config is not None:
             hf_fsdp_kwargs["mp_policy"] = mp_config
@@ -2409,7 +2448,7 @@ def train(
             model,
             device_mesh,
             mp_config,
-            sharding_strategy=args.sharding_strategy,
+            reshard_after_forward=args.reshard_after_forward,
             activation_checkpoint=args.activation_checkpoint,
             loss_parallel=use_loss_parallel,
         )

--- a/tests/test_fsdp_tp_reshard.py
+++ b/tests/test_fsdp_tp_reshard.py
@@ -55,6 +55,24 @@ class TestReshardAfterForwardFlag:
         with pytest.raises(SystemExit):
             m.parse_args(["--reshard-after-forward", "sometimes"])
 
+    def test_conflicting_new_flags_last_wins(self):
+        """--reshard-after-forward and --no-… share a dest; last-on-line wins.
+
+        Locks the argparse precedence so a future ordering/parsing change
+        can't silently flip which policy applies when both are passed.
+        """
+        m = _import_fsdp_tp()
+        # --no-… last -> never
+        a = m.parse_args(
+            ["--reshard-after-forward", "always", "--no-reshard-after-forward"]
+        )
+        assert a.reshard_after_forward == "never"
+        # --reshard-after-forward last -> its value wins
+        b = m.parse_args(
+            ["--no-reshard-after-forward", "--reshard-after-forward", "always"]
+        )
+        assert b.reshard_after_forward == "always"
+
 
 class TestReshardArg:
     """The pure policy->bool mapper used for fully_shard."""
@@ -66,6 +84,12 @@ class TestReshardArg:
     def test_never_false(self):
         m = _import_fsdp_tp()
         assert m._reshard_arg("never") is False
+
+    def test_invalid_policy_raises(self):
+        """A bad programmatic value raises rather than silently -> True."""
+        m = _import_fsdp_tp()
+        with pytest.raises(ValueError, match="invalid reshard_after_forward"):
+            m._reshard_arg("alwyas")
 
 
 class TestLegacyShardingStrategyAlias:

--- a/tests/test_fsdp_tp_reshard.py
+++ b/tests/test_fsdp_tp_reshard.py
@@ -19,7 +19,9 @@ import pytest
 def _import_fsdp_tp():
     try:
         return importlib.import_module("ezpz.examples.fsdp_tp")
-    except Exception as exc:  # heavy optional deps may be missing
+    except ImportError as exc:  # only missing optional deps -> skip
+        # Real regressions (SyntaxError, AttributeError, ...) propagate and
+        # fail the run rather than being silently skipped.
         pytest.skip(f"could not import ezpz.examples.fsdp_tp: {exc}")
 
 

--- a/tests/test_fsdp_tp_reshard.py
+++ b/tests/test_fsdp_tp_reshard.py
@@ -1,0 +1,123 @@
+"""Tests for the `--reshard-after-forward` flag in ezpz.examples.fsdp_tp.
+
+Covers the new `--reshard-after-forward {always,never}` /
+`--no-reshard-after-forward` surface, the `_reshard_arg` policy->bool
+mapper, and the deprecated `--sharding-strategy` alias (mapping +
+hard-error on the removed `hybrid_shard*` values).
+
+CPU-only: pure arg parsing + a pure mapping function; no accelerator or
+process group needed.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _import_fsdp_tp():
+    try:
+        return importlib.import_module("ezpz.examples.fsdp_tp")
+    except Exception as exc:  # heavy optional deps may be missing
+        pytest.skip(f"could not import ezpz.examples.fsdp_tp: {exc}")
+
+
+class TestReshardAfterForwardFlag:
+    """The new --reshard-after-forward / --no-reshard-after-forward surface."""
+
+    def test_default_is_always(self):
+        m = _import_fsdp_tp()
+        assert m.parse_args([]).reshard_after_forward == "always"
+
+    def test_bare_flag_is_always(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--reshard-after-forward"])
+        assert args.reshard_after_forward == "always"
+
+    def test_explicit_never(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--reshard-after-forward", "never"])
+        assert args.reshard_after_forward == "never"
+
+    def test_explicit_always(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--reshard-after-forward", "always"])
+        assert args.reshard_after_forward == "always"
+
+    def test_negation_flag_is_never(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--no-reshard-after-forward"])
+        assert args.reshard_after_forward == "never"
+
+    def test_invalid_value_rejected(self):
+        m = _import_fsdp_tp()
+        with pytest.raises(SystemExit):
+            m.parse_args(["--reshard-after-forward", "sometimes"])
+
+
+class TestReshardArg:
+    """The pure policy->bool mapper used for fully_shard."""
+
+    def test_always_true(self):
+        m = _import_fsdp_tp()
+        assert m._reshard_arg("always") is True
+
+    def test_never_false(self):
+        m = _import_fsdp_tp()
+        assert m._reshard_arg("never") is False
+
+
+class TestLegacyShardingStrategyAlias:
+    """The deprecated --sharding-strategy alias maps to the new policy."""
+
+    def test_full_shard_maps_to_always(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--sharding-strategy", "full_shard"])
+        assert args.reshard_after_forward == "always"
+
+    def test_shard_grad_op_maps_to_never(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--sharding-strategy", "shard_grad_op"])
+        assert args.reshard_after_forward == "never"
+
+    def test_no_shard_maps_to_never(self):
+        m = _import_fsdp_tp()
+        args = m.parse_args(["--sharding-strategy", "no_shard"])
+        assert args.reshard_after_forward == "never"
+
+    @pytest.mark.parametrize("hv", ["hybrid_shard", "hybrid_shard_zero2"])
+    def test_hybrid_values_hard_error(self, hv):
+        m = _import_fsdp_tp()
+        with pytest.raises(SystemExit, match="dp-replicate|dp-shard|HSDP"):
+            m.parse_args(["--sharding-strategy", hv])
+
+    def test_unknown_value_hard_error(self):
+        m = _import_fsdp_tp()
+        with pytest.raises(SystemExit):
+            m.parse_args(["--sharding-strategy", "bogus"])
+
+    def test_both_flags_deprecated_wins(self):
+        """When both are passed, the deprecated alias is applied last."""
+        m = _import_fsdp_tp()
+        args = m.parse_args(
+            ["--reshard-after-forward", "always",
+             "--sharding-strategy", "shard_grad_op"]
+        )
+        assert args.reshard_after_forward == "never"
+
+
+class TestHelpSurface:
+    """--help advertises the new flag and hides the deprecated one."""
+
+    def test_help_lists_new_flag_and_hides_legacy(self, capsys):
+        m = _import_fsdp_tp()
+        with pytest.raises(SystemExit):
+            m.parse_args(["--help"])
+        out = capsys.readouterr().out
+        assert "--reshard-after-forward" in out
+        assert "--no-reshard-after-forward" in out
+        # Deprecated alias is argparse.SUPPRESS-hidden; removed hybrid names
+        # must not appear anywhere in the help text.
+        assert "--sharding-strategy" not in out
+        assert "hybrid_shard" not in out


### PR DESCRIPTION
## Motivation

FSDP2 (`fully_shard`) has no sharding-strategy enum — sharding is a single knob, `reshard_after_forward` (bool). The legacy `--sharding-strategy {no_shard, full_shard, shard_grad_op, hybrid_shard, hybrid_shard_zero2}` mapped **5 FSDP1 names onto only 2 behaviors**, and `hybrid_shard*` were actively misleading: they never did real HSDP under FSDP2 (that's what `--dp-replicate` / `--dp-shard` do, shipped in #186). Now that HSDP has its own flags, the enum is cruft.

## New surface

```
--reshard-after-forward {always,never}   # bare == always; default always
--no-reshard-after-forward               # == never (Pythonic negation)
```
- `always` = ZeRO-3 (reshard after forward; lowest memory, re-all-gathers in backward)
- `never` = ZeRO-2 (keep params gathered; more memory, skips the backward all-gather)

Names exactly what it controls, and matches torchtitan's `fsdp_reshard_after_forward` vocabulary for config portability.

**No `default` value** (considered, dropped): in `fsdp_tp` it would map to `True` — byte-identical to `always` — reintroducing the same "value that doesn't do its own thing" cruft we're removing. ezpz implements none of torch's smart-default semantics, so exposing the name would mislead anyone porting from torchtitan.

## Backward compatibility

`--sharding-strategy` stays as a **hidden, deprecated alias** (`argparse.SUPPRESS`), resolved post-parse:
- `full_shard` → `always`; `shard_grad_op` / `no_shard` → `never`, with a one-time deprecation warning (`no_shard` keeps its "not real ZeRO-0 under FSDP2" clarification).
- `hybrid_shard` / `hybrid_shard_zero2` → **hard error** (`SystemExit`) pointing at `--dp-replicate` / `--dp-shard`.
- Both flags passed → the deprecated one applies last (documented precedence).

Existing scripts using `full_shard` / `shard_grad_op` / `no_shard` keep working (with a nudge). Only the already-broken `hybrid_shard*` values now fail loudly instead of silently doing plain FSDP.

## Implementation

- New `_reshard_arg(policy) -> bool` (`always→True`, `never→False`) replaces the old `_reshard_after_forward(name)`.
- `_resolve_reshard_after_forward(args)` folds the legacy alias in, called from `parse_args`.
- `parallelize()` takes `reshard_after_forward: str`; TP branch + HF branch both use `_reshard_arg(...)`.
- Removed the now-dead `dp_mesh` local and the relocated `no_shard` warning.

## Tests

`tests/test_fsdp_tp_reshard.py` (16 tests, CPU-only): flag defaults / bare / explicit / negation / invalid; `_reshard_arg` mapping; legacy alias mapping; `hybrid_shard*` hard-error; both-flags precedence; and `--help` advertises the new flags while hiding `--sharding-strategy` and all `hybrid_shard` names. Full fsdp_tp suites: 54 passed.

## Docs

`docs/examples/fsdp-tp.md`: regenerated the `--help` usage/options dump, dropped `--sharding-strategy full_shard` from example commands (it's the default), rewrote the sharding section as "Reshard-after-forward policy", and fixed the stale `--8<--` code-include. `compare.md` / `distributed-training.md` left as-is (their mentions are the generic FSDP `reshard_after_forward` API, not the fsdp_tp CLI flag). `vit` / `diffusion`'s separate `--fsdp-sharding-strategy` is out of scope.

## Scope / validation

Pure CLI + arg-resolution change; the resulting `reshard_after_forward` bool path is already exercised by the merged fsdp_tp runs (and was on-node validated in #189–#191). No new on-node run required.

`release:minor` — user-facing CLI change (new flag; a legacy value set now hard-errors).

## Summary by Sourcery

Replace the FSDP sharding-strategy CLI enum with an explicit reshard-after-forward policy while keeping a hidden, deprecated alias for backward compatibility.

New Features:
- Introduce --reshard-after-forward {always,never} and --no-reshard-after-forward flags to control FSDP2 reshard_after_forward behavior via the CLI.

Enhancements:
- Normalize reshard_after_forward handling through a new string policy mapped to a bool in both tensor-parallel and HF FSDP paths.
- Remove obsolete hybrid_shard sharding options and clarify HSDP usage via existing --dp-replicate / --dp-shard flags.
- Simplify fsdp_tp parallelization by dropping the unused dp_mesh local and centralizing reshard policy resolution.

Documentation:
- Update fsdp-tp example documentation to describe the new reshard-after-forward policy flags, remove legacy sharding-strategy usage from commands, and regenerate the CLI help dump.

Tests:
- Add a dedicated test suite for the new reshard-after-forward CLI surface, its policy-to-bool mapping, legacy alias behavior, and help output visibility.