### PR TITLE
feat(failover): Sunspot bad-node patterns + machine-agnostic --auto-retry driver (validated on Sunspot)

### DIFF
--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -398,9 +398,20 @@ Two ready-to-submit PBS drivers ship with the package, both
 following the same scenario-runner pattern (each scenario writes
 `PASS|FAIL` to a summary at the end):
 
+The `--auto-retry` driver is machine-agnostic — the `#PBS` directives
+default to Aurora, but qsub command-line flags override them, so pass the
+per-machine account / queue / filesystems (nothing inside the script is
+Aurora-specific):
+
 ```bash
-# In an ezpz checkout on Aurora:
-qsub src/ezpz/bin/test_launch_auto_retry_aurora.pbs
+# In an ezpz checkout (run `mkdir -p logs` first):
+
+# Aurora:
+qsub src/ezpz/bin/test_launch_auto_retry.pbs
+
+# Sunspot:
+qsub -A datascience -q workq -l filesystems=tegu:home -l select=4 \
+    src/ezpz/bin/test_launch_auto_retry.pbs
 
 # Or for the pre-#144 watchdog/retries (PR #136):
 qsub src/ezpz/bin/test_launch_timeout_retries_aurora.pbs

--- a/src/ezpz/bin/failover.sh
+++ b/src/ezpz/bin/failover.sh
@@ -311,7 +311,7 @@ failover_run() {
             # (real shepherd kill), `died from signal 6` (SIGABRT
             # from a real assert), etc. still count.
             crash_lines=$(grep -vE "rank [0-9]+ died from signal (11|15)" "$logf" 2>/dev/null \
-                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|rank [0-9]+ exited with code [1-9]|EOFError: No data left in file")
+                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|rank [0-9]+ exited with code [1-9][0-9]*|EOFError: No data left in file")
             if (( crash_lines >= 1 )); then
                 _failover_log "WARNING: shell exit 0 but log has $crash_lines crash-pattern line(s); treating as failure (rc=1)"
                 rc=1
@@ -344,7 +344,7 @@ failover_run() {
             # override the clean rc=143 into a bad-node retry and
             # burn spares for nothing.
             bad_crash_lines=$(grep -vE "rank [0-9]+ died from signal (11|15)" "$logf" 2>/dev/null \
-                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|rank [0-9]+ exited with code [1-9]|EOFError: No data left in file")
+                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|rank [0-9]+ exited with code [1-9][0-9]*|EOFError: No data left in file")
             if (( bad_crash_lines == 0 )); then
                 _failover_log "attempt ${attempt} exited 143 (walltime / SIGTERM) — not a bad-node failure, no retry"
                 return "$rc"

--- a/src/ezpz/bin/failover.sh
+++ b/src/ezpz/bin/failover.sh
@@ -311,7 +311,7 @@ failover_run() {
             # (real shepherd kill), `died from signal 6` (SIGABRT
             # from a real assert), etc. still count.
             crash_lines=$(grep -vE "rank [0-9]+ died from signal (11|15)" "$logf" 2>/dev/null \
-                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file")
+                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|rank [0-9]+ exited with code [1-9]|EOFError: No data left in file")
             if (( crash_lines >= 1 )); then
                 _failover_log "WARNING: shell exit 0 but log has $crash_lines crash-pattern line(s); treating as failure (rc=1)"
                 rc=1
@@ -344,7 +344,7 @@ failover_run() {
             # override the clean rc=143 into a bad-node retry and
             # burn spares for nothing.
             bad_crash_lines=$(grep -vE "rank [0-9]+ died from signal (11|15)" "$logf" 2>/dev/null \
-                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|EOFError: No data left in file")
+                | grep -cE "RuntimeError: \[.*gloo.*\] Connection closed by peer|RuntimeError: \[.*gloo.*\] Timed out waiting|OutOfMemoryError|UR_RESULT_ERROR_OUT_OF_RESOURCES|died from signal|rank [0-9]+ exited with code [1-9]|EOFError: No data left in file")
             if (( bad_crash_lines == 0 )); then
                 _failover_log "attempt ${attempt} exited 143 (walltime / SIGTERM) — not a bad-node failure, no retry"
                 return "$rc"

--- a/src/ezpz/bin/test_launch_auto_retry.pbs
+++ b/src/ezpz/bin/test_launch_auto_retry.pbs
@@ -200,24 +200,32 @@ else
 fi
 
 # ---- B: blind rotation — first attempt crashes, scraper finds nothing -----
-hdr "B" "Blind rotation: fail rc=1 once, scraper empty, succeed attempt 2 → 1 swap"
+hdr "B" "Blind rotation: fail once, scraper empty, succeed attempt 2 → 1 swap"
 D=$(scen_dir B)
 cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
-COUNTER="${D}/counter_b"
-echo 0 > "${COUNTER}"
+# Fail-once latch: a MARKER FILE, not a read-increment-write counter. The
+# command runs on all GPN ranks concurrently; a counter races (12 ranks
+# lose updates → wrong attempt number). A one-way marker is race-safe: on
+# attempt 1 the marker is absent for every rank (all fail); on attempt 2 it
+# exists for every rank (all succeed). Even if ranks fail/create the marker
+# out of order, PALS tears the whole attempt down when ANY rank exits
+# nonzero, so attempt 1 fails as a unit. Lives on the shared FS (scen dir).
+MARKER="${D}/failed_once"
+rm -f "${MARKER}"
 START=$(date +%s)
 # First attempt: print no recognized crash signature, exit 1 → blind rotation
-# Second attempt: succeed
+# (the scraper finds no shepherd-9/gloo, so the swap is blind). PALS adds a
+# `rank N exited with code 1` line, which the classifier reads as a crash
+# → it retries. Second attempt: succeed.
 ezpz launch "${NP[@]}" --auto-retry --timeout 60 \
     -- bash -c "
-        n=\$(cat '${COUNTER}')
-        n=\$((n + 1))
-        echo \$n > '${COUNTER}'
-        echo \"B attempt \$n iter step=\$n\"
-        if [ \$n -eq 1 ]; then
+        if [ ! -e '${MARKER}' ]; then
+            : > '${MARKER}'
+            echo 'B attempt 1 iter step=1'
             echo 'random non-recognized error'
             exit 1
         fi
+        echo 'B attempt 2 iter step=2'
         exit 0
     " > "${LOG}" 2>&1
 RC=$?
@@ -238,8 +246,10 @@ fi
 hdr "C" "Named swap: emit shepherd-died-9 from rank 0 host, succeed attempt 2"
 D=$(scen_dir C)
 cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
-COUNTER="${D}/counter_c"
-echo 0 > "${COUNTER}"
+# Fail-once via a marker file, not a counter (see scenario B — a counter
+# races across the GPN concurrent ranks).
+MARKER="${D}/failed_once"
+rm -f "${MARKER}"
 # Find the FIRST active host (= the one the failover loop would use as
 # nproc/ppn=GPN → 1 active host = head -n 1 of PBS_NODEFILE)
 ACTIVE_HOST=$(head -n 1 "${PBS_NODEFILE}")
@@ -247,11 +257,9 @@ log_message INFO "Active host for scenario C: ${ACTIVE_HOST}"
 START=$(date +%s)
 ezpz launch "${NP[@]}" --auto-retry --timeout 60 \
     -- bash -c "
-        n=\$(cat '${COUNTER}')
-        n=\$((n + 1))
-        echo \$n > '${COUNTER}'
-        echo \"C attempt \$n iter step=\$n\"
-        if [ \$n -eq 1 ]; then
+        if [ ! -e '${MARKER}' ]; then
+            : > '${MARKER}'
+            echo 'C attempt 1 iter step=1'
             # Emit the PALS shepherd-9 signature that scrape_bad_nodes
             # recognizes. The line is built from the REAL first node, so it
             # carries this machine's actual hostname suffix — the machine's
@@ -261,6 +269,7 @@ ezpz launch "${NP[@]}" --auto-retry --timeout 60 \
             echo '${ACTIVE_HOST}: shepherd died from signal 9'
             exit 1
         fi
+        echo 'C attempt 2 iter step=2'
         exit 0
     " > "${LOG}" 2>&1
 RC=$?
@@ -296,10 +305,14 @@ else
 fi
 
 # ---- D: --max-failover-retries cap — fail forever, cap at 2 ----------------
-hdr "D" "Cap exhaustion: --max-failover-retries 2, always-fail → 3 attempts, rc=1"
+hdr "D" "Cap exhaustion: --max-failover-retries 2, always-fail → 3 attempts, rc!=0"
 D=$(scen_dir D)
 cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
 START=$(date +%s)
+# Always fail WITH progress (step=1) so it's not the stuck-guard path — we
+# want the failover cap to be what stops it. rc is whatever PALS returns for
+# a nonzero exit (143 on Aurora/Sunspot, 1 elsewhere), so assert rc!=0, not
+# a specific code.
 ezpz launch "${NP[@]}" --auto-retry --max-failover-retries 2 --timeout 60 \
     -- bash -c 'echo "D iter step=1"; echo "transient error"; exit 1' > "${LOG}" 2>&1
 RC=$?
@@ -308,12 +321,12 @@ cd "${PBS_O_WORKDIR}" || { log_message ERROR "cd back to PBS_O_WORKDIR failed"; 
 
 ATTEMPTS=$(ls "${D}"/logs/failover-*/attempt-*.log 2>/dev/null | wc -l | tr -d ' ')
 echo "exit=${RC}  elapsed=${ELAPSED}s  attempts=${ATTEMPTS}"
-grep -E "FAILOVER STOP|max_failover_retries" "${LOG}" | head -5
+grep -E "FAILOVER STOP|max_failover_retries|exhausted" "${LOG}" | head -5
 # cap=2 means 1 initial + 2 retries = 3 attempts total.
-if [[ ${RC} -eq 1 && ${ATTEMPTS} -eq 3 ]]; then
+if [[ ${RC} -ne 0 && ${ATTEMPTS} -eq 3 ]]; then
     record D PASS "cap exhausted after ${ATTEMPTS} attempts, rc=${RC} in ${ELAPSED}s"
 else
-    record D FAIL "rc=${RC} attempts=${ATTEMPTS} (wanted rc=1, attempts=3)"
+    record D FAIL "rc=${RC} attempts=${ATTEMPTS} (wanted rc!=0, attempts=3)"
 fi
 
 # ---- E: stuck_pre_training — 2 consecutive 0-progress attempts ------------
@@ -330,12 +343,13 @@ cd "${PBS_O_WORKDIR}" || { log_message ERROR "cd back to PBS_O_WORKDIR failed"; 
 ATTEMPTS=$(ls "${D}"/logs/failover-*/attempt-*.log 2>/dev/null | wc -l | tr -d ' ')
 echo "exit=${RC}  elapsed=${ELAPSED}s  attempts=${ATTEMPTS}"
 grep -E "FAILOVER STOP|stuck_pre_training" "${LOG}" | head -5
-# stuck guard fires on attempt 2 (prior=no progress, current=no progress).
-# So exactly 2 attempts before bail.
-if [[ ${RC} -eq 1 && ${ATTEMPTS} -eq 2 ]]; then
+# stuck guard fires on attempt 2 (prior=no progress, current=no progress),
+# so exactly 2 attempts before bail. rc is whatever PALS returns for the
+# nonzero exit (143 on Aurora/Sunspot, 1 elsewhere) → assert rc!=0.
+if [[ ${RC} -ne 0 && ${ATTEMPTS} -eq 2 ]]; then
     record E PASS "stuck_pre_training after ${ATTEMPTS} attempts in ${ELAPSED}s"
 else
-    record E FAIL "rc=${RC} attempts=${ATTEMPTS} (wanted rc=1, attempts=2)"
+    record E FAIL "rc=${RC} attempts=${ATTEMPTS} (wanted rc!=0, attempts=2)"
 fi
 
 # ---- F: realistic — ezpz.examples.test under --auto-retry -----------------

--- a/src/ezpz/bin/test_launch_auto_retry.pbs
+++ b/src/ezpz/bin/test_launch_auto_retry.pbs
@@ -6,7 +6,12 @@
 #PBS -l filesystems=flare:home
 #PBS -N ezpz-launch-auto-retry-test
 #PBS -j oe
-#PBS -o logs/ezpz-launch-auto-retry-test.${PBS_JOBID}.log
+# NB: point -o at the logs/ DIRECTORY (trailing slash), not a filename with
+# ${PBS_JOBID} — PBS does NOT expand shell variables in -o, so a literal
+# name makes every run append to the same file. With a directory, PBS writes
+# logs/<jobname>.o<jobid> using the real job id. (logs/ must exist at submit
+# time: `mkdir -p logs` before qsub.)
+#PBS -o logs/
 #
 # PBS test driver for `ezpz launch --auto-retry` — machine-agnostic.
 #

--- a/src/ezpz/bin/test_launch_auto_retry.pbs
+++ b/src/ezpz/bin/test_launch_auto_retry.pbs
@@ -8,7 +8,7 @@
 #PBS -j oe
 #PBS -o logs/ezpz-launch-auto-retry-test.${PBS_JOBID}.log
 #
-# PBS test driver for `ezpz launch --auto-retry` on Aurora.
+# PBS test driver for `ezpz launch --auto-retry` — machine-agnostic.
 #
 # Companion to test_launch_timeout_retries_aurora.pbs (which covers
 # --timeout / --retries from PR #136). This driver exercises the
@@ -21,17 +21,33 @@
 # work for the trivial scenarios but exhausts spares too fast for
 # the rotation tests.
 #
-# Submit with:
-#   cd ~/ezpz  # (or wherever your checkout is)
-#   qsub src/ezpz/bin/test_launch_auto_retry_aurora.pbs
+# The `#PBS` directives above default to Aurora, but qsub command-line
+# options OVERRIDE script directives — so submit with the per-machine
+# flags below (nothing inside the script is Aurora-specific):
+#
+#   # Aurora:
+#   qsub src/ezpz/bin/test_launch_auto_retry.pbs
+#
+#   # Sunspot:
+#   qsub -A datascience -q workq -l filesystems=tegu:home -l select=4 \
+#        src/ezpz/bin/test_launch_auto_retry.pbs
+#
+#   # Polaris:
+#   qsub -A <proj> -q debug -l filesystems=eagle:home -l select=4 \
+#        src/ezpz/bin/test_launch_auto_retry.pbs
+#
+# GPUs-per-node is derived at runtime (EZPZ_GPN override, else
+# ezpz.get_gpus_per_node()), so the topology is correct on any machine.
+#
+# Scenario C (named swap) needs a registered bad-node pattern module for
+# the current machine (ezpz.failover.patterns.<machine>). Aurora + Sunspot
+# ship one; on a machine without one the scraper returns [] and C would do
+# a BLIND swap instead of a named one. The preflight self-check below tells
+# you up front whether a pattern fired on this machine's nodefile format.
 #
 # Inspect:
 #   tail -f logs/ezpz-launch-auto-retry-test.*.log
 #   ls logs/failover-*/   # per-scenario attempt-N.log + bad_nodes.txt
