### PR TITLE
feat(fsdp_tp): consumed-token metrics + global_batch_size in config

### DIFF
--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -569,21 +569,26 @@ Per step, the example reports how many tokens were consumed:
 | `train/tps` | Global tokens/sec across all ranks |
 | `train/tps_per_gpu` | Per-rank tokens/sec |
 
-Global tokens/step is `batch × local_seq_len × (dp_size × tp)`, where the
-`dp_size × tp` factor counts the ranks holding **distinct** tokens:
+Global tokens/step is `batch × seq_len × dp_size`, using the **full,
+pre-shard** sequence length (`inp.shape[1]`) and the data-parallel degree:
 
-- **ezpz Transformer, `tp>1`** uses sequence parallelism, so each TP rank
-  holds a distinct slice of the sequence (see `_slice_for_sequence_parallel`)
-  — all `world_size` ranks process distinct tokens, and `dp_size × tp ==
-  world_size`.
-- **HF models (`--model owner/repo`)** force `tp=1` with **no** sequence
-  parallelism, so the TP-dim ranks see duplicate samples. Here `tp` is the
-  post-force value (`1`), so the multiplier collapses to `dp_size` and does
-  not overcount by the requested TP factor.
+- The model **input** is replicated across the TP group (the TP plan shards
+  only the embedding *output*, not the input), so `inp.shape[1]` is the full
+  sequence and is identical on every rank — the metric is rank-invariant
+  even though only rank 0 logs.
+- Under sequence parallelism the TP ranks hold *shards of the same*
+  sequence, not distinct sequences, so `tp` does **not** enter the global
+  count. (Summing each rank's local shard length recovers the full
+  sequence.) Scaling rank 0's SP-local shard by `tp` instead would overcount
+  by `dp_size × (tp − remainder)` whenever `seq_len` isn't divisible by `tp`
+  — and since `inp = x[:, :-1]`, an odd length is the common case.
+- **HF models (`--model owner/repo`)** force `tp=1` with no sequence
+  parallelism, so the TP-dim ranks see duplicate samples; multiplying by
+  `dp_size` (not `world_size`) counts each distinct token exactly once.
 
-At `tp=1` this is just `dp_size`. Note the global *batch* excludes `tp`
-entirely (tp ranks share the same samples), so under SP the token
-throughput and the global batch scale differently by a factor of `tp`.
+The global *batch* (samples/step) is `batch × dp_size` — the same `dp_size`
+factor — so tokens/step is simply the global batch times the sequence
+length, on every parallelism configuration.
 
 ## torch.compile
 

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -574,7 +574,7 @@ Per step, the example reports how many tokens were consumed:
 |--------|---------|
 | `train/tokens` | Global tokens processed **this step** |
 | `train/tokens_seen` | Cumulative tokens over the whole run (the standard x-axis for loss-vs-tokens curves) |
-| `train/tps` | Global tokens/sec across all ranks |
+| `train/tps` | Global tokens/sec (over distinct-data ranks — see the `dp_size` note below) |
 | `train/tps_per_gpu` | Per-rank tokens/sec |
 
 Global tokens/step is `batch × seq_len × dp_size`, using the **full,

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -569,12 +569,21 @@ Per step, the example reports how many tokens were consumed:
 | `train/tps` | Global tokens/sec across all ranks |
 | `train/tps_per_gpu` | Per-rank tokens/sec |
 
-Global tokens/step is `batch × local_seq_len × world_size` — **`world_size`,
-not `dp_size`**. Under sequence parallelism each TP rank holds a distinct
-slice of the sequence (see `_slice_for_sequence_parallel`), so the TP
-ranks process distinct tokens; using `dp_size` would undercount by a
-factor of `tp`. At `tp=1` the two are equal. This is the one place token
-throughput and the global *batch* (which excludes tp) scale differently.
+Global tokens/step is `batch × local_seq_len × (dp_size × tp)`, where the
+`dp_size × tp` factor counts the ranks holding **distinct** tokens:
+
+- **ezpz Transformer, `tp>1`** uses sequence parallelism, so each TP rank
+  holds a distinct slice of the sequence (see `_slice_for_sequence_parallel`)
+  — all `world_size` ranks process distinct tokens, and `dp_size × tp ==
+  world_size`.
+- **HF models (`--model owner/repo`)** force `tp=1` with **no** sequence
+  parallelism, so the TP-dim ranks see duplicate samples. Here `tp` is the
+  post-force value (`1`), so the multiplier collapses to `dp_size` and does
+  not overcount by the requested TP factor.
+
+At `tp=1` this is just `dp_size`. Note the global *batch* excludes `tp`
+entirely (tp ranks share the same samples), so under SP the token
+throughput and the global batch scale differently by a factor of `tp`.
 
 ## torch.compile
 

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -576,12 +576,14 @@ pre-shard** sequence length (`inp.shape[1]`) and the data-parallel degree:
   only the embedding *output*, not the input), so `inp.shape[1]` is the full
   sequence and is identical on every rank — the metric is rank-invariant
   even though only rank 0 logs.
-- Under sequence parallelism the TP ranks hold *shards of the same*
-  sequence, not distinct sequences, so `tp` does **not** enter the global
-  count. (Summing each rank's local shard length recovers the full
-  sequence.) Scaling rank 0's SP-local shard by `tp` instead would overcount
-  by `dp_size × (tp − remainder)` whenever `seq_len` isn't divisible by `tp`
-  — and since `inp = x[:, :-1]`, an odd length is the common case.
+- `tp` does **not** enter the global count: the TP ranks hold the *same*
+  sequence, not distinct sequences — as full-length logits under the default
+  `Replicate()` output, or as `Shard(1)` slices whose lengths sum to the full
+  sequence under `--loss-impl fused-linear`/`loss-parallel`. The tempting
+  `local_seq_len × dp_size × tp` over-counts: by a full `~tp×` in the default
+  eager path (there `local_seq_len` is the *gathered* full sequence), or by
+  `dp_size × (tp − remainder)` in the seq-sharded paths when `seq_len` isn't
+  divisible by `tp` (and `inp = x[:, :-1]` makes an odd length common).
 - **HF models (`--model owner/repo`)** force `tp=1` with no sequence
   parallelism, so the TP-dim ranks see duplicate samples; multiplying by
   `dp_size` (not `world_size`) counts each distinct token exactly once.

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -424,28 +424,28 @@ loads data, then runs the epoch loop.
 **Device mesh creation.** World size is split into `dp` x `tp`
 dimensions.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2185:2197"
---8<-- "src/ezpz/examples/fsdp_tp.py:2185:2197"
+```python title="src/ezpz/examples/fsdp_tp.py:2206:2218"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2206:2218"
 ```
 
 **HuggingFace dataset loading.** If `--dataset` is not `"mnist"` or
 `"random"`, a tokenized HF text dataset is loaded and the vocab size is
 synced to the tokenizer.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2199:2220"
---8<-- "src/ezpz/examples/fsdp_tp.py:2199:2220"
+```python title="src/ezpz/examples/fsdp_tp.py:2220:2241"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2220:2241"
 ```
 
 **Model construction and parallelization.** A `Transformer` is built
 from `ModelArgs`, moved to the device, optionally given a
 `MixedPrecision` config, and then handed to `parallelize`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2227:2306"