-#
-# Sunspot users: change `-A AuroraGPT` → `-A datascience`,
-# `filesystems=flare:home` → `filesystems=tegu:home`. Everything
-# else is identical (same scrape patterns, same workflow).
 
 set -u
 unset CDPATH
@@ -91,7 +107,7 @@ log_message INFO "First node: $(head -1 "${PBS_NODEFILE}")"
 # point of view and scenario B/C fail spuriously. PBS_O_WORKDIR is
 # the user's submit-time CWD — Lustre on Aurora, GPFS on Polaris —
 # always visible from every compute node in the allocation.
-TMP="$(mktemp -d -p "${PBS_O_WORKDIR}" ezpz-aurora-auto-retry-XXXXXX)"
+TMP="$(mktemp -d -p "${PBS_O_WORKDIR}" ezpz-auto-retry-XXXXXX)"
 log_message INFO "Scratch dir (shared FS): ${TMP}"
 LOG="${TMP}/scenario.log"
 SUMMARY="${TMP}/summary.txt"
@@ -127,10 +143,40 @@ scen_dir() {
     echo "${d}"
 }
 
-# Use --nproc 12 -ppn 12 (matches Aurora's 12 GPUs/node) so the
-# topology inference is unambiguous. With 4 allocated nodes →
-# ceil(12/12) = 1 active host, 3 spares.
-NP=(--nproc 12 --nproc_per_node 12)
+# GPUs-per-node, derived at runtime so this isn't Aurora-specific
+# (Aurora + Sunspot-FLAT are both 12; Polaris is 4). EZPZ_GPN overrides.
+# We pass --nproc == --nproc_per_node == GPN so topology inference is
+# unambiguous: with 4 allocated nodes → ceil(GPN/GPN) = 1 active host,
+# 3 spares.
+GPN="${EZPZ_GPN:-$(python3 -c 'import ezpz; print(ezpz.get_gpus_per_node())' 2>/dev/null || echo 12)}"
+if ! [[ "${GPN}" =~ ^[0-9]+$ ]] || (( GPN < 1 )); then
+    log_message WARN "Could not derive GPUs/node (got '${GPN}'); defaulting to 12."
+    GPN=12
+fi
+log_message INFO "GPUs per node: ${GPN} (override with EZPZ_GPN)"
+NP=(--nproc "${GPN}" --nproc_per_node "${GPN}")
+
+# ---- Preflight: does this machine have a bad-node scraper pattern? ---------
+# Scenario C (named swap) only works if scrape_bad_nodes recognizes a
+# signature for the current machine + nodefile hostname format. Synthesize
+# a shepherd-9 line from the real first node and check whether a pattern
+# fires BEFORE running the scenarios, so a C failure is diagnosable in one
+# line ("no pattern for this machine" / "nodefile format didn't match")
+# rather than a bare assertion mismatch.
+PREFLIGHT_HOST=$(head -n 1 "${PBS_NODEFILE}")
+PREFLIGHT_LOG="${TMP}/preflight.log"
+printf '%s: shepherd died from signal 9\n' "${PREFLIGHT_HOST}" > "${PREFLIGHT_LOG}"
+log_message INFO "Preflight: scraping a synthetic shepherd-9 line for ${PREFLIGHT_HOST}"
+PREFLIGHT_MATCH=$(python3 -m ezpz.failover "${PREFLIGHT_LOG}" 2>/dev/null | head -1)
+if [[ "${PREFLIGHT_MATCH}" == "${PREFLIGHT_HOST}" ]]; then
+    log_message INFO "Preflight OK: scraper named the host → scenario C should do a NAMED swap."
+    PREFLIGHT_NAMED=1
+else
+    log_message WARN "Preflight: scraper did NOT name the host (got '${PREFLIGHT_MATCH}')."
+    log_message WARN "  → No pattern for this machine/nodefile format; scenario C will BLIND-swap."
+    log_message WARN "  → python3 -m ezpz.failover --explain '${PREFLIGHT_LOG}' for the per-pattern breakdown."
+    PREFLIGHT_NAMED=0
+fi
 
 # ---- A: happy path — succeeds first attempt, no retry ----------------------
 hdr "A" "Happy path: --auto-retry, succeeds first attempt → 1 attempt, rc=0"