---8<-- "src/ezpz/examples/fsdp_tp.py:2227:2306"
+```python title="src/ezpz/examples/fsdp_tp.py:2248:2331"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2248:2331"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2461:2468"
---8<-- "src/ezpz/examples/fsdp_tp.py:2461:2468"
+```python title="src/ezpz/examples/fsdp_tp.py:2486:2493"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2486:2493"
 ```
 
 **DataLoader setup.** Three branches: MNIST, random synthetic data, or
@@ -453,15 +453,15 @@ HuggingFace datasets. For HF data, a `DistributedSampler` partitions
 across the DP dimension, and `TPBroadcastDataLoader` replicates batches
 within each TP group.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2623:2676"
---8<-- "src/ezpz/examples/fsdp_tp.py:2623:2676"
+```python title="src/ezpz/examples/fsdp_tp.py:2648:2701"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2648:2701"
 ```
 
 **Metric tracking.** An `ezpz.history.History` object is created for
 JSONL metric logging and optional distributed aggregation.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2688:2704"
---8<-- "src/ezpz/examples/fsdp_tp.py:2688:2704"
+```python title="src/ezpz/examples/fsdp_tp.py:2713:2729"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2713:2729"
 ```
 
 **Training loop.** Each batch is moved to device, split into
@@ -469,30 +469,30 @@ JSONL metric logging and optional distributed aggregation.
 `cross_entropy`. Labels are narrowed for sequence parallelism when
 needed. Gradient clipping is applied before `optimizer.step()`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2713:2965"
---8<-- "src/ezpz/examples/fsdp_tp.py:2713:2965"
+```python title="src/ezpz/examples/fsdp_tp.py:2744:3006"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2744:3006"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2863:2870"
---8<-- "src/ezpz/examples/fsdp_tp.py:2863:2870"
+```python title="src/ezpz/examples/fsdp_tp.py:2894:2901"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2894:2901"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2878:2890"
---8<-- "src/ezpz/examples/fsdp_tp.py:2878:2890"
+```python title="src/ezpz/examples/fsdp_tp.py:2909:2921"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2909:2921"
 ```
 
 After each step, timing and loss metrics are collected into a dict and
 passed to `history.update` and `history.log_metrics`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2956:2963"
---8<-- "src/ezpz/examples/fsdp_tp.py:2956:2963"
+```python title="src/ezpz/examples/fsdp_tp.py:2997:3004"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2997:3004"
 ```
 
 At the end of training, activation hooks are removed, a barrier syncs
 all ranks, and `history.finalize` writes the summary dataset on rank 0.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2966:2971"
---8<-- "src/ezpz/examples/fsdp_tp.py:2966:2971"
+```python title="src/ezpz/examples/fsdp_tp.py:3007:3012"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3007:3012"
 ```
 
 </details>
@@ -503,15 +503,15 @@ all ranks, and `history.finalize` writes the summary dataset on rank 0.
 distributed backend (including TP groups), determines the output
 directory, and dispatches to `train`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2975:3015"
---8<-- "src/ezpz/examples/fsdp_tp.py:2975:3015"
+```python title="src/ezpz/examples/fsdp_tp.py:3016:3056"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3016:3056"
 ```
 
 The `if __name__ == "__main__"` block parses args, runs `main`, cleans
 up distributed state, and exits.
 
-```python title="src/ezpz/examples/fsdp_tp.py:3018:3022"
---8<-- "src/ezpz/examples/fsdp_tp.py:3018:3022"
+```python title="src/ezpz/examples/fsdp_tp.py:3059:3063"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3059:3063"
 ```
 
 </details>
@@ -548,6 +548,33 @@ metrics["train/mfu"] = compute_mfu(_model_flops, t2 - t0)
 ```
 
 See [`ezpz.flops`](../python/Code-Reference/flops.md) for details.
+
+## Token Accounting
+
+The global batch size is resolved once in `train` and backfilled onto
+`args` so it lands in the run config (and the W&B config):
+
+```python
+# global batch = local batch × (dp_replicate × dp_shard); tp does NOT
+# scale the batch — tp ranks share the same samples:
+args.global_batch_size = args.batch_size * dp_replicate * dp_shard
+```
+
+Per step, the example reports how many tokens were consumed:
+
+| Metric | Meaning |
+|--------|---------|
+| `train/tokens` | Global tokens processed **this step** |
+| `train/tokens_seen` | Cumulative tokens over the whole run (the standard x-axis for loss-vs-tokens curves) |
+| `train/tps` | Global tokens/sec across all ranks |
+| `train/tps_per_gpu` | Per-rank tokens/sec |
+
+Global tokens/step is `batch × local_seq_len × world_size` — **`world_size`,
+not `dp_size`**. Under sequence parallelism each TP rank holds a distinct
+slice of the sequence (see `_slice_for_sequence_parallel`), so the TP
+ranks process distinct tokens; using `dp_size` would undercount by a
+factor of `tp`. At `tp=1` the two are equal. This is the one place token
+throughput and the global *batch* (which excludes tp) scale differently.
 
 ## torch.compile
 

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -424,28 +424,28 @@ loads data, then runs the epoch loop.
 **Device mesh creation.** World size is split into `dp` x `tp`
 dimensions.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2206:2218"
---8<-- "src/ezpz/examples/fsdp_tp.py:2206:2218"
+```python title="src/ezpz/examples/fsdp_tp.py:2215:2227"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2215:2227"
 ```
 
 **HuggingFace dataset loading.** If `--dataset` is not `"mnist"` or
 `"random"`, a tokenized HF text dataset is loaded and the vocab size is
 synced to the tokenizer.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2220:2241"
---8<-- "src/ezpz/examples/fsdp_tp.py:2220:2241"
+```python title="src/ezpz/examples/fsdp_tp.py:2229:2250"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2229:2250"
 ```
 
 **Model construction and parallelization.** A `Transformer` is built
 from `ModelArgs`, moved to the device, optionally given a
 `MixedPrecision` config, and then handed to `parallelize`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2248:2331"
---8<-- "src/ezpz/examples/fsdp_tp.py:2248:2331"
+```python title="src/ezpz/examples/fsdp_tp.py:2257:2342"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2257:2342"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2486:2493"
---8<-- "src/ezpz/examples/fsdp_tp.py:2486:2493"
+```python title="src/ezpz/examples/fsdp_tp.py:2497:2504"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2497:2504"
 ```
 
 **DataLoader setup.** Three branches: MNIST, random synthetic data, or
@@ -453,15 +453,15 @@ HuggingFace datasets. For HF data, a `DistributedSampler` partitions
 across the DP dimension, and `TPBroadcastDataLoader` replicates batches
 within each TP group.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2648:2701"
---8<-- "src/ezpz/examples/fsdp_tp.py:2648:2701"
+```python title="src/ezpz/examples/fsdp_tp.py:2659:2679"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2659:2679"
 ```
 
 **Metric tracking.** An `ezpz.history.History` object is created for
 JSONL metric logging and optional distributed aggregation.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2713:2729"
---8<-- "src/ezpz/examples/fsdp_tp.py:2713:2729"
+```python title="src/ezpz/examples/fsdp_tp.py:2724:2740"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2724:2740"
 ```
 
 **Training loop.** Each batch is moved to device, split into
@@ -469,30 +469,30 @@ JSONL metric logging and optional distributed aggregation.
 `cross_entropy`. Labels are narrowed for sequence parallelism when
 needed. Gradient clipping is applied before `optimizer.step()`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2744:3006"
---8<-- "src/ezpz/examples/fsdp_tp.py:2744:3006"
+```python title="src/ezpz/examples/fsdp_tp.py:2766:3041"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2766:3041"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2894:2901"
---8<-- "src/ezpz/examples/fsdp_tp.py:2894:2901"
+```python title="src/ezpz/examples/fsdp_tp.py:2916:2923"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2916:2923"
 ```
 
-```python title="src/ezpz/examples/fsdp_tp.py:2909:2921"
---8<-- "src/ezpz/examples/fsdp_tp.py:2909:2921"
+```python title="src/ezpz/examples/fsdp_tp.py:2931:2943"
+--8<-- "src/ezpz/examples/fsdp_tp.py:2931:2943"
 ```
 
 After each step, timing and loss metrics are collected into a dict and
 passed to `history.update` and `history.log_metrics`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:2997:3004"
---8<-- "src/ezpz/examples/fsdp_tp.py:2997:3004"
+```python title="src/ezpz/examples/fsdp_tp.py:3032:3039"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3032:3039"
 ```
 
 At the end of training, activation hooks are removed, a barrier syncs
 all ranks, and `history.finalize` writes the summary dataset on rank 0.
 
-```python title="src/ezpz/examples/fsdp_tp.py:3007:3012"
---8<-- "src/ezpz/examples/fsdp_tp.py:3007:3012"
+```python title="src/ezpz/examples/fsdp_tp.py:3042:3047"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3042:3047"
 ```
 
 </details>
@@ -503,15 +503,15 @@ all ranks, and `history.finalize` writes the summary dataset on rank 0.
 distributed backend (including TP groups), determines the output
 directory, and dispatches to `train`.
 
-```python title="src/ezpz/examples/fsdp_tp.py:3016:3056"
---8<-- "src/ezpz/examples/fsdp_tp.py:3016:3056"
+```python title="src/ezpz/examples/fsdp_tp.py:3051:3091"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3051:3091"
 ```
 
 The `if __name__ == "__main__"` block parses args, runs `main`, cleans
 up distributed state, and exits.
 
-```python title="src/ezpz/examples/fsdp_tp.py:3059:3063"
---8<-- "src/ezpz/examples/fsdp_tp.py:3059:3063"
+```python title="src/ezpz/examples/fsdp_tp.py:3094:3098"
+--8<-- "src/ezpz/examples/fsdp_tp.py:3094:3098"
 ```
 
 </details>
@@ -559,6 +559,14 @@ The global batch size is resolved once in `train` and backfilled onto
 # scale the batch — tp ranks share the same samples:
 args.global_batch_size = args.batch_size * dp_replicate * dp_shard
 ```