@@ -195,7 +241,7 @@ cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
 COUNTER="${D}/counter_c"
 echo 0 > "${COUNTER}"
 # Find the FIRST active host (= the one the failover loop would use as
-# nproc/ppn=12 → 1 active host = head -n 1 of PBS_NODEFILE)
+# nproc/ppn=GPN → 1 active host = head -n 1 of PBS_NODEFILE)
 ACTIVE_HOST=$(head -n 1 "${PBS_NODEFILE}")
 log_message INFO "Active host for scenario C: ${ACTIVE_HOST}"
 START=$(date +%s)
@@ -206,10 +252,12 @@ ezpz launch "${NP[@]}" --auto-retry --timeout 60 \
         echo \$n > '${COUNTER}'
         echo \"C attempt \$n iter step=\$n\"
         if [ \$n -eq 1 ]; then
-            # Emit the exact Aurora PALS shepherd-9 signature that
-            # scrape_bad_nodes recognizes. Must include hostname-like
-            # prefix matching the .hsn.cm.aurora pattern (so the
-            # registered Aurora scraper regex fires).
+            # Emit the PALS shepherd-9 signature that scrape_bad_nodes
+            # recognizes. The line is built from the REAL first node, so it
+            # carries this machine's actual hostname suffix — the machine's
+            # registered scraper pattern (aurora/sunspot/...) fires iff that
+            # suffix is one it knows. This is what makes scenario C a real
+            # named-swap test of the per-machine pattern module.
             echo '${ACTIVE_HOST}: shepherd died from signal 9'
             exit 1
         fi
@@ -227,11 +275,24 @@ BAD_NODES_FILE=$(ls "${D}"/logs/failover-*/bad_nodes.txt 2>/dev/null | head -1)
 SWAPPED_HOST=$(head -1 "${BAD_NODES_FILE}" 2>/dev/null || echo "")
 echo "exit=${RC}  elapsed=${ELAPSED}s  attempts=${ATTEMPTS}  swapped_host='${SWAPPED_HOST}'"
 grep -E "FAILOVER STOP|bad nodes detected|swapped:" "${LOG}" | head -10
-# We want: 2 attempts, the SWAPPED host == ACTIVE_HOST (named swap, not blind).
-if [[ ${RC} -eq 0 && ${ATTEMPTS} -eq 2 && "${SWAPPED_HOST}" == "${ACTIVE_HOST}" ]]; then
-    record C PASS "named swap of ${SWAPPED_HOST}, rc=0 in ${ELAPSED}s"
+# Assertion depends on whether this machine has a scraper pattern (preflight):
+#  - PREFLIGHT_NAMED=1 → expect a NAMED swap: SWAPPED_HOST == ACTIVE_HOST.
+#  - PREFLIGHT_NAMED=0 → no pattern for this machine, so the loop falls back
+#    to a BLIND swap. Recovery still succeeds in 2 attempts; the swapped host
+#    is unnamed (blind rotation drops a host without scraping), so we only
+#    assert rc=0 + 2 attempts and record it as a blind-swap pass.
+if (( PREFLIGHT_NAMED == 1 )); then
+    if [[ ${RC} -eq 0 && ${ATTEMPTS} -eq 2 && "${SWAPPED_HOST}" == "${ACTIVE_HOST}" ]]; then
+        record C PASS "named swap of ${SWAPPED_HOST}, rc=0 in ${ELAPSED}s"
+    else
+        record C FAIL "rc=${RC} attempts=${ATTEMPTS} swapped='${SWAPPED_HOST}' wanted='${ACTIVE_HOST}'"
+    fi
 else
-    record C FAIL "rc=${RC} attempts=${ATTEMPTS} swapped='${SWAPPED_HOST}' wanted='${ACTIVE_HOST}'"
+    if [[ ${RC} -eq 0 && ${ATTEMPTS} -eq 2 ]]; then
+        record C PASS "blind swap (no scraper pattern for this machine), rc=0 in ${ELAPSED}s"
+    else
+        record C FAIL "rc=${RC} attempts=${ATTEMPTS} (blind-swap machine; wanted rc=0, attempts=2)"
+    fi
 fi
 
 # ---- D: --max-failover-retries cap — fail forever, cap at 2 ----------------
@@ -306,8 +367,8 @@ cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
 head -n 2 "${PBS_NODEFILE}" > "${D}/user.hostfile"
 log_message INFO "User hostfile (2 nodes): $(tr '\n' ' ' < "${D}/user.hostfile")"
 START=$(date +%s)
-# --np 12 -ppn 12 → 1 active host → 1 spare from the user's 2-host file
-# (NOT 3 spares from the full PBS allocation).
+# --nproc GPN -ppn GPN → 1 active host → 1 spare from the user's 2-host
+# file (NOT 3 spares from the full PBS allocation).
 ezpz launch "${NP[@]}" --hostfile "${D}/user.hostfile" \
     --auto-retry --timeout 60 \
     -- bash -c 'echo "iter step=1"; exit 0' > "${LOG}" 2>&1
@@ -329,7 +390,9 @@ fi
 
 # ---- Final report ---------------------------------------------------------
 printf "\n========================================================================\n"
-printf "Aurora --auto-retry summary  (PASS=%d  FAIL=%d)\n" "${PASS}" "${FAIL}"
+printf "%s --auto-retry summary  (PASS=%d  FAIL=%d)\n" \
+    "$(python3 -c 'import ezpz; print(ezpz.get_machine())' 2>/dev/null || echo '')" \
+    "${PASS}" "${FAIL}"
 printf "========================================================================\n"
 cat "${SUMMARY}"
 

--- a/src/ezpz/failover/patterns/aurora.py
+++ b/src/ezpz/failover/patterns/aurora.py
@@ -149,10 +149,11 @@ register_patterns(
     AURORA_PATTERNS,
     hostname_normalizer=normalize_aurora_hostname,
 )
-# NOTE: Sunspot uses the same XPU fabric + PALS shepherd as Aurora,
-# so the patterns SHOULD apply — but the full hostname suffix differs
-# from Aurora's `.hsn.cm.aurora.alcf.anl.gov`. We haven't postmortemed
-# a real Sunspot failure yet to confirm the exact suffix shape, so the
-# Aurora pattern is NOT auto-registered for sunspot here. Add a
-# dedicated `sunspot.py` module once a real failure provides the
-# hostname format to match against.
+# NOTE: Sunspot uses the same XPU fabric + PALS shepherd as Aurora, so the
+# same two failure modes apply — but the hostname suffix differs
+# (`.hsn.cm.sunspot.alcf.anl.gov`, with an optional `-hsnN` on the node
+# token). The Sunspot equivalents live in a dedicated `sunspot.py` module
+# (registered under the "sunspot" machine key), rather than reusing these
+# Aurora regexes, so each machine's suffix stays explicit. The exact HSN
+# suffix a gloo reverse-DNS returns on Sunspot is still unconfirmed against
+# a real postmortem — see the note in `sunspot.py`.