+
+This is the general Megatron/NeMo global-batch formula —
+`micro_batch × world_size × grad_accum / (tensor_parallel ×
+pipeline_parallel)` — specialized to this example, which has no pipeline
+parallelism and no gradient accumulation (both factors are `1`), and where
+`world_size / tp == dp_replicate × dp_shard`. Add a fine-tuning loop with
+gradient accumulation or a pipeline dimension and this would need the
+matching `× grad_accum` / `÷ pipeline_parallel` factor.
 
 Per step, the example reports how many tokens were consumed:
 

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2991,7 +2991,8 @@ def train(
                 metrics["train/mfu"] = compute_mfu(_model_flops, dt_step)
             # Throughput.
             #   - train/tps_per_gpu : per-rank tokens/sec (torchtitan's `tgs`)
-            #   - train/tps         : global tokens/sec across ALL ranks
+            #   - train/tps         : global tokens/sec (over distinct-data
+            #                         ranks; see the dpsize rationale below)
             # tokens_per_rank uses `local_seq_len` (= pred.shape[1]) because it
             # describes THIS rank's work. Global tokens, however, are computed
             # from the FULL pre-shard sequence length `inp.shape[1]` times the

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2983,24 +2983,29 @@ def train(
             # Throughput.
             #   - train/tps_per_gpu : per-rank tokens/sec (torchtitan's `tgs`)
             #   - train/tps         : global tokens/sec across ALL ranks
-            # tokens_per_rank uses `local_seq_len` (this rank's post-SP-slice
-            # length) because it describes THIS rank's work. Global tokens,
-            # however, are computed from the FULL pre-shard sequence length
-            # `inp.shape[1]` times the data-parallel degree `dpsize`:
-            #   * `inp` is Replicate() across the tp group (the TP plan shards
-            #     only the embedding OUTPUT, not the input), so inp.shape[1] is
-            #     the full sequence and is identical on every rank — the metric
-            #     is rank-invariant even though only rank 0 logs.
-            #   * Summing local_seq_len over tp ranks also equals inp.shape[1]
-            #     (SP hands base+1 tokens to the first `remainder` ranks and
-            #     base to the rest), so batch * inp.shape[1] * dpsize is the
-            #     EXACT global token count. Scaling rank-0's local_seq_len by
-            #     tp instead overcounts by dpsize*(tp - remainder) whenever the
-            #     sequence isn't divisible by tp (and inp = x[:, :-1] makes an
-            #     odd length the common case).
-            #   * On the HF path (tp forced to 1, no SP) the tp-dim ranks see
-            #     DUPLICATE samples; multiplying by dpsize (not world_size)
-            #     counts each distinct token exactly once.
+            # tokens_per_rank uses `local_seq_len` (= pred.shape[1]) because it
+            # describes THIS rank's work. Global tokens, however, are computed
+            # from the FULL pre-shard sequence length `inp.shape[1]` times the
+            # data-parallel degree `dpsize`. `inp` is Replicate() across the tp
+            # group (the TP plan shards only the embedding OUTPUT, never the
+            # input), so inp.shape[1] is the full sequence, identical on every
+            # rank — the metric is exact and rank-invariant even though only
+            # rank 0 logs. tp does NOT enter: the tp ranks hold the SAME
+            # sequence (as full-length logits under the default Replicate()
+            # output, or as Shard(1) slices whose lengths sum to inp.shape[1]
+            # under fused-linear / loss-parallel), never distinct sequences.
+            #
+            # Why not `local_seq_len * dpsize * tp`? It over-counts, by a margin
+            # that depends on the loss path:
+            #   * default (eager, Replicate() output): local_seq_len is the FULL
+            #     gathered sequence, so that formula is a full ~tp x over-count.
+            #   * seq-sharded output (fused-linear / loss-parallel): local_seq_len
+            #     is this rank's shard; scaling it by tp over-counts by
+            #     dpsize*(tp - remainder) when the sequence isn't divisible by tp
+            #     (and inp = x[:, :-1] makes an odd length common).
+            # On the HF path (tp forced to 1, no SP) the tp-dim ranks see
+            # DUPLICATE samples; multiplying by dpsize (not world_size) counts
+            # each distinct token exactly once.
             tokens_per_rank = args.batch_size * local_seq_len
             # Global tokens processed THIS step across all distinct-data ranks.
             tokens_this_step = args.batch_size * inp.shape[1] * dpsize

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2739,10 +2739,9 @@ def train(
     global_step = 0
     # Cumulative count of training tokens consumed across the whole run
     # (summed global tokens/step). Logged as train/tokens_seen — the standard
-    # x-axis for loss-vs-tokens curves. See the metrics block for the
-    # per-step global-token computation (dpsize * effective-tp = number of
-    # ranks holding distinct tokens; == world_size under SP, == dpsize on the
-    # HF no-SP path where tp was forced to 1).
+    # x-axis for loss-vs-tokens curves. See the metrics block: global
+    # tokens/step = batch * full_seq_len * dpsize (full pre-shard seq length,
+    # not the SP-local shard, so it's exact and rank-invariant).
     tokens_seen = 0
     # Push the RESOLVED CLI args to the wandb run config now — after every
     # args mutation (HF tp-force, loss_impl normalization) and after the
@@ -2981,27 +2980,30 @@ def train(
             if _model_flops > 0 and dt_step > 0:
                 metrics["train/tflops"] = _model_flops / dt_step / 1e12
                 metrics["train/mfu"] = compute_mfu(_model_flops, dt_step)
-            # Throughput. `--batch-size` is the PER-DP-RANK micro-batch and
-            # `local_seq_len` is this rank's (post-SP-slice) sequence length,
-            # so tokens processed per rank per step is batch_size *
-            # local_seq_len.
+            # Throughput.
             #   - train/tps_per_gpu : per-rank tokens/sec (torchtitan's `tgs`)
             #   - train/tps         : global tokens/sec across ALL ranks
-            # The global multiplier is the number of ranks that hold DISTINCT
-            # tokens, which is dpsize * (effective) args.tp:
-            #   * ezpz Transformer + tp>1 uses sequence parallelism, so each TP
-            #     rank holds a distinct seq shard (labels sliced via
-            #     _slice_for_sequence_parallel) -> all world_size ranks distinct;
-            #     dpsize * args.tp == world_size (no change from before).
-            #   * HF models force args.tp=1 with NO SP (see the HF branch), while
-            #     dpsize was computed with the ORIGINAL tp, so the tp-dim ranks
-            #     see DUPLICATE samples. Here args.tp is the post-force value (1),
-            #     so dpsize * args.tp == dpsize and we don't overcount by ~tp.
-            # Using world_size unconditionally would overstate HF-path tokens by
-            # the requested TP factor.
+            # tokens_per_rank uses `local_seq_len` (this rank's post-SP-slice
+            # length) because it describes THIS rank's work. Global tokens,
+            # however, are computed from the FULL pre-shard sequence length
+            # `inp.shape[1]` times the data-parallel degree `dpsize`:
+            #   * `inp` is Replicate() across the tp group (the TP plan shards
+            #     only the embedding OUTPUT, not the input), so inp.shape[1] is
+            #     the full sequence and is identical on every rank — the metric
+            #     is rank-invariant even though only rank 0 logs.
+            #   * Summing local_seq_len over tp ranks also equals inp.shape[1]
+            #     (SP hands base+1 tokens to the first `remainder` ranks and
+            #     base to the rest), so batch * inp.shape[1] * dpsize is the
+            #     EXACT global token count. Scaling rank-0's local_seq_len by
+            #     tp instead overcounts by dpsize*(tp - remainder) whenever the
+            #     sequence isn't divisible by tp (and inp = x[:, :-1] makes an
+            #     odd length the common case).
+            #   * On the HF path (tp forced to 1, no SP) the tp-dim ranks see
+            #     DUPLICATE samples; multiplying by dpsize (not world_size)
+            #     counts each distinct token exactly once.
             tokens_per_rank = args.batch_size * local_seq_len
             # Global tokens processed THIS step across all distinct-data ranks.
-            tokens_this_step = tokens_per_rank * dpsize * args.tp
+            tokens_this_step = args.batch_size * inp.shape[1] * dpsize
             tokens_seen += tokens_this_step
             # Cumulative consumed training tokens — the standard x-axis for
             # loss curves. Accumulated every step (this block runs each step),

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2167,6 +2167,27 @@ def train(
         dp_shard=args.dp_shard,
     )
     dpsize = dp_replicate * dp_shard  # == flattened "dp" size
+    # Global batch size = per-DP-rank micro-batch x data-parallel degree.
+    # Data parallelism is dp_replicate * dp_shard (== dpsize): BOTH the HSDP
+    # replicate dim and the FSDP shard dim get a distinct data slice (the
+    # DistributedSampler shards over num_replicas=dpsize). TP is NOT data
+    # parallel — tp ranks process the SAME batch (sharded across the hidden
+    # dim), so tp does not enter here. Backfilled onto args so it lands in the
+    # wandb run config (History logs vars(args); we also push it to
+    # wandb.config below). Computed here, not in parse_args, because the
+    # default --dp-shard -1 ("use all remaining ranks") only resolves to a
+    # concrete degree once WORLD_SIZE is known.
+    args.global_batch_size = args.batch_size * dpsize
+    if ezpz.get_rank() == 0:
+        logger.info(
+            "global_batch_size=%d (batch_size=%d x dp_replicate=%d x "
+            "dp_shard=%d; tp=%d does not scale the batch)",
+            args.global_batch_size,
+            args.batch_size,
+            dp_replicate,
+            dp_shard,
+            args.tp,
+        )
     # fused-linear (Liger/Cut-CE): needs the model's hidden states + output
     # weight, so only the ezpz Transformer (not HF models) and — for now —
     # only tp=1 (tp>1 needs vocab-shard composition, gated to a follow-up).
@@ -2255,6 +2276,10 @@ def train(
         from dataclasses import asdict
 
         wandb.config.update(asdict(config))  # type:ignore
+        # Also surface the resolved CLI args (incl. the backfilled
+        # global_batch_size) in the run config. allow_val_change since some
+        # keys may already be present from main()'s init.
+        wandb.config.update(vars(args), allow_val_change=True)  # type:ignore
 
     device_type = ezpz.distributed.get_torch_device_type()
     device = (
@@ -2710,6 +2735,12 @@ def train(
     # x = torch.tensor((args.batch_size, args.seq_len))
     x = torch.tensor(0)
     global_step = 0
+    # Cumulative count of training tokens consumed across the whole run
+    # (summed global tokens/step). Logged as train/tokens_seen — the standard
+    # x-axis for loss-vs-tokens curves. See the metrics block for the
+    # per-step global-token computation (world_size, not dp_size, because SP
+    # gives each tp rank a distinct sequence shard).
+    tokens_seen = 0
     for epoch in range(args.epochs):
         if sampler is not None:
             sampler.set_epoch(epoch)
@@ -2947,10 +2978,20 @@ def train(
             # _slice_for_sequence_parallel), so the TP ranks process distinct
             # tokens too. Using dp_size would undercount global tps by ~tp.
             # At tp=1, world_size == dp_size so this is unchanged.
+            tokens_per_rank = args.batch_size * local_seq_len
+            # Global tokens processed THIS step across all ranks. world_size
+            # (not dp_size): under SP each tp rank holds a distinct seq shard,
+            # so tp ranks consume distinct tokens (at tp=1 these are equal).
+            tokens_this_step = tokens_per_rank * world_size
+            tokens_seen += tokens_this_step
+            # Cumulative consumed training tokens — the standard x-axis for
+            # loss curves. Accumulated every step (this block runs each step),
+            # so it's exact regardless of the metrics-logging interval.
+            metrics["train/tokens"] = tokens_this_step
+            metrics["train/tokens_seen"] = tokens_seen
             if dt_step > 0:
-                tokens_per_rank = args.batch_size * local_seq_len
                 metrics["train/tps_per_gpu"] = tokens_per_rank / dt_step
-                metrics["train/tps"] = tokens_per_rank * world_size / dt_step
+                metrics["train/tps"] = tokens_this_step / dt_step
             # Device memory: empty on CPU/MPS, 4 keys on CUDA/XPU.
             metrics |= ezpz.get_memory_metrics(prefix="train/")
             history.update(metrics, summarize=False)

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2177,6 +2177,15 @@ def train(
     # wandb.config below). Computed here, not in parse_args, because the
     # default --dp-shard -1 ("use all remaining ranks") only resolves to a
     # concrete degree once WORLD_SIZE is known.
+    #
+    # This is the general Megatron/NeMo formula
+    #   gbs = micro_batch * world_size * grad_accum
+    #         / (tensor_parallel * pipeline_parallel)
+    # specialized to this example: there is no pipeline parallelism
+    # (pipeline_parallel = 1) and no gradient accumulation (grad_accum = 1 —
+    # zero_grad/backward/step run every iteration), and world_size / tp ==
+    # dp_replicate * dp_shard == dpsize. If either is ever added, this must
+    # gain the corresponding factor (* grad_accum, / pipeline_parallel).
     args.global_batch_size = args.batch_size * dpsize
     if ezpz.get_rank() == 0:
         logger.info(

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2268,6 +2268,12 @@ def train(
     hist_samples = int(os.environ.get("EZPZ_HIST_SAMPLES", "20000"))
     dataset_tag = args.dataset.lower().replace("/", "_")
     # Update wandb config with model args (run already initialised in main).
+    # NOTE: `config` (ModelArgs) is not mutated later, so it's safe to push
+    # here. The resolved CLI `args`, however, ARE still mutated below (the HF
+    # branch forces args.tp=1; args.loss_impl can be normalized to
+    # "compiled"), so vars(args) is pushed just before the training loop
+    # instead (see below) — logging it here would record the requested
+    # settings rather than the effective ones actually used.
     if (
         ezpz.get_rank() == 0
         and wandb is not None
@@ -2276,10 +2282,6 @@ def train(
         from dataclasses import asdict
 
         wandb.config.update(asdict(config))  # type:ignore
-        # Also surface the resolved CLI args (incl. the backfilled
-        # global_batch_size) in the run config. allow_val_change since some
-        # keys may already be present from main()'s init.
-        wandb.config.update(vars(args), allow_val_change=True)  # type:ignore
 
     device_type = ezpz.distributed.get_torch_device_type()
     device = (
@@ -2742,6 +2744,17 @@ def train(
     # ranks holding distinct tokens; == world_size under SP, == dpsize on the
     # HF no-SP path where tp was forced to 1).
     tokens_seen = 0
+    # Push the RESOLVED CLI args to the wandb run config now — after every
+    # args mutation (HF tp-force, loss_impl normalization) and after the
+    # global_batch_size backfill — so the logged config reflects the settings
+    # actually used for the rest of training, not the requested ones.
+    if (
+        ezpz.get_rank() == 0
+        and wandb is not None
+        and getattr(wandb, "run", None) is not None
+    ):
+        # allow_val_change since some keys may already be present from main().
+        wandb.config.update(vars(args), allow_val_change=True)  # type:ignore
     for epoch in range(args.epochs):
         if sampler is not None:
             sampler.set_epoch(epoch)

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2738,8 +2738,9 @@ def train(
     # Cumulative count of training tokens consumed across the whole run
     # (summed global tokens/step). Logged as train/tokens_seen — the standard
     # x-axis for loss-vs-tokens curves. See the metrics block for the
-    # per-step global-token computation (world_size, not dp_size, because SP
-    # gives each tp rank a distinct sequence shard).
+    # per-step global-token computation (dpsize * effective-tp = number of
+    # ranks holding distinct tokens; == world_size under SP, == dpsize on the
+    # HF no-SP path where tp was forced to 1).
     tokens_seen = 0
     for epoch in range(args.epochs):
         if sampler is not None:
@@ -2973,16 +2974,21 @@ def train(
             # local_seq_len.
             #   - train/tps_per_gpu : per-rank tokens/sec (torchtitan's `tgs`)
             #   - train/tps         : global tokens/sec across ALL ranks
-            # Multiply by world_size, not dp_size: under sequence parallelism
-            # each TP rank holds a DISTINCT seq shard (labels are sliced via
-            # _slice_for_sequence_parallel), so the TP ranks process distinct
-            # tokens too. Using dp_size would undercount global tps by ~tp.
-            # At tp=1, world_size == dp_size so this is unchanged.
+            # The global multiplier is the number of ranks that hold DISTINCT
+            # tokens, which is dpsize * (effective) args.tp:
+            #   * ezpz Transformer + tp>1 uses sequence parallelism, so each TP
+            #     rank holds a distinct seq shard (labels sliced via
+            #     _slice_for_sequence_parallel) -> all world_size ranks distinct;
+            #     dpsize * args.tp == world_size (no change from before).
+            #   * HF models force args.tp=1 with NO SP (see the HF branch), while
+            #     dpsize was computed with the ORIGINAL tp, so the tp-dim ranks
+            #     see DUPLICATE samples. Here args.tp is the post-force value (1),
+            #     so dpsize * args.tp == dpsize and we don't overcount by ~tp.
+            # Using world_size unconditionally would overstate HF-path tokens by
+            # the requested TP factor.
             tokens_per_rank = args.batch_size * local_seq_len
-            # Global tokens processed THIS step across all ranks. world_size
-            # (not dp_size): under SP each tp rank holds a distinct seq shard,
-            # so tp ranks consume distinct tokens (at tp=1 these are equal).
-            tokens_this_step = tokens_per_rank * world_size
+            # Global tokens processed THIS step across all distinct-data ranks.
+            tokens_this_step = tokens_per_rank * dpsize * args.tp
             tokens_seen += tokens_this_step
             # Cumulative consumed training tokens — the standard x-axis for
             # loss curves. Accumulated every step (this block runs each step),

--- a/tests/test_fsdp_tp_dp_degrees.py
+++ b/tests/test_fsdp_tp_dp_degrees.py
@@ -179,69 +179,96 @@ class TestGlobalBatchSize:
 
 
 class TestConsumedTokensAccounting:
-    """Locks the token-accounting invariants used by train()'s metrics.
+    """Locks the token-accounting invariant used by train()'s metrics.
 
-    train() logs global tokens as `batch * local_seq_len * (dp_size * tp)`
-    per step (cumulative in train/tokens_seen), where `dp_size * tp` counts
-    the ranks that hold DISTINCT tokens. This equals WORLD_SIZE only on the
-    sequence-parallel path (ezpz Transformer, tp>1: each tp rank owns a
-    distinct seq shard). On the HF path, train() forces tp=1 with NO SP, so
-    the tp-dim ranks see duplicate samples and the correct multiplier is
-    dp_size (== dp_size * 1). Contrast with the global-batch-size formula,
-    which always uses dp_size and excludes tp entirely. These are
-    pure-arithmetic checks of that intent (the loop itself needs a live run).
+    train() logs global tokens/step as `batch * inp.shape[1] * dpsize`,
+    where inp.shape[1] is the FULL pre-shard sequence length (the model
+    input is Replicate() across the tp group; only the embedding OUTPUT is
+    sequence-sharded). tp does NOT enter: under SP the tp ranks hold shards
+    of the SAME sequence (summing the shards recovers the full length), and
+    on the HF path tp is forced to 1 with no SP. So the token count is
+    exactly the global batch (batch * dpsize) times the sequence length, on
+    every parallelism config.
+
+    The earlier `local_seq_len * dpsize * tp` framing overcounted by
+    `dpsize * (tp - remainder)` whenever seq_len % tp != 0 — and since
+    inp = x[:, :-1] makes seq_len odd, that was the common case. These are
+    pure-arithmetic checks of the corrected formula (the loop needs a live
+    run to exercise the tensors themselves).
     """
 
-    def _tok_factor(self, m, *, world_size, tp, effective_tp, dp_replicate,
-                    dp_shard):
-        """Distinct-token rank count as train() computes it: dpsize *
-        effective_tp, where dpsize comes from the ORIGINAL tp (that's what
-        the DistributedSampler shards over) and effective_tp is the
-        post-force value used at the metrics block."""
+    def _global_tokens(self, m, *, batch, seq_len, world_size, tp,
+                       dp_replicate, dp_shard):
+        """Global tokens/step exactly as train() computes it:
+        batch * seq_len * dpsize, where seq_len is the full (pre-shard)
+        length and dpsize is resolved from the ORIGINAL tp."""
         rep, shard = m._resolve_dp_degrees(
             world_size=world_size, tp=tp, dp_replicate=dp_replicate,
             dp_shard=dp_shard,
         )
-        return (rep * shard) * effective_tp
+        return batch * seq_len * (rep * shard)
 
-    def test_sp_path_equals_world_size(self):
-        """ezpz Transformer, tp>1 (SP): effective_tp == tp, so the multiplier
-        is dpsize * tp == world_size (all ranks hold distinct tokens)."""
+    def test_sp_path_seq_divisible_by_tp(self):
+        """ezpz Transformer, tp=2, seq divisible by tp: 8 ranks → dpsize=4.
+        Global tokens = batch * seq * 4 (tp does not enter)."""
         m = _import_fsdp_tp()
-        # 8 ranks, tp=2, SP active → effective_tp=2 → factor=4*2=8=world_size.
-        assert self._tok_factor(
-            m, world_size=8, tp=2, effective_tp=2, dp_replicate=1, dp_shard=-1
-        ) == 8
+        assert self._global_tokens(
+            m, batch=2, seq_len=4096, world_size=8, tp=2,
+            dp_replicate=1, dp_shard=-1,
+        ) == 2 * 4096 * 4
+
+    def test_sp_path_seq_not_divisible_by_tp(self):
+        """The bug Copilot flagged: seq_len=4095, tp=2. The full-length
+        formula gives batch*4095*dpsize exactly; the old shard*tp framing
+        would have given batch*4096*dpsize (overcount by dpsize per step)."""
+        m = _import_fsdp_tp()
+        batch, seq, tp, dpsize = 2, 4095, 2, 4
+        exact = self._global_tokens(
+            m, batch=batch, seq_len=seq, world_size=8, tp=tp,
+            dp_replicate=1, dp_shard=-1,
+        )
+        assert exact == batch * seq * dpsize          # 2 * 4095 * 4 = 32760
+        # Old (buggy) framing: batch * rank0_shard * dpsize * tp, where
+        #   rank0_shard = ceil(seq/tp) = 2048  →  batch*2048*dpsize*2 = 32768,
+        # overcounting the true 32760 by batch*dpsize*(tp - remainder) = 8.
+        rank0_shard = (seq + tp - 1) // tp            # ceil(4095/2) = 2048
+        buggy = batch * rank0_shard * dpsize * tp
+        remainder = seq % tp                          # 1
+        assert buggy == exact + batch * dpsize * (tp - remainder)
+        assert buggy != exact
 
     def test_hf_forced_tp1_uses_dp_size_not_world_size(self):
-        """HF path forces tp=1 with NO SP: dpsize was computed with the
-        ORIGINAL tp (=2), but effective_tp=1, so the multiplier is dpsize
-        (=4), NOT world_size (=8). Using world_size would 2x-overcount."""
+        """HF path forces tp=1 with NO SP: dpsize was resolved with the
+        ORIGINAL tp (=2), so global tokens use dpsize (=4), NOT world_size
+        (=8). Multiplying by world_size would 2x-overcount duplicated ranks."""
         m = _import_fsdp_tp()
-        factor = self._tok_factor(
-            m, world_size=8, tp=2, effective_tp=1, dp_replicate=1, dp_shard=-1
+        tokens = self._global_tokens(
+            m, batch=2, seq_len=1024, world_size=8, tp=2,
+            dp_replicate=1, dp_shard=-1,
         )
-        assert factor == 4          # dpsize, not world_size
-        assert factor != 8          # the bug Codex flagged (would overcount)
+        assert tokens == 2 * 1024 * 4          # dpsize=4, not world_size=8
+        assert tokens != 2 * 1024 * 8
 
-    def test_tp1_path_equals_dp_size_and_world_size(self):
-        """Plain tp=1: dpsize == world_size and effective_tp=1, so all three
-        framings agree (regression guard for the common path)."""
+    def test_tp1_path(self):
+        """Plain tp=1: dpsize == world_size, regression guard for the
+        common path."""
         m = _import_fsdp_tp()
-        assert self._tok_factor(
-            m, world_size=8, tp=1, effective_tp=1, dp_replicate=1, dp_shard=-1
-        ) == 8
+        assert self._global_tokens(
+            m, batch=2, seq_len=512, world_size=8, tp=1,
+            dp_replicate=1, dp_shard=-1,
+        ) == 2 * 512 * 8
 
-    def test_tps_and_gbs_differ_by_tp_under_sp(self):
-        """GBS excludes tp (samples), token-throughput includes it (SP seq
-        shards). On the SP path the two scalings differ by exactly tp."""
+    def test_tokens_equal_global_batch_times_seq(self):
+        """Tokens/step == global_batch * seq_len on every config: the token
+        multiplier (dpsize) is exactly the global-batch multiplier."""
         m = _import_fsdp_tp()
-        batch, world_size, tp = 2, 8, 2
+        batch, seq, world_size, tp = 3, 2048, 16, 2
         rep, shard = m._resolve_dp_degrees(
-            world_size=world_size, tp=tp, dp_replicate=1, dp_shard=-1
+            world_size=world_size, tp=tp, dp_replicate=2, dp_shard=-1
         )
-        gbs_factor = rep * shard              # dp_size = 4 (samples)
-        tok_factor = gbs_factor * tp          # 8 = world_size (SP, distinct)
-        assert tok_factor == world_size
-        assert batch * gbs_factor == 8        # global batch (samples/step)
-        assert batch * tok_factor == 16       # global-token rank multiplier
+        gbs = batch * rep * shard                     # global batch (samples)
+        tokens = self._global_tokens(
+            m, batch=batch, seq_len=seq, world_size=world_size, tp=tp,
+            dp_replicate=2, dp_shard=-1,
+        )
+        assert tokens == gbs * seq

--- a/tests/test_fsdp_tp_dp_degrees.py
+++ b/tests/test_fsdp_tp_dp_degrees.py
@@ -114,3 +114,89 @@ class TestDpArgParsing:
         args = m.parse_args(["--dp-replicate", "3"])
         assert isinstance(args.dp_replicate, int)
         assert isinstance(args.dp_shard, int)
+
+
+class TestGlobalBatchSize:
+    """global_batch_size = local_batch * dp_replicate * dp_shard.
+
+    Data parallelism spans BOTH the HSDP replicate dim and the FSDP shard
+    dim (the DistributedSampler shards over num_replicas = dp_replicate *
+    dp_shard). TP is NOT data parallel — tp ranks share the same batch — so
+    it must NOT scale the global batch. train() backfills
+    args.global_batch_size = args.batch_size * (dp_replicate * dp_shard);
+    these tests lock that formula via the resolver it's built on.
+    """
+
+    def _gbs(self, m, *, batch, world_size, tp, dp_replicate, dp_shard):
+        rep, shard = m._resolve_dp_degrees(
+            world_size=world_size,
+            tp=tp,
+            dp_replicate=dp_replicate,
+            dp_shard=dp_shard,
+        )
+        return batch * rep * shard
+
+    def test_flat_fsdp_tp1(self):
+        """8 ranks, tp=1, defaults → dp=8; gbs = batch * 8."""
+        m = _import_fsdp_tp()
+        assert self._gbs(
+            m, batch=2, world_size=8, tp=1, dp_replicate=1, dp_shard=-1
+        ) == 16
+
+    def test_tp_does_not_scale_batch(self):
+        """tp>1 must NOT multiply the batch: 8 ranks, tp=2 → dp=4; gbs=batch*4.
+
+        Contrast with world_size=8: if tp were (wrongly) included, gbs would
+        be batch*8. It must be batch*4.
+        """
+        m = _import_fsdp_tp()
+        assert self._gbs(
+            m, batch=2, world_size=8, tp=2, dp_replicate=1, dp_shard=-1
+        ) == 8  # 2 * (dp_replicate=1 * dp_shard=4), NOT 2*8
+
+    def test_hsdp_both_dp_dims_count(self):
+        """Both replicate and shard scale the batch: 16 ranks, tp=2,
+        replicate=2 → shard=4, dp=8; gbs = batch * 8 (NOT batch * 2)."""
+        m = _import_fsdp_tp()
+        assert self._gbs(
+            m, batch=3, world_size=16, tp=2, dp_replicate=2, dp_shard=-1
+        ) == 24  # 3 * (2 * 4)
+
+    def test_single_rank(self):
+        m = _import_fsdp_tp()
+        assert self._gbs(
+            m, batch=4, world_size=1, tp=1, dp_replicate=1, dp_shard=-1
+        ) == 4
+
+
+class TestConsumedTokensAccounting:
+    """Locks the token-accounting invariants used by train()'s metrics.
+
+    train() logs global tokens as `batch * local_seq_len * world_size` per
+    step (cumulative in train/tokens_seen). Global tokens use WORLD_SIZE, not
+    dp_size — contrast with the global-batch-size formula, which uses dp_size
+    (excludes tp). Under sequence parallelism each tp rank holds a distinct
+    seq shard, so tp ranks consume distinct tokens; hence world_size here.
+    These are pure-arithmetic checks of that intent (the loop itself needs a
+    live run to exercise).
+    """
+
+    def test_global_tokens_per_step_uses_world_size(self):
+        # 8 ranks, tp=2: world_size=8. Global tokens/step = batch*seq*8,
+        # NOT batch*seq*dp_size (which would be batch*seq*4).
+        batch, seq, world_size = 2, 4096, 8
+        assert batch * seq * world_size == 65536
+
+    def test_tps_and_gbs_differ_by_tp_under_sp(self):
+        """GBS excludes tp (samples), token-throughput includes it (SP seq
+        shards). At tp>1 the two scalings must differ by exactly tp."""
+        m = _import_fsdp_tp()
+        batch, world_size, tp = 2, 8, 2
+        rep, shard = m._resolve_dp_degrees(
+            world_size=world_size, tp=tp, dp_replicate=1, dp_shard=-1
+        )
+        gbs_factor = rep * shard          # dp_size = 4 (samples)
+        tok_factor = world_size           # 8 (distinct-token ranks, SP)
+        assert tok_factor == gbs_factor * tp
+        assert batch * gbs_factor == 8    # global batch (samples/step)
+        assert batch * tok_factor == 16   # global-token rank multiplier

--- a/tests/test_fsdp_tp_dp_degrees.py
+++ b/tests/test_fsdp_tp_dp_degrees.py
@@ -199,13 +199,16 @@ class TestConsumedTokensAccounting:
     run to exercise the tensors themselves).
     """
 
-    def _global_tokens(self, m, *, batch, seq_len, world_size, tp,
-                       dp_replicate, dp_shard):
+    def _global_tokens(
+        self, m, *, batch, seq_len, world_size, tp, dp_replicate, dp_shard
+    ):
         """Global tokens/step exactly as train() computes it:
         batch * seq_len * dpsize, where seq_len is the full (pre-shard)
         length and dpsize is resolved from the ORIGINAL tp."""
         rep, shard = m._resolve_dp_degrees(
-            world_size=world_size, tp=tp, dp_replicate=dp_replicate,
+            world_size=world_size,
+            tp=tp,
+            dp_replicate=dp_replicate,
             dp_shard=dp_shard,
         )
         return batch * seq_len * (rep * shard)

--- a/tests/test_fsdp_tp_dp_degrees.py
+++ b/tests/test_fsdp_tp_dp_degrees.py
@@ -190,9 +190,11 @@ class TestConsumedTokensAccounting:
     exactly the global batch (batch * dpsize) times the sequence length, on
     every parallelism config.
 
-    The earlier `local_seq_len * dpsize * tp` framing overcounted by
-    `dpsize * (tp - remainder)` whenever seq_len % tp != 0 — and since
-    inp = x[:, :-1] makes seq_len odd, that was the common case. These are
+    The earlier `local_seq_len * dpsize * tp` framing overcounted, by an
+    amount that depends on the loss path: a full ~tp x in the default eager
+    path (there local_seq_len is the gathered FULL sequence, Replicate()
+    output), or dpsize * (tp - remainder) in the seq-sharded paths
+    (fused-linear / loss-parallel) when seq_len % tp != 0. These are
     pure-arithmetic checks of the corrected formula (the loop needs a live
     run to exercise the tensors themselves).
     """
@@ -218,9 +220,10 @@ class TestConsumedTokensAccounting:
         ) == 2 * 4096 * 4
 
     def test_sp_path_seq_not_divisible_by_tp(self):
-        """The bug Copilot flagged: seq_len=4095, tp=2. The full-length
-        formula gives batch*4095*dpsize exactly; the old shard*tp framing
-        would have given batch*4096*dpsize (overcount by dpsize per step)."""
+        """Seq-sharded remainder case (one facet of what Copilot flagged):
+        seq_len=4095, tp=2. The full-length formula gives batch*4095*dpsize
+        exactly; the old shard*tp framing would have given batch*4096*dpsize
+        (overcount by dpsize per step)."""
         m = _import_fsdp_tp()
         batch, seq, tp, dpsize = 2, 4095, 2, 4
         exact = self._global_tokens(

--- a/tests/test_fsdp_tp_dp_degrees.py
+++ b/tests/test_fsdp_tp_dp_degrees.py
@@ -162,6 +162,15 @@ class TestGlobalBatchSize:
             m, batch=3, world_size=16, tp=2, dp_replicate=2, dp_shard=-1
         ) == 24  # 3 * (2 * 4)
 
+    def test_explicit_dp_shard(self):
+        """Explicit --dp-shard (not -1) still scales the batch: 8 ranks,
+        tp=2, replicate=1, shard=4 → dp=4; gbs = batch * 4. (Product
+        constraint: 1 * 4 * 2 == world_size=8.)"""
+        m = _import_fsdp_tp()
+        assert self._gbs(
+            m, batch=8, world_size=8, tp=2, dp_replicate=1, dp_shard=4
+        ) == 32  # 8 * (1 * 4); explicit shard honored, tp excluded
+
     def test_single_rank(self):
         m = _import_fsdp_tp()
         assert self._gbs(
@@ -172,31 +181,67 @@ class TestGlobalBatchSize:
 class TestConsumedTokensAccounting:
     """Locks the token-accounting invariants used by train()'s metrics.
 
-    train() logs global tokens as `batch * local_seq_len * world_size` per
-    step (cumulative in train/tokens_seen). Global tokens use WORLD_SIZE, not
-    dp_size — contrast with the global-batch-size formula, which uses dp_size
-    (excludes tp). Under sequence parallelism each tp rank holds a distinct
-    seq shard, so tp ranks consume distinct tokens; hence world_size here.
-    These are pure-arithmetic checks of that intent (the loop itself needs a
-    live run to exercise).
+    train() logs global tokens as `batch * local_seq_len * (dp_size * tp)`
+    per step (cumulative in train/tokens_seen), where `dp_size * tp` counts
+    the ranks that hold DISTINCT tokens. This equals WORLD_SIZE only on the
+    sequence-parallel path (ezpz Transformer, tp>1: each tp rank owns a
+    distinct seq shard). On the HF path, train() forces tp=1 with NO SP, so
+    the tp-dim ranks see duplicate samples and the correct multiplier is
+    dp_size (== dp_size * 1). Contrast with the global-batch-size formula,
+    which always uses dp_size and excludes tp entirely. These are
+    pure-arithmetic checks of that intent (the loop itself needs a live run).
     """
 
-    def test_global_tokens_per_step_uses_world_size(self):
-        # 8 ranks, tp=2: world_size=8. Global tokens/step = batch*seq*8,
-        # NOT batch*seq*dp_size (which would be batch*seq*4).
-        batch, seq, world_size = 2, 4096, 8
-        assert batch * seq * world_size == 65536
+    def _tok_factor(self, m, *, world_size, tp, effective_tp, dp_replicate,
+                    dp_shard):
+        """Distinct-token rank count as train() computes it: dpsize *
+        effective_tp, where dpsize comes from the ORIGINAL tp (that's what
+        the DistributedSampler shards over) and effective_tp is the
+        post-force value used at the metrics block."""
+        rep, shard = m._resolve_dp_degrees(
+            world_size=world_size, tp=tp, dp_replicate=dp_replicate,
+            dp_shard=dp_shard,
+        )
+        return (rep * shard) * effective_tp
+
+    def test_sp_path_equals_world_size(self):
+        """ezpz Transformer, tp>1 (SP): effective_tp == tp, so the multiplier
+        is dpsize * tp == world_size (all ranks hold distinct tokens)."""
+        m = _import_fsdp_tp()
+        # 8 ranks, tp=2, SP active → effective_tp=2 → factor=4*2=8=world_size.
+        assert self._tok_factor(
+            m, world_size=8, tp=2, effective_tp=2, dp_replicate=1, dp_shard=-1
+        ) == 8
+
+    def test_hf_forced_tp1_uses_dp_size_not_world_size(self):
+        """HF path forces tp=1 with NO SP: dpsize was computed with the
+        ORIGINAL tp (=2), but effective_tp=1, so the multiplier is dpsize
+        (=4), NOT world_size (=8). Using world_size would 2x-overcount."""
+        m = _import_fsdp_tp()
+        factor = self._tok_factor(
+            m, world_size=8, tp=2, effective_tp=1, dp_replicate=1, dp_shard=-1
+        )
+        assert factor == 4          # dpsize, not world_size
+        assert factor != 8          # the bug Codex flagged (would overcount)
+
+    def test_tp1_path_equals_dp_size_and_world_size(self):
+        """Plain tp=1: dpsize == world_size and effective_tp=1, so all three
+        framings agree (regression guard for the common path)."""
+        m = _import_fsdp_tp()
+        assert self._tok_factor(
+            m, world_size=8, tp=1, effective_tp=1, dp_replicate=1, dp_shard=-1
+        ) == 8
 
     def test_tps_and_gbs_differ_by_tp_under_sp(self):
         """GBS excludes tp (samples), token-throughput includes it (SP seq
-        shards). At tp>1 the two scalings must differ by exactly tp."""
+        shards). On the SP path the two scalings differ by exactly tp."""
         m = _import_fsdp_tp()
         batch, world_size, tp = 2, 8, 2
         rep, shard = m._resolve_dp_degrees(
             world_size=world_size, tp=tp, dp_replicate=1, dp_shard=-1
         )
-        gbs_factor = rep * shard          # dp_size = 4 (samples)
-        tok_factor = world_size           # 8 (distinct-token ranks, SP)
-        assert tok_factor == gbs_factor * tp
-        assert batch * gbs_factor == 8    # global batch (samples/step)
-        assert batch * tok_factor == 16   # global-token rank multiplier
+        gbs_factor = rep * shard              # dp_size = 4 (samples)
+        tok_factor = gbs_factor * tp          # 8 = world_size (SP, distinct)
+        assert tok_factor == world_size
+        assert batch * gbs_factor == 8        # global batch (samples/step)
+        assert batch * tok_factor == 16       # global-token rank multiplier


### PR DESCRIPTION
## Summary

Two observability features for `ezpz.examples.fsdp_tp`, so token-based loss
curves and the effective global batch size are visible in the run config / W&B.

### 1. Consumed-token metrics
Per-step and cumulative token accounting in the training loop:

| Metric | Meaning |
|--------|---------|
| `train/tokens` | Global tokens processed **this step** |
| `train/tokens_seen` | Cumulative tokens over the run (standard x-axis for loss-vs-tokens) |
| `train/tps` | Global tokens/sec (over distinct-data ranks) |
| `train/tps_per_gpu` | Per-rank tokens/sec (unchanged) |

**Global tokens/step = `batch × inp.shape[1] × dpsize`** — the **full,
pre-shard** sequence length (`inp.shape[1]`) times the data-parallel degree
`dpsize = dp_replicate × dp_shard`.

- `inp` is `Replicate()` across the tp group (the TP plan shards only the
  embedding *output*, never the input), so `inp.shape[1]` is the full sequence
  and is identical on every rank — the metric is exact and rank-invariant.
- **`tp` does not enter.** Under SP the tp ranks hold the *same* sequence
  (full-length logits under the default `Replicate()` output, or `Shard(1)`
  slices summing to the full length under fused-linear/loss-parallel), never
  distinct sequences. On the HF path (`tp` forced to 1, no SP) the tp-dim ranks
  see *duplicate* samples, so `dpsize` (not `world_size`) counts each distinct
  token once.

> Earlier iterations of this PR used `local_seq_len × world_size` (and briefly
> `local_seq_len × dpsize × tp`); both over-counted — by a full `~tp×` in the
> default eager path, or by `dpsize × (tp − remainder)` off-divisor in the
> seq-sharded paths. The final formula above is exact on every config.

### 2. `global_batch_size` in config
Computed in `train()` (not `parse_args`, because `--dp-shard -1` only resolves
once `WORLD_SIZE` is known), backfilled onto `args` so `History`'s `vars(args)`
and `wandb.config` both pick it up:

```python
args.global_batch_size = args.batch_size * dp_replicate * dp_shard
```

This is the general Megatron/NeMo formula `micro_batch × world_size ×
grad_accum / (tensor_parallel × pipeline_parallel)` specialized to this
example (no pipeline parallelism, no gradient accumulation → both factors 1;
`world_size / tp == dp_replicate × dp_shard`). It excludes `tp` (tp ranks share
the same samples).

## Tests
- `TestGlobalBatchSize` — `dp_replicate × dp_shard` formula; tp does **not** scale it; explicit `--dp-shard` path.
- `TestConsumedTokensAccounting` — full-length formula across SP-divisible, SP-remainder, HF-forced-tp1, and tp=1 paths.
- Full suite: `21 passed`; ruff clean.

## Docs
- New **Token Accounting** section in `docs/examples/fsdp-tp.md`.
- Re-anchored the `--8<--` snippet ranges that drifted as the source grew.

## Validation (2-node Sunspot, XPU)
ezpz installed from this PR head; world_size=24, dp_shard=12, dpsize=12, tp=2:
- `seq_len=512` → `train/tokens = 6144` (= 1×512×12), `tokens_seen` exact over 2666 steps.
- `seq_len=513` (odd) → `train/tokens = 6156` (= 1×513×12) — uses the true pre-shard length, not the padded/sharded one.
- `global_batch_size=12` present in the live W&B config (nested + flattened).
- Old formula would have reported 12288 / 12312 — confirming the fix.