--- a/src/ezpz/failover/patterns/sunspot.py
+++ b/src/ezpz/failover/patterns/sunspot.py
@@ -1,0 +1,153 @@
+"""Sunspot-specific bad-node failure patterns.
+
+Sunspot is the Aurora test-and-development system: same Intel PVC (XPU)
+hardware, same PALS/cray-pals runtime, same failure modes. The signatures
+are therefore identical to :mod:`ezpz.failover.patterns.aurora` — only the
+hostname suffix differs (``.hsn.cm.sunspot.alcf.anl.gov`` vs Aurora's
+``.hsn.cm.aurora.alcf.anl.gov``), plus Sunspot's HSN node token can carry a
+``-hsnN`` suffix (e.g. ``x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov``)
+that Aurora's does not.
+
+  - **shepherd_signal_9** — PALS shepherd kill (node went bad mid-run).
+    Same runtime as Aurora, so the same signature applies.
+
+  - **gloo_connection_closed** — gloo TCP failure, IP reverse-resolved to
+    a hostname. The extractor is IP-based and machine-agnostic.
+
+We DO NOT match ``rank N died from signal {11,15}`` — those are almost
+always cascading deaths downstream of a primary kill on a *different* node,
+so including them would falsely tag innocent nodes. Same reasoning as
+Aurora (see that module's docstring for the job-8466848 example).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from ezpz.failover.patterns import (
+    BadNodePattern,
+    compile_multiline,
+    register_patterns,
+    reverse_resolve_ip,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1: PALS shepherd kill
+#
+# Log line shape (note the optional -hsnN on the node token):
+#     x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: shepherd died from signal 9
+#
+# Same PALS runtime as Aurora; signal 9 = SIGKILL from the node-local
+# daemon going non-responsive (almost always a hardware fault). The
+# capture group is intentionally permissive ([A-Za-z0-9.-]+) so it accepts
+# both the -hsnN and plain node-token forms; the anchoring `.hsn.cm.sunspot`
+# suffix is what keeps it Sunspot-specific.
+# ---------------------------------------------------------------------------
+_SHEPHERD_SIG9_RX = compile_multiline(
+    r"^([a-zA-Z0-9.-]+\.hsn\.cm\.sunspot\.alcf\.anl\.gov):\s+"
+    r"shepherd\s+died\s+from\s+signal\s+9\b",
+)
+
+
+def _extract_shepherd_sig9(log_text: str) -> Iterable[str]:
+    for m in _SHEPHERD_SIG9_RX.finditer(log_text):
+        yield m.group(1)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2: gloo TCP peer-closed
+#
+# Log line shape:
+#     RuntimeError: [..gloo..] Connection closed by peer [10.0.0.42]:12345
+#
+# IP-based and machine-agnostic — identical to the Aurora extractor. We
+# reverse-resolve the IP to a hostname; the scraper's downstream normalizer
+# canonicalizes the suffix.
+# ---------------------------------------------------------------------------
+_GLOO_PEER_RX = compile_multiline(
+    r"Connection closed by peer\s+\[([0-9.]+)\]:\d+",
+)
+
+
+def _extract_gloo_peer(log_text: str) -> Iterable[str]:
+    for m in _GLOO_PEER_RX.finditer(log_text):
+        ip = m.group(1)
+        host = reverse_resolve_ip(ip)
+        if host is not None:
+            yield host
+
+
+# ---------------------------------------------------------------------------
+# Hostname normalizer
+#
+# PBS hostfile entries and PALS shepherd lines use the
+# `.hsn.cm.sunspot.alcf.anl.gov` form, with the HSN node token optionally
+# carrying a `-hsnN` suffix. The `.hostmgmtNNNN.cm.sunspot...` management
+# form maps 1:1 to the HSN interface and is safe to rewrite. Any OTHER
+# suffix on an `x...n0.` host is something we haven't seen and shouldn't
+# speculatively rewrite — return None (drop) rather than risk tagging a
+# wrong node.
+# ---------------------------------------------------------------------------
+_SUNSPOT_HSN_RX = re.compile(
+    r"^x\d+c\d+s\d+b\d+n\d+(?:-hsn\d+)?\.hsn\.cm\.sunspot\.alcf\.anl\.gov$"
+)
+_SUNSPOT_HOSTMGMT_RX = re.compile(
+    r"^(x\d+c\d+s\d+b\d+n\d+)\.hostmgmt\d+\.cm\.sunspot\.alcf\.anl\.gov$"
+)
+
+
+def normalize_sunspot_hostname(host: str) -> "str | None":
+    """Return the canonical ``.hsn.cm.sunspot.alcf.anl.gov`` form, or None
+    if *host* doesn't look like a valid Sunspot compute hostname.
+
+    Examples (in → out):
+      ``x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov``      → unchanged
+      ``x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov``           → unchanged
+      ``x1922c7s6b0n0.hostmgmt2001.cm.sunspot.alcf.anl.gov``  → HSN form
+      ``x1922c7s6b0n0.something-else.example.com``            → None
+      ``some-other-host``                                     → None
+
+    NOTE: the exact HSN suffix that a gloo reverse-DNS lookup returns on
+    Sunspot (with vs without ``-hsn0``) is not yet confirmed against a real
+    postmortem. The hostmgmt→HSN rewrite drops the ``-hsnN`` token (mirrors
+    the observed PBS hostfile + shepherd-line form); revisit if a real
+    failure shows a different mapping.
+    """
+    if _SUNSPOT_HSN_RX.match(host):
+        return host
+    m = _SUNSPOT_HOSTMGMT_RX.match(host)
+    if m:
+        return f"{m.group(1)}.hsn.cm.sunspot.alcf.anl.gov"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Register at import time
+# ---------------------------------------------------------------------------
+SUNSPOT_PATTERNS = [
+    BadNodePattern(
+        name="sunspot.shepherd_signal_9",
+        extractor=_extract_shepherd_sig9,
+        description=(
+            "PALS shepherd kill (signal 9). Node-local daemon went "
+            "non-responsive; almost always a hardware fault. Same runtime "
+            "as Aurora."
+        ),
+    ),
+    BadNodePattern(
+        name="sunspot.gloo_connection_closed",
+        extractor=_extract_gloo_peer,
+        description=(
+            "gloo TCP peer-connection closed. IP reverse-resolved to a "
+            "Sunspot HSN hostname."
+        ),
+    ),
+]
+
+register_patterns(
+    "sunspot",
+    SUNSPOT_PATTERNS,
+    hostname_normalizer=normalize_sunspot_hostname,
+)

--- a/src/ezpz/failover/patterns/sunspot.py
+++ b/src/ezpz/failover/patterns/sunspot.py
@@ -90,8 +90,13 @@ def _extract_gloo_peer(log_text: str) -> Iterable[str]:
 # speculatively rewrite — return None (drop) rather than risk tagging a
 # wrong node.
 # ---------------------------------------------------------------------------
+# Capture the node token (group 1) so we can canonicalize to ONE form
+# regardless of an optional `-hsnN` HSN suffix. Both `x...n0-hsn0.hsn...`
+# and `x...n0.hsn...` name the same node; returning them verbatim would let
+# the same node dedupe as two entries (breaking swap_in's hostfile grep and
+# the caller's de-duplication). Always emit the suffix-less form.
 _SUNSPOT_HSN_RX = re.compile(
-    r"^x\d+c\d+s\d+b\d+n\d+(?:-hsn\d+)?\.hsn\.cm\.sunspot\.alcf\.anl\.gov$"
+    r"^(x\d+c\d+s\d+b\d+n\d+)(?:-hsn\d+)?\.hsn\.cm\.sunspot\.alcf\.anl\.gov$"
 )
 _SUNSPOT_HOSTMGMT_RX = re.compile(
     r"^(x\d+c\d+s\d+b\d+n\d+)\.hostmgmt\d+\.cm\.sunspot\.alcf\.anl\.gov$"
@@ -99,24 +104,28 @@ _SUNSPOT_HOSTMGMT_RX = re.compile(
 
 
 def normalize_sunspot_hostname(host: str) -> "str | None":
-    """Return the canonical ``.hsn.cm.sunspot.alcf.anl.gov`` form, or None
-    if *host* doesn't look like a valid Sunspot compute hostname.
+    """Return the canonical ``x...n0.hsn.cm.sunspot.alcf.anl.gov`` form, or
+    None if *host* doesn't look like a valid Sunspot compute hostname.
+
+    The ``-hsnN`` HSN token is stripped so the SAME node always maps to ONE
+    canonical name (else `x...n0-hsn0...` and `x...n0...` would count as two
+    different bad nodes).
 
     Examples (in → out):
-      ``x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov``      → unchanged
+      ``x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov``      → x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov
       ``x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov``           → unchanged
       ``x1922c7s6b0n0.hostmgmt2001.cm.sunspot.alcf.anl.gov``  → HSN form
       ``x1922c7s6b0n0.something-else.example.com``            → None
       ``some-other-host``                                     → None
 
-    NOTE: the exact HSN suffix that a gloo reverse-DNS lookup returns on
-    Sunspot (with vs without ``-hsn0``) is not yet confirmed against a real
-    postmortem. The hostmgmt→HSN rewrite drops the ``-hsnN`` token (mirrors
-    the observed PBS hostfile + shepherd-line form); revisit if a real
-    failure shows a different mapping.
+    NOTE: whether swap_in must match the `-hsnN` form in the live PBS
+    hostfile is not yet confirmed against a real postmortem — the observed
+    hostfile + shepherd-line form is suffix-less, so we canonicalize to that.
+    Revisit if a real failure shows the hostfile carries `-hsnN`.
     """
-    if _SUNSPOT_HSN_RX.match(host):
-        return host
+    m = _SUNSPOT_HSN_RX.match(host)
+    if m:
+        return f"{m.group(1)}.hsn.cm.sunspot.alcf.anl.gov"
     m = _SUNSPOT_HOSTMGMT_RX.match(host)
     if m:
         return f"{m.group(1)}.hsn.cm.sunspot.alcf.anl.gov"

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -78,8 +78,9 @@ _CRASH_PATTERNS_RX = re.compile(
     # stripped as an innocent cascade below) and the loop would NOT retry
     # it. Confirmed on a live Sunspot run (job 12471663): scenarios B/D/E
     # all stopped after 1-2 attempts as "walltime" for a plain `exit 1`.
-    # `[1-9]` excludes the clean `exited with code 0` PALS prints per rank.
-    r"|rank \d+ exited with code [1-9]"
+    # `[1-9][0-9]*` = any nonzero code (incl. 10+, e.g. 137 = SIGKILL/OOM),
+    # while excluding the clean `exited with code 0` PALS prints per rank.
+    r"|rank \d+ exited with code [1-9][0-9]*"
     r"|EOFError: No data left in file"
 )
 

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -69,6 +69,17 @@ _CRASH_PATTERNS_RX = re.compile(
     r"|OutOfMemoryError"
     r"|UR_RESULT_ERROR_OUT_OF_RESOURCES"
     r"|died from signal"
+    # A rank returning a NONZERO application exit code. On Aurora/Sunspot
+    # PALS, one rank's `exit 1` tears the job down with SIGTERM and the
+    # aggregate surfaces as bash 143 (== _WALLTIME_RC) plus a
+    # `<host>: rank N exited with code K` line (K != 0). Without this
+    # pattern a genuine crash is indistinguishable from a clean walltime
+    # kill (which only ever emits `rank N died from signal {11,15}`,
+    # stripped as an innocent cascade below) and the loop would NOT retry
+    # it. Confirmed on a live Sunspot run (job 12471663): scenarios B/D/E
+    # all stopped after 1-2 attempts as "walltime" for a plain `exit 1`.
+    # `[1-9]` excludes the clean `exited with code 0` PALS prints per rank.
+    r"|rank \d+ exited with code [1-9]"
     r"|EOFError: No data left in file"
 )
 

--- a/tests/test_failover_lib.sh
+++ b/tests/test_failover_lib.sh
@@ -451,6 +451,74 @@ EOF
     assert_eq "$(wc -l < "${FAILOVER_BAD}" | tr -d ' ')" "0" "bad_nodes_count"
 }
 
+test_run_walltime_143_retries_on_nonzero_rank_exit_only() {
+    # Regression for live Sunspot job 12471663: a plain application
+    # `exit 1` on PALS tears the job down with SIGTERM, so the aggregate
+    # is rc=143 and the ONLY crash signal is `rank N exited with code 1`
+    # (K != 0) — no UR_OOM, no gloo, no shepherd-9. The innocent
+    # `rank N died from signal 15` cascade is stripped. Before the
+    # `rank N exited with code [1-9]` crash pattern this looked exactly
+    # like a clean walltime kill and did NOT retry a genuine crash.
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/nonzero_exit_cmd" <<'EOF'
+#!/usr/bin/env bash
+n_file="${TMPDIR}/call_count"
+n=$(cat "${n_file}" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "${n}" > "${n_file}"
+if [[ "${n}" == "1" ]]; then
+    echo "step: 1 loss: 3.14"
+    echo "x1921c2s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: rank 0 exited with code 1"
+    echo "x1921c2s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: rank 11 died from signal 15"
+    exit 143
+else
+    exit 0
+fi
+EOF
+    chmod +x "${bindir}/nonzero_exit_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""  # blind rotation
+
+    export FAILOVER_MAX_RETRIES=2
+    failover_run nonzero_exit_cmd || exit 1
+    # We DID retry (nonzero rank exit was recognized as a crash, not
+    # misread as a clean walltime kill) → a host was swapped out.
+    assert_file_contents "${FAILOVER_BAD}" "host1"
+}
+
+test_run_walltime_143_no_retry_when_only_rank_exit_code_0() {
+    # Guard the `[1-9]` bound: PALS prints `rank N exited with code 0`
+    # for every rank on a CLEAN shutdown. Combined with a real walltime
+    # SIGTERM (rc=143) that must stay WALLTIME (no swap), not be read as
+    # a crash.
+    setup_pbs_nodefile "host1
+host2
+host3" >/dev/null
+    failover_init 2 || exit 1
+    local bindir="${TMPDIR}/bin"
+    mkdir -p "${bindir}"
+    cat > "${bindir}/clean_exit_cmd" <<'EOF'
+#!/usr/bin/env bash
+echo "x1921c2s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: rank 0 exited with code 0"
+echo "rank 1 died from signal 15"
+exit 143
+EOF
+    chmod +x "${bindir}/clean_exit_cmd"
+    export PATH="${bindir}:${PATH}"
+    shadow_scrape_response ""
+
+    export FAILOVER_MAX_RETRIES=2
+    local rc=0
+    failover_run clean_exit_cmd || rc=$?
+    assert_eq "${rc}" "143" "rc"
+    assert_eq "$(wc -l < "${FAILOVER_BAD}" | tr -d ' ')" "0" "bad_nodes_count"
+}
+
 test_run_walltime_143_retries_on_real_aurora_ur_oom_with_cascade() {
     # Regression for actual Aurora torchtitan log shape (2026-05-12):
     # 18 training steps complete cleanly, then a real level_zero
@@ -681,6 +749,8 @@ run_test "run retries on failure, succeeds on attempt 2"      test_run_retries_o
 run_test "run does NOT retry on walltime (143) when clean"    test_run_walltime_143_no_retry_when_clean
 run_test "run DOES retry on 143 when log has bad-node pattern" test_run_walltime_143_retries_when_bad_node_pattern_in_log
 run_test "run does NOT retry on 143 with only innocent rank-signal lines" test_run_walltime_143_no_retry_when_only_innocent_rank_signals
+run_test "run DOES retry on 143 when only signal is nonzero rank exit"     test_run_walltime_143_retries_on_nonzero_rank_exit_only
+run_test "run does NOT retry on 143 with only rank-exit-code-0 lines"      test_run_walltime_143_no_retry_when_only_rank_exit_code_0
 run_test "run DOES retry on 143 when real hw death is mixed with cascade"  test_run_walltime_143_retries_on_real_hw_death_mixed_with_innocent_cascade
 run_test "run handles real Aurora UR_OOM + cascade regression"             test_run_walltime_143_retries_on_real_aurora_ur_oom_with_cascade
 run_test "run swaps named bad node (from scraper)"            test_run_swaps_named_bad_node_when_scraper_finds_one

--- a/tests/test_failover_scrape.py
+++ b/tests/test_failover_scrape.py
@@ -246,7 +246,9 @@ class TestSunspotShepherdSignal9:
             "More output after\n"
         ))
         hosts = scrape_bad_nodes(log, machine="sunspot")
-        assert hosts == ["x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"]
+        # The `-hsn0` token is canonicalized away by the normalizer so the
+        # node has a single canonical name (see normalize_sunspot_hostname).
+        assert hosts == ["x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"]
 
     def test_single_signal_9_extracted_plain_token(self, tmp_path):
         """Plain node token (no `-hsnN`) — the PBS_NODEFILE form may use
@@ -259,15 +261,17 @@ class TestSunspotShepherdSignal9:
         assert hosts == ["x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"]
 
     def test_multiple_signal_9_deduplicated(self, tmp_path):
+        # Same node emitted BOTH with and without the -hsn0 token — must
+        # collapse to ONE canonical entry (the point of stripping -hsnN).
         log = _make_log(tmp_path, (
             "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
             "shepherd died from signal 9\n"
             "more output\n"
-            "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov: "
             "shepherd died from signal 9\n"
         ))
         hosts = scrape_bad_nodes(log, machine="sunspot")
-        assert hosts == ["x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"]
+        assert hosts == ["x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"]
 
     def test_innocent_rank_signal_11_not_matched(self, tmp_path):
         """Same critical exclusion as Aurora: cascading `rank N died from
@@ -311,7 +315,8 @@ class TestSunspotGlooConnectionClosed:
             "[10.0.0.42]:12345\n"
         ))
         hosts = scrape_bad_nodes(log, machine="sunspot")
-        assert hosts == ["x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"]
+        # reverse-DNS returned the -hsn0 form; normalizer canonicalizes it.
+        assert hosts == ["x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"]
 
     def test_hostmgmt_form_canonicalized_to_hsn(self, tmp_path, monkeypatch):
         """Reverse-lookup returning the .hostmgmtNNNN form is rewritten to
@@ -343,14 +348,17 @@ class TestSunspotGlooConnectionClosed:
 class TestSunspotHostnameNormalizer:
     """Direct unit tests of `normalize_sunspot_hostname`."""
 
-    def test_hsn_forms_pass_through(self):
+    def test_hsn_forms_canonicalize_to_one_name(self):
         from ezpz.failover.patterns.sunspot import normalize_sunspot_hostname
 
+        canonical = "x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"
+        # Both the -hsn0 and suffix-less forms must map to the SAME canonical
+        # name so one node never counts as two.
         for h in (
             "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov",
             "x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov",
         ):
-            assert normalize_sunspot_hostname(h) == h
+            assert normalize_sunspot_hostname(h) == canonical
 
     def test_hostmgmt_rewritten_to_hsn(self):
         from ezpz.failover.patterns.sunspot import normalize_sunspot_hostname

--- a/tests/test_failover_scrape.py
+++ b/tests/test_failover_scrape.py
@@ -225,6 +225,155 @@ class TestAuroraGlooConnectionClosed:
 
 
 # ---------------------------------------------------------------------------
+# Sunspot: same failure modes as Aurora, different hostname suffix
+# ---------------------------------------------------------------------------
+
+class TestSunspotShepherdSignal9:
+    """Pattern: `<host>.hsn.cm.sunspot.alcf.anl.gov: shepherd died from signal 9`.
+
+    Sunspot is Aurora's test-and-dev twin (same PVC + PALS runtime), so the
+    shepherd-kill signature is identical apart from the `.sunspot` suffix and
+    an optional `-hsnN` on the HSN node token.
+    """
+
+    def test_single_signal_9_extracted_hsn_suffix_token(self, tmp_path):
+        """HSN node token carries a `-hsn0` suffix (observed on real
+        Sunspot allocations)."""
+        log = _make_log(tmp_path, (
+            "Some normal training output\n"
+            "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+            "More output after\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == ["x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"]
+
+    def test_single_signal_9_extracted_plain_token(self, tmp_path):
+        """Plain node token (no `-hsnN`) — the PBS_NODEFILE form may use
+        either, so both must match."""
+        log = _make_log(tmp_path, (
+            "x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == ["x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"]
+
+    def test_multiple_signal_9_deduplicated(self, tmp_path):
+        log = _make_log(tmp_path, (
+            "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+            "more output\n"
+            "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == ["x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"]
+
+    def test_innocent_rank_signal_11_not_matched(self, tmp_path):
+        """Same critical exclusion as Aurora: cascading `rank N died from
+        signal {11,15}` must NOT tag a node, and `shepherd died from
+        signal 11` (not 9) must NOT match either."""
+        log = _make_log(tmp_path, (
+            "rank 1304 died from signal 11\n"
+            "rank 88 died from signal 15\n"
+            "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "shepherd died from signal 11\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == [], (
+            f"Innocent ranks/signals must not be tagged, got: {hosts!r}"
+        )
+
+    def test_aurora_suffix_not_matched_on_sunspot(self, tmp_path):
+        """A line with the Aurora suffix must not match under the Sunspot
+        pattern set (keeps each machine's suffix explicit)."""
+        log = _make_log(tmp_path, (
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov: "
+            "shepherd died from signal 9\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == []
+
+
+class TestSunspotGlooConnectionClosed:
+    """gloo peer-closed → IP reverse-resolved, then normalized to the
+    `.hsn.cm.sunspot` form. `reverse_resolve_ip` is stubbed (no real DNS)."""
+
+    def test_single_peer_ip_resolved_to_hostname(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.sunspot.reverse_resolve_ip",
+            lambda ip, **_kw: (
+                "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"
+            ),
+        )
+        log = _make_log(tmp_path, (
+            "RuntimeError: [..gloo..] Connection closed by peer "
+            "[10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == ["x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"]
+
+    def test_hostmgmt_form_canonicalized_to_hsn(self, tmp_path, monkeypatch):
+        """Reverse-lookup returning the .hostmgmtNNNN form is rewritten to
+        the .hsn form so downstream swap_in finds it in the PBS hostfile."""
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.sunspot.reverse_resolve_ip",
+            lambda ip, **_kw: (
+                "x1922c7s6b0n0.hostmgmt2001.cm.sunspot.alcf.anl.gov"
+            ),
+        )
+        log = _make_log(tmp_path, (
+            "Connection closed by peer [10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == ["x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"]
+
+    def test_non_sunspot_resolved_name_dropped(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "ezpz.failover.patterns.sunspot.reverse_resolve_ip",
+            lambda ip, **_kw: "some-unrelated-host.example.com",
+        )
+        log = _make_log(tmp_path, (
+            "Connection closed by peer [10.0.0.42]:12345\n"
+        ))
+        hosts = scrape_bad_nodes(log, machine="sunspot")
+        assert hosts == []
+
+
+class TestSunspotHostnameNormalizer:
+    """Direct unit tests of `normalize_sunspot_hostname`."""
+
+    def test_hsn_forms_pass_through(self):
+        from ezpz.failover.patterns.sunspot import normalize_sunspot_hostname
+
+        for h in (
+            "x1922c7s6b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov",
+            "x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov",
+        ):
+            assert normalize_sunspot_hostname(h) == h
+
+    def test_hostmgmt_rewritten_to_hsn(self):
+        from ezpz.failover.patterns.sunspot import normalize_sunspot_hostname
+
+        assert (
+            normalize_sunspot_hostname(
+                "x1922c7s6b0n0.hostmgmt2001.cm.sunspot.alcf.anl.gov"
+            )
+            == "x1922c7s6b0n0.hsn.cm.sunspot.alcf.anl.gov"
+        )
+
+    def test_junk_dropped(self):
+        from ezpz.failover.patterns.sunspot import normalize_sunspot_hostname
+
+        for h in (
+            "some-other-host",
+            "x1922c7s6b0n0.something-else.example.com",
+            "x4502c1s3b0n0.hsn.cm.aurora.alcf.anl.gov",  # Aurora suffix
+        ):
+            assert normalize_sunspot_hostname(h) is None
+
+
+# ---------------------------------------------------------------------------
 # Cross-pattern: dedup + ordering
 # ---------------------------------------------------------------------------
 

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -270,6 +270,44 @@ class TestClassifyAttempt:
             is TerminationReason.BAD_NODE_BLIND
         )
 
+    def test_pals_nonzero_exit_surfaces_as_143_is_bad_node(self, tmp_path):
+        """REGRESSION (live Sunspot job 12471663): on Aurora/Sunspot PALS a
+        rank's nonzero application exit tears the job down with SIGTERM, so
+        the aggregate shell rc is 143 (== _WALLTIME_RC) and the log shows
+        `<host>: rank N exited with code K` (K != 0) alongside innocent
+        `rank M died from signal 15` cascade lines. Before the
+        `rank N exited with code [1-9]` crash pattern, this classified as a
+        clean WALLTIME and the loop did NOT retry a genuine crash. It must
+        be a bad-node retry.
+        """
+        log = _write(
+            tmp_path / "log",
+            "some training output\n"
+            "x1921c2s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "rank 0 exited with code 1\n"
+            "x1921c2s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "rank 11 died from signal 15\n",
+        )
+        assert (
+            classify_attempt(143, log, []).reason
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_pals_clean_exit_code_0_not_treated_as_crash(self, tmp_path):
+        """Guard the `[1-9]` bound: PALS prints `rank N exited with code 0`
+        for every rank on a CLEAN shutdown. That must NOT count as a crash,
+        so a genuine walltime kill (rc=143) with only code-0 lines + signal
+        cascades stays WALLTIME.
+        """
+        log = _write(
+            tmp_path / "log",
+            "Execution finished with 0\n"
+            "x1921c2s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: "
+            "rank 0 exited with code 0\n"
+            "rank 1 died from signal 15\n",
+        )
+        assert classify_attempt(143, log, []).reason is TerminationReason.WALLTIME
+
     def test_watchdog_124_triggers_blind(self, tmp_path):
         log = _write(tmp_path / "log", "starting...\n")
         assert (

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -293,6 +293,38 @@ class TestClassifyAttempt:
             is TerminationReason.BAD_NODE_BLIND
         )
 
+    def test_pals_mixed_exit_codes_is_bad_node(self, tmp_path):
+        """rc=143 where PALS printed BOTH `exited with code 0` (clean ranks)
+        AND `exited with code 1` (the crashed rank). Any nonzero exit must
+        override the clean-shutdown noise → bad-node retry, not WALLTIME.
+        """
+        log = _write(
+            tmp_path / "log",
+            "x1921c2s1b0n0.hsn.cm.sunspot.alcf.anl.gov: "
+            "rank 0 exited with code 0\n"
+            "x1921c2s1b0n0.hsn.cm.sunspot.alcf.anl.gov: "
+            "rank 5 exited with code 1\n"
+            "rank 6 died from signal 15\n",
+        )
+        assert (
+            classify_attempt(143, log, []).reason
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
+    def test_pals_multidigit_exit_code_is_bad_node(self, tmp_path):
+        """Exit codes >= 10 (e.g. 137 = 128+SIGKILL/OOM) must count as a
+        crash — the pattern is `[1-9][0-9]*`, not a single digit.
+        """
+        log = _write(
+            tmp_path / "log",
+            "x1921c2s1b0n0.hsn.cm.sunspot.alcf.anl.gov: "
+            "rank 3 exited with code 137\n",
+        )
+        assert (
+            classify_attempt(143, log, []).reason
+            is TerminationReason.BAD_NODE_BLIND
+        )
+
     def test_pals_clean_exit_code_0_not_treated_as_crash(self, tmp_path):
         """Guard the `[1-9]` bound: PALS prints `rank N exited with code 0`
         for every rank on a CLEAN shutdown. That must NOT count as a crash,


### PR DESCRIPTION
## Summary

Adds Sunspot support to the failover stack and generalizes the `--auto-retry`
integration test driver — then **validates it end-to-end on a live 4-node
Sunspot allocation (7/7 scenarios pass)**, the first time the `ezpz launch
--auto-retry` swap-and-retry loop has run on real PALS hardware. The live run
also caught a **real classifier bug** (below).

## What's here

**1. `src/ezpz/failover/patterns/sunspot.py` (new).** Sunspot is Aurora's
test/dev twin (same PVC + PALS) but a different hostname suffix
(`.hsn.cm.sunspot.alcf.anl.gov`, optional `-hsnN` on the node token). Before
this, `scrape_bad_nodes` on Sunspot imported a nonexistent module → `[]` →
`--auto-retry` could only blind-rotate, never a named swap. Mirrors `aurora.py`.

**2. `fix(failover)`: retry when a nonzero rank exit surfaces as rc=143.**
Found by the live run. On PALS, a rank's nonzero app exit tears the job down
with SIGTERM → rc=143 (`_WALLTIME_RC`) + `rank N exited with code K`. That
wasn't a crash pattern, so a genuine crash was misread as a clean walltime kill
and NOT retried. Added `rank \d+ exited with code [1-9]` to the Python + bash
crash patterns (the `[1-9]` bound excludes PALS's clean `code 0` lines).

**3. Generalized PBS driver → `test_launch_auto_retry.pbs`.** `git mv` from
`_aurora.pbs`; runtime GPUs/node, per-machine qsub flags, preflight scraper
self-check, race-free marker-file fakes, `rc!=0` assertions, per-job log path.

## Tests
+11 Sunspot scrape tests, +2 classifier tests, +2 bash tests. **149 python +
23 bash failover tests pass; ruff clean.**

## Live Sunspot validation (job 12471669, 4 nodes)
Preflight named the real `-hsn0` host; **A–G all PASS (7/7)** — including
scenario **C's real named swap** driven by the new `sunspot.py` pattern.

## Test plan
- [x] Local: pytest (149) + bash (23) + ruff clean
- [x] Live Sunspot: 7/7 on a real 4-node allocation

## Summary by Sourcery

Add Sunspot-specific failover patterns and extend crash classification to correctly retry PALS nonzero-rank exits surfaced as rc=143.

New Features:
- Introduce Sunspot-specific bad-node scraping patterns and hostname normalization registered under the Sunspot machine key.
- Generalize the launch auto-retry PBS driver script to be machine-agnostic for running integration scenarios beyond Aurora.

Bug Fixes:
- Treat PALS logs with nonzero rank exit codes surfaced as rc=143 as bad-node crashes rather than clean walltime exits, while preserving clean handling of rank exit code 0 cases.

Tests:
- Add Sunspot scraping and hostname normalization unit tests to validate bad-node detection on Sunspot logs.
- Add regression tests in Python and bash to cover rc=143 classification for nonzero and zero rank exit codes in the auto-retry flow.