### PR TITLE
feat(utils): ezpz_setup <venv> auto-creates the venv when missing

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -2937,22 +2937,26 @@ ezpz_setup_env() {
 #   sets up the job.
 #
 # Flow B — venv path argument:
-#   Calls `ezpz_setup_job && ezpz_load_modules && source <venv>/bin/activate`.
-#   This is the "I have my own venv" path: it loads the BARE module stack
-#   (no frameworks/conda) and activates the venv you point at. The venv
-#   must already exist — this function will NOT create one for you
-#   (use `uv venv` after `ezpz_load_modules` if you need to bootstrap).
+#   Calls `ezpz_setup_job && ezpz_load_modules`, then activates <venv>/bin/
+#   activate. This is the "I have my own venv" path: it loads the BARE module
+#   stack (no frameworks/conda) and activates the venv you point at. If the
+#   venv does NOT exist, it is auto-created with
+#   `uv venv --system-site-packages` on top of the just-loaded modules (so it
+#   uses the correct module-provided python3 + inherits the framework build).
+#   Set `EZPZ_NO_AUTO_VENV=1` to disable auto-create and fail loudly instead
+#   (e.g. in CI). Auto-create requires `uv` on PATH.
 #
 # The two flows are mutually exclusive. Flow A's `ezpz_setup_python` would
 # load `frameworks`/`conda` on top of Flow B's bare modules, which double-
 # loads modules and risks version mismatches. Pick one based on intent.
 #
 # Args:
-#   $1 (optional): path to an existing venv to activate. Resolved to an
-#                  absolute path via `ezpz_realpath` so the activated venv
-#                  survives a later `cd` (the activate script exports
-#                  VIRTUAL_ENV, and many tools key off that).
-# Returns: 0 on success, 1 on failure (missing venv, module load failed, etc).
+#   $1 (optional): path to a venv to activate (created if missing; see Flow B).
+#                  Resolved to an absolute path via `ezpz_realpath` so the
+#                  activated venv survives a later `cd` (the activate script
+#                  exports VIRTUAL_ENV, and many tools key off that).
+# Returns: 0 on success, 1 on failure (module load failed, uv missing or
+#          venv absent under EZPZ_NO_AUTO_VENV=1, venv creation failed, etc).
 # -----------------------------------------------------------------------------
 ezpz_setup() {
 	local venv_path="${1:-}"
@@ -2980,13 +2984,12 @@ ezpz_setup() {
 		venv_abs="$(cd "$(dirname "${venv_path}")" 2>/dev/null && pwd)/$(basename "${venv_path}")"
 	fi
 	local activate="${venv_abs}/bin/activate"
-	if [[ ! -f "${activate}" ]]; then
-		log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET} (no ${activate})."
-		log_message ERROR "  - Create one first, e.g.:"
-		log_message ERROR "        ezpz_load_modules && uv venv ${venv_path}"
-		return 1
-	fi
 
+	# Load job env + modules BEFORE the venv existence check. Two reasons:
+	#   1. auto-creation (below) needs `uv` and the correct module-provided
+	#      python3 on PATH — creating against the bare login-node python would
+	#      silently produce a venv without the framework (e.g. torch+xpu) build.
+	#   2. even for an existing venv we want modules loaded first, unchanged.
 	if ! ezpz_setup_job; then
 		log_message ERROR "  - Job setup failed. Aborting."
 		return 1
@@ -2995,6 +2998,39 @@ ezpz_setup() {
 		log_message ERROR "  - Module load failed. Aborting."
 		return 1
 	fi
+
+	# Auto-create the venv when missing (the function's job is to land you in a
+	# working venv, and the modules loaded above provide `uv` + the right
+	# python3). Opt out with EZPZ_NO_AUTO_VENV=1 to restore the strict "must
+	# already exist" behavior (e.g. for CI that wants to fail loudly).
+	if [[ ! -f "${activate}" ]]; then
+		if [[ "${EZPZ_NO_AUTO_VENV:-0}" == "1" ]]; then
+			log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET} (no ${activate})."
+			log_message ERROR "  - EZPZ_NO_AUTO_VENV=1 set; not auto-creating. Create it with:"
+			log_message ERROR "        uv venv --system-site-packages ${venv_path}"
+			return 1
+		fi
+		if ! command -v uv >/dev/null 2>&1; then
+			log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET} and ${CYAN}uv${RESET} is not on PATH."
+			log_message ERROR "  - Install uv (or create the venv manually) then re-run:"
+			log_message ERROR "        uv venv --system-site-packages ${venv_path}"
+			return 1
+		fi
+		local _py
+		_py="$(command -v python3)"
+		log_message INFO "  - venv not found at ${CYAN}${venv_abs}${RESET}; creating with ${CYAN}uv${RESET} (python=${_py:-python3})..."
+		mkdir -p "$(dirname "${venv_abs}")" 2>/dev/null || true
+		if ! uv venv --python="${_py:-python3}" --system-site-packages "${venv_abs}"; then
+			log_message ERROR "  - Failed to create venv at ${RED}${venv_abs}${RESET}."
+			return 1
+		fi
+		if [[ ! -f "${activate}" ]]; then
+			log_message ERROR "  - venv creation reported success but ${activate} is missing."
+			return 1
+		fi
+		log_message INFO "  ${GREEN}[✓]${RESET} Created venv at: ${CYAN}${venv_abs}${RESET}"
+	fi
+
 	# shellcheck source=/dev/null
 	if ! source "${activate}"; then
 		log_message ERROR "  - Failed to activate venv at ${venv_abs}."

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -2977,11 +2977,16 @@ ezpz_setup() {
 	# to silently rewrite.
 	local venv_abs
 	if ! venv_abs=$(ezpz_realpath "${venv_path}" 2>/dev/null); then
-		# ezpz_realpath fails when the parent dir doesn't exist; fall back
-		# to a plain abs-path computation that doesn't require the target
-		# to exist, so the error message below can name the path the user
-		# typed (in absolute form, which is easier to debug than `.venv`).
-		venv_abs="$(cd "$(dirname "${venv_path}")" 2>/dev/null && pwd)/$(basename "${venv_path}")"
+		# ezpz_realpath fails when the parent dir doesn't exist. Build the
+		# absolute path WITHOUT requiring the parent to exist: a `cd` into a
+		# missing parent yields an empty string, so the old
+		# "$(cd $(dirname ...) && pwd)/$(basename ...)" form collapsed
+		# `venvs/run` to `/run` — and since we now CREATE the venv, that would
+		# mkdir at the filesystem root. Just prefix $PWD for relative paths.
+		case "${venv_path}" in
+		/*) venv_abs="${venv_path}" ;;
+		*) venv_abs="${PWD}/${venv_path}" ;;
+		esac
 	fi
 	local activate="${venv_abs}/bin/activate"
 
@@ -3007,18 +3012,45 @@ ezpz_setup() {
 		if [[ "${EZPZ_NO_AUTO_VENV:-0}" == "1" ]]; then
 			log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET} (no ${activate})."
 			log_message ERROR "  - EZPZ_NO_AUTO_VENV=1 set; not auto-creating. Create it with:"
-			log_message ERROR "        uv venv --system-site-packages ${venv_path}"
+			log_message ERROR "        uv venv --system-site-packages ${venv_abs}"
 			return 1
 		fi
 		if ! command -v uv >/dev/null 2>&1; then
 			log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET} and ${CYAN}uv${RESET} is not on PATH."
 			log_message ERROR "  - Install uv (or create the venv manually) then re-run:"
-			log_message ERROR "        uv venv --system-site-packages ${venv_path}"
+			log_message ERROR "        uv venv --system-site-packages ${venv_abs}"
 			return 1
 		fi
 		local _py
 		_py="$(command -v python3)"
-		log_message INFO "  - venv not found at ${CYAN}${venv_abs}${RESET}; creating with ${CYAN}uv${RESET} (python=${_py:-python3})..."
+		if [[ -z "${_py}" ]]; then
+			log_message ERROR "  - No python3 on PATH; cannot create a venv."
+			return 1
+		fi
+		# `ezpz_load_modules` deliberately loads only the BARE stack (oneAPI /
+		# PrgEnv / CUDA deps) — NOT frameworks/conda — so on a clean login shell
+		# `python3` may be the system interpreter with no accelerator torch.
+		# Creating with --system-site-packages against it would "succeed" while
+		# exposing nothing useful, leaving a torch-less venv that fails later
+		# and confusingly. Check for torch and refuse with an actionable message
+		# instead of silently building the wrong thing. EZPZ_ALLOW_BARE_VENV=1
+		# proceeds anyway (e.g. a CPU-only box, or you plan to install torch
+		# yourself).
+		if ! "${_py}" -c "import torch" >/dev/null 2>&1; then
+			if [[ "${EZPZ_ALLOW_BARE_VENV:-0}" != "1" ]]; then
+				log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET}, and the python3 on PATH"
+				log_message ERROR "    (${CYAN}${_py}${RESET}) has no ${CYAN}torch${RESET} — the bare module stack does not"
+				log_message ERROR "    provide a framework python, so auto-creating here would give you a"
+				log_message ERROR "    venv WITHOUT the accelerator torch build. Do one of:"
+				log_message ERROR "      1. use the all-in-one flow (loads frameworks/conda + makes a venv):"
+				log_message ERROR "             ${CYAN}ezpz_setup${RESET}          # no venv argument"
+				log_message ERROR "      2. load a framework python yourself, then re-run this command"
+				log_message ERROR "      3. ${CYAN}EZPZ_ALLOW_BARE_VENV=1${RESET} to create against ${_py} anyway"
+				return 1
+			fi
+			log_message WARN "  - python3 (${_py}) has no torch; creating anyway (EZPZ_ALLOW_BARE_VENV=1)."
+		fi
+		log_message INFO "  - venv not found at ${CYAN}${venv_abs}${RESET}; creating with ${CYAN}uv${RESET} (python=${_py})..."
 		mkdir -p "$(dirname "${venv_abs}")" 2>/dev/null || true
 		if ! uv venv --python="${_py:-python3}" --system-site-packages "${venv_abs}"; then
 			log_message ERROR "  - Failed to create venv at ${RED}${venv_abs}${RESET}."

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -2990,6 +2990,19 @@ ezpz_setup() {
 	fi
 	local activate="${venv_abs}/bin/activate"
 
+	# If the caller already has a torch-bearing python active (e.g. they ran
+	# `module load frameworks/...` first), remember it NOW: ezpz_load_modules
+	# below loads the bare stack, and on Aurora/Sunspot `module load oneapi/...`
+	# swaps MODULEPATH and EVICTS a previously-loaded frameworks module —
+	# leaving `python3` as the system 3.6 interpreter. Without this, telling a
+	# user to "load a framework python and re-run" is impossible advice, since
+	# this function would throw their python away before using it.
+	local _preloaded_py=""
+	if command -v python3 >/dev/null 2>&1 \
+		&& python3 -c "import torch" >/dev/null 2>&1; then
+		_preloaded_py="$(command -v python3)"
+	fi
+
 	# Load job env + modules BEFORE the venv existence check. Two reasons:
 	#   1. auto-creation (below) needs `uv` and the correct module-provided
 	#      python3 on PATH — creating against the bare login-node python would
@@ -3022,30 +3035,43 @@ ezpz_setup() {
 			return 1
 		fi
 		local _py
-		_py="$(command -v python3)"
+		# Prefer the torch-bearing python captured BEFORE ezpz_load_modules ran
+		# (see _preloaded_py above): on Aurora/Sunspot the bare `oneapi` load
+		# evicts a user's frameworks module, so the post-load `python3` is the
+		# system 3.6 interpreter even when the user did the right thing.
+		if [[ -n "${_preloaded_py}" ]]; then
+			_py="${_preloaded_py}"
+			log_message INFO "  - Using the framework python you had loaded: ${CYAN}${_py}${RESET}"
+		else
+			_py="$(command -v python3)"
+		fi
 		if [[ -z "${_py}" ]]; then
 			log_message ERROR "  - No python3 on PATH; cannot create a venv."
 			return 1
 		fi
 		# `ezpz_load_modules` deliberately loads only the BARE stack (oneAPI /
 		# PrgEnv / CUDA deps) — NOT frameworks/conda — so on a clean login shell
-		# `python3` may be the system interpreter with no accelerator torch.
-		# Creating with --system-site-packages against it would "succeed" while
-		# exposing nothing useful, leaving a torch-less venv that fails later
-		# and confusingly. Check for torch and refuse with an actionable message
-		# instead of silently building the wrong thing. EZPZ_ALLOW_BARE_VENV=1
-		# proceeds anyway (e.g. a CPU-only box, or you plan to install torch
-		# yourself).
+		# `python3` may be the system interpreter with no accelerator torch
+		# (observed on Sunspot: /usr/bin/python3 == 3.6.15, which is also below
+		# this project's requires-python). Creating with --system-site-packages
+		# against it would "succeed" while exposing nothing useful, leaving a
+		# broken venv that fails later and confusingly. Refuse with actionable
+		# guidance instead. EZPZ_ALLOW_BARE_VENV=1 proceeds anyway.
 		if ! "${_py}" -c "import torch" >/dev/null 2>&1; then
 			if [[ "${EZPZ_ALLOW_BARE_VENV:-0}" != "1" ]]; then
-				log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET}, and the python3 on PATH"
+				log_message ERROR "  - venv not found at ${RED}${venv_abs}${RESET}, and the available python3"
 				log_message ERROR "    (${CYAN}${_py}${RESET}) has no ${CYAN}torch${RESET} — the bare module stack does not"
 				log_message ERROR "    provide a framework python, so auto-creating here would give you a"
 				log_message ERROR "    venv WITHOUT the accelerator torch build. Do one of:"
 				log_message ERROR "      1. use the all-in-one flow (loads frameworks/conda + makes a venv):"
 				log_message ERROR "             ${CYAN}ezpz_setup${RESET}          # no venv argument"
-				log_message ERROR "      2. load a framework python yourself, then re-run this command"
-				log_message ERROR "      3. ${CYAN}EZPZ_ALLOW_BARE_VENV=1${RESET} to create against ${_py} anyway"
+				log_message ERROR "      2. load a framework python FIRST, then re-run — e.g."
+				log_message ERROR "             ${CYAN}module load frameworks${RESET} && ${CYAN}ezpz_setup ${venv_path}${RESET}"
+				log_message ERROR "         (it is picked up even though the bare module load evicts it)"
+				log_message ERROR "      3. create it yourself, then re-run:"
+				log_message ERROR "             ${CYAN}uv venv --system-site-packages ${venv_abs}${RESET}"
+				log_message ERROR "      4. ${CYAN}EZPZ_ALLOW_BARE_VENV=1${RESET} to build against ${_py} anyway"
+				log_message ERROR "         (NOT recommended on Aurora/Sunspot: yields a python 3.6 venv)"
 				return 1
 			fi
 			log_message WARN "  - python3 (${_py}) has no torch; creating anyway (EZPZ_ALLOW_BARE_VENV=1)."

--- a/tests/test_ezpz_setup_venv.sh
+++ b/tests/test_ezpz_setup_venv.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# test_ezpz_setup_venv.sh — unit tests for ezpz_setup()'s Flow B (venv-arg)
+# auto-create behavior in src/ezpz/bin/utils.sh.
+#
+# Run from the repo root:
+#   bash tests/test_ezpz_setup_venv.sh
+#
+# ezpz_setup() is embedded in a 3000-line utils.sh whose other helpers touch
+# real modules/schedulers, so instead of sourcing the whole file we EXTRACT
+# just the ezpz_setup function body and run it against STUBS for its
+# dependencies (ezpz_setup_job, ezpz_load_modules, log_message, ezpz_realpath)
+# plus a fake `uv` on PATH. This isolates the branching logic:
+#
+#   1. missing venv + uv present        -> auto-creates, activates
+#   2. missing venv + EZPZ_NO_AUTO_VENV -> errors, does NOT create
+#   3. missing venv + no uv on PATH     -> errors cleanly
+#   4. existing venv                     -> activates, does NOT re-create
+#   5. modules loaded BEFORE the venv check (ordering guard)
+#
+# Each test runs in its own temp dir + subshell.
+
+set -u
+unset CDPATH
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+    G=$'\033[1;32m'; R=$'\033[1;31m'; C=$'\033[1;36m'; N=$'\033[0m'
+else
+    G=""; R=""; C=""; N=""
+fi
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
+UTILS="${REPO_ROOT}/src/ezpz/bin/utils.sh"
+if [[ ! -f "${UTILS}" ]]; then
+    printf "%sFATAL%s: utils.sh not found at %s\n" "${R}" "${N}" "${UTILS}" >&2
+    exit 1
+fi
+
+# Extract just the `ezpz_setup() { ... }` function into a temp file we can
+# source in isolation. awk from the def line to the first line that is exactly
+# a closing brace at column 0.
+EZPZ_SETUP_FN="$(mktemp "/tmp/ezpz-setup-fn-XXXXXX.sh")"
+awk '/^ezpz_setup\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "${UTILS}" > "${EZPZ_SETUP_FN}"
+if ! grep -q "EZPZ_NO_AUTO_VENV" "${EZPZ_SETUP_FN}"; then
+    printf "%sFATAL%s: extracted ezpz_setup lacks the auto-venv logic\n" "${R}" "${N}" >&2
+    rm -f "${EZPZ_SETUP_FN}"; exit 1
+fi
+
+# ---- stubs shared by all tests --------------------------------------------
+# A preamble sourced before the function so its dependencies exist. Records
+# call order in $ORDER_LOG so we can assert modules load before the venv check.
+_make_preamble() {
+    cat <<'STUB'
+# color/format vars the function references
+BRIGHT_GREEN=""; RESET=""; CYAN=""; GREEN=""; RED=""
+log_message() { :; }                 # silence; tests assert on state not logs
+ezpz_realpath() { ( cd "$(dirname "$1")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$1")" ); }
+ezpz_setup_job()   { printf 'job\n'  >> "${ORDER_LOG}"; return 0; }
+ezpz_load_modules(){ printf 'mods\n' >> "${ORDER_LOG}"; return 0; }
+STUB
+}
+
+# A fake `uv` that actually creates a minimal venv (bin/activate) so the
+# post-create activation succeeds. Records that it ran.
+_make_fake_uv() {
+    local dir="$1"
+    cat > "${dir}/uv" <<'UVEOF'
+#!/usr/bin/env bash
+# fake uv: parse the final arg as the venv dir, create bin/activate
+printf 'uv-ran\n' >> "${ORDER_LOG}"
+venv="${@: -1}"
+mkdir -p "${venv}/bin"
+printf '# fake activate\n' > "${venv}/bin/activate"
+exit 0
+UVEOF
+    chmod +x "${dir}/uv"
+}
+
+run_test() {
+    local name="$1" fn="$2"
+    printf "  %s%-55s%s " "${C}" "${name}" "${N}"
+    local tmpdir output
+    tmpdir=$(mktemp -d "/tmp/ezpz-setup-test-XXXXXX")
+    if output=$(
+        cd "${tmpdir}"
+        export ORDER_LOG="${tmpdir}/order.log"
+        : > "${ORDER_LOG}"
+        # shellcheck disable=SC1090
+        source <(_make_preamble)
+        # shellcheck disable=SC1090
+        source "${EZPZ_SETUP_FN}"
+        "${fn}"
+    ) 2>&1; then
+        PASS=$((PASS+1)); printf "%sPASS%s\n" "${G}" "${N}"
+    else
+        FAIL=$((FAIL+1)); FAILED_TESTS+=("${name}")
+        printf "%sFAIL%s\n" "${R}" "${N}"
+        printf "%s\n" "${output}" | sed 's/^/      /'
+    fi
+    rm -rf "${tmpdir}"
+}
+
+assert() { # assert <cond-cmd...>; message via $MSG
+    if ! "$@"; then printf "ASSERT FAIL: %s\n" "$*" >&2; exit 1; fi
+}
+assert_file() { [[ -f "$1" ]] || { printf "ASSERT FAIL: missing file %s\n" "$1" >&2; exit 1; }; }
+assert_no_file() { [[ ! -f "$1" ]] || { printf "ASSERT FAIL: unexpected file %s\n" "$1" >&2; exit 1; }; }
+assert_contains_file() { grep -q "$2" "$1" || { printf "ASSERT FAIL: %s not in %s\n" "$2" "$1" >&2; exit 1; }; }
+
+# ---- tests -----------------------------------------------------------------
+
+test_auto_create_when_missing() {
+    _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
+    unset EZPZ_NO_AUTO_VENV
+    ezpz_setup ".venv" || return 1
+    assert_file "${tmpdir}/.venv/bin/activate"     # created
+    assert_contains_file "${ORDER_LOG}" "uv-ran"   # uv actually invoked
+}
+
+test_no_auto_venv_opt_out() {
+    _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
+    export EZPZ_NO_AUTO_VENV=1
+    if ezpz_setup ".venv"; then
+        printf "ASSERT FAIL: expected nonzero exit under EZPZ_NO_AUTO_VENV=1\n" >&2
+        return 1
+    fi
+    assert_no_file "${tmpdir}/.venv/bin/activate"  # NOT created
+    ! grep -q "uv-ran" "${ORDER_LOG}" || { printf "ASSERT FAIL: uv ran despite opt-out\n" >&2; return 1; }
+}
+
+test_no_uv_available_errors() {
+    # No fake uv on PATH, and neutralize any real uv so creation can't happen.
+    unset EZPZ_NO_AUTO_VENV
+    uv() { return 127; }; export -f uv 2>/dev/null || true
+    # Also shadow command -v uv by putting a PATH without uv is hard; instead
+    # rely on the function's `command -v uv` — so ensure no uv on a clean PATH.
+    export PATH="/usr/bin:/bin"
+    if command -v uv >/dev/null 2>&1; then
+        printf "SKIP: uv present on minimal PATH; cannot test no-uv branch\n" >&2
+        return 0
+    fi
+    if ezpz_setup ".venv"; then
+        printf "ASSERT FAIL: expected nonzero exit when uv missing\n" >&2
+        return 1
+    fi
+    assert_no_file "${tmpdir}/.venv/bin/activate"
+}
+
+test_existing_venv_not_recreated() {
+    _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
+    unset EZPZ_NO_AUTO_VENV
+    mkdir -p "${tmpdir}/.venv/bin"
+    printf '# preexisting\n' > "${tmpdir}/.venv/bin/activate"
+    ezpz_setup ".venv" || return 1
+    # uv must NOT have run (venv already existed)
+    ! grep -q "uv-ran" "${ORDER_LOG}" || { printf "ASSERT FAIL: uv ran on existing venv\n" >&2; return 1; }
+    assert_contains_file "${tmpdir}/.venv/bin/activate" "preexisting"  # untouched
+}
+
+test_modules_loaded_before_venv_check() {
+    _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
+    unset EZPZ_NO_AUTO_VENV
+    ezpz_setup ".venv" || return 1
+    # order.log must show job + mods BEFORE uv-ran (creation)
+    local order; order="$(tr '\n' ',' < "${ORDER_LOG}")"
+    case "${order}" in
+        job,mods,uv-ran,*) : ;;  # correct ordering
+        *) printf "ASSERT FAIL: bad order %q (want job,mods,uv-ran)\n" "${order}" >&2; return 1 ;;
+    esac
+}
+
+# ---- run -------------------------------------------------------------------
+printf "\n%sezpz_setup() Flow B auto-venv tests%s\n" "${C}" "${N}"
+run_test "auto-create when missing"          test_auto_create_when_missing
+run_test "EZPZ_NO_AUTO_VENV opt-out"         test_no_auto_venv_opt_out
+run_test "no uv available -> clean error"    test_no_uv_available_errors
+run_test "existing venv not recreated"       test_existing_venv_not_recreated
+run_test "modules load before venv check"    test_modules_loaded_before_venv_check
+
+rm -f "${EZPZ_SETUP_FN}"
+printf "\n%d passed, %d failed\n" "${PASS}" "${FAIL}"
+if (( FAIL > 0 )); then
+    printf "%sFAILED:%s %s\n" "${R}" "${N}" "${FAILED_TESTS[*]}"
+    exit 1
+fi
+exit 0

--- a/tests/test_ezpz_setup_venv.sh
+++ b/tests/test_ezpz_setup_venv.sh
@@ -22,7 +22,9 @@
 #   6. relative path, missing parent     -> resolves under $PWD, NOT / (the
 #                                           old fallback collapsed venvs/run
 #                                           to /run and would mkdir at root)
-#   7. modules loaded BEFORE the venv check (ordering guard)
+#   7. a PRE-LOADED framework python survives ezpz_load_modules evicting it
+#                                          -> used for creation anyway
+#   8. modules loaded BEFORE the venv check (ordering guard)
 #
 # Each test runs in its own temp dir + subshell.
 
@@ -154,6 +156,37 @@ PYEOF
         printf "ASSERT FAIL: uv ran despite the no-torch guard\n" >&2; return 1; }
 }
 
+test_preloaded_framework_python_survives_module_load() {
+    # Sunspot-observed scenario: the user runs `module load frameworks` (so
+    # python3 HAS torch), then calls ezpz_setup. ezpz_load_modules loads the
+    # bare oneapi stack, which swaps MODULEPATH and EVICTS the frameworks
+    # module — leaving python3 as the system 3.6 interpreter with no torch.
+    # The pre-load capture must keep the user's torch python for creation,
+    # otherwise the guard refuses and the "load a framework python and re-run"
+    # remedy is impossible advice.
+    _make_fake_uv "${tmpdir}"
+    local good="${tmpdir}/goodbin" bare="${tmpdir}/barebin"
+    mkdir -p "${good}" "${bare}"
+    # torch-bearing python (pre-load)
+    printf '#!/usr/bin/env bash\nexit 0\n' > "${good}/python3"    # import torch OK
+    # bare python (post-load): import torch fails
+    printf '#!/usr/bin/env bash\nexit 1\n' > "${bare}/python3"
+    chmod +x "${good}/python3" "${bare}/python3"
+    # start with the GOOD python visible...
+    export PATH="${good}:${tmpdir}:${PATH}"
+    # ...and make ezpz_load_modules evict it, exactly like `module load oneapi`.
+    ezpz_load_modules() {
+        printf 'mods\n' >> "${ORDER_LOG}"
+        export PATH="${bare}:${tmpdir}:/usr/bin:/bin"
+        return 0
+    }
+    unset EZPZ_NO_AUTO_VENV EZPZ_ALLOW_BARE_VENV
+    ezpz_setup ".venv" || {
+        printf "ASSERT FAIL: refused despite a pre-loaded torch python\n" >&2; return 1; }
+    assert_file "${tmpdir}/.venv/bin/activate"
+    assert_contains_file "${ORDER_LOG}" "uv-ran"
+}
+
 test_relative_path_with_missing_parent() {
     # P2: `ezpz_setup venvs/run` when `venvs/` does not exist must resolve to
     # $PWD/venvs/run — the old fallback collapsed it to /run (filesystem root!),
@@ -237,6 +270,7 @@ run_test "EZPZ_NO_AUTO_VENV opt-out"         test_no_auto_venv_opt_out
 run_test "no uv available -> clean error"    test_no_uv_available_errors
 run_test "existing venv not recreated"       test_existing_venv_not_recreated
 run_test "refuses when python3 lacks torch"   test_refuses_when_python_has_no_torch
+run_test "preloaded framework python survives"  test_preloaded_framework_python_survives_module_load
 run_test "relative path, missing parent"     test_relative_path_with_missing_parent
 run_test "modules load before venv check"    test_modules_loaded_before_venv_check
 

--- a/tests/test_ezpz_setup_venv.sh
+++ b/tests/test_ezpz_setup_venv.sh
@@ -11,11 +11,18 @@
 # dependencies (ezpz_setup_job, ezpz_load_modules, log_message, ezpz_realpath)
 # plus a fake `uv` on PATH. This isolates the branching logic:
 #
-#   1. missing venv + uv present        -> auto-creates, activates
-#   2. missing venv + EZPZ_NO_AUTO_VENV -> errors, does NOT create
-#   3. missing venv + no uv on PATH     -> errors cleanly
+#   1. missing venv + uv present         -> auto-creates, activates
+#   2. missing venv + EZPZ_NO_AUTO_VENV  -> errors, does NOT create
+#   3. missing venv + no uv on PATH      -> errors cleanly
 #   4. existing venv                     -> activates, does NOT re-create
-#   5. modules loaded BEFORE the venv check (ordering guard)
+#   5. python3 without torch             -> refuses (bare module stack has no
+#                                           framework python; would build a
+#                                           torch-less venv) unless
+#                                           EZPZ_ALLOW_BARE_VENV=1
+#   6. relative path, missing parent     -> resolves under $PWD, NOT / (the
+#                                           old fallback collapsed venvs/run
+#                                           to /run and would mkdir at root)
+#   7. modules loaded BEFORE the venv check (ordering guard)
 #
 # Each test runs in its own temp dir + subshell.
 
@@ -116,9 +123,48 @@ assert_contains_file() { grep -q "$2" "$1" || { printf "ASSERT FAIL: %s not in %
 test_auto_create_when_missing() {
     _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
     unset EZPZ_NO_AUTO_VENV
+    # The framework-python guard would otherwise refuse (test python3 has no
+    # torch); this test covers the CREATION branching, not torch detection —
+    # that's test_refuses_when_python_has_no_torch below.
+    export EZPZ_ALLOW_BARE_VENV=1
     ezpz_setup ".venv" || return 1
     assert_file "${tmpdir}/.venv/bin/activate"     # created
     assert_contains_file "${ORDER_LOG}" "uv-ran"   # uv actually invoked
+}
+
+test_refuses_when_python_has_no_torch() {
+    # P1 guard: the bare module stack has no framework python, so creating
+    # --system-site-packages against it yields a torch-less venv. Refuse loudly
+    # (unless EZPZ_ALLOW_BARE_VENV=1) instead of silently building the wrong env.
+    _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
+    unset EZPZ_NO_AUTO_VENV EZPZ_ALLOW_BARE_VENV
+    # Shadow python3 with one that has no torch (import torch fails).
+    cat > "${tmpdir}/python3" <<'PYEOF'
+#!/usr/bin/env bash
+# stub python3: `-c "import torch"` always fails
+exit 1
+PYEOF
+    chmod +x "${tmpdir}/python3"
+    if ezpz_setup ".venv"; then
+        printf "ASSERT FAIL: expected refusal when python3 lacks torch\n" >&2
+        return 1
+    fi
+    assert_no_file "${tmpdir}/.venv/bin/activate"   # nothing created
+    ! grep -q "uv-ran" "${ORDER_LOG}" || {
+        printf "ASSERT FAIL: uv ran despite the no-torch guard\n" >&2; return 1; }
+}
+
+test_relative_path_with_missing_parent() {
+    # P2: `ezpz_setup venvs/run` when `venvs/` does not exist must resolve to
+    # $PWD/venvs/run — the old fallback collapsed it to /run (filesystem root!),
+    # which the auto-create would then mkdir.
+    _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
+    unset EZPZ_NO_AUTO_VENV
+    export EZPZ_ALLOW_BARE_VENV=1
+    ezpz_setup "venvs/run" || return 1
+    assert_file "${tmpdir}/venvs/run/bin/activate"   # under CWD, not /run
+    [[ ! -e /run/bin/activate ]] || {
+        printf "ASSERT FAIL: created a venv at the filesystem root (/run)\n" >&2; return 1; }
 }
 
 test_no_auto_venv_opt_out() {
@@ -135,13 +181,23 @@ test_no_auto_venv_opt_out() {
 test_no_uv_available_errors() {
     # No fake uv on PATH, and neutralize any real uv so creation can't happen.
     unset EZPZ_NO_AUTO_VENV
-    uv() { return 127; }; export -f uv 2>/dev/null || true
-    # Also shadow command -v uv by putting a PATH without uv is hard; instead
-    # rely on the function's `command -v uv` — so ensure no uv on a clean PATH.
-    export PATH="/usr/bin:/bin"
+    # Do NOT define a `uv()` shell function to fake absence: `command -v uv`
+    # finds functions, so the no-uv branch would never be exercised (and the
+    # test would silently pass via the SKIP path). Instead point PATH at a
+    # directory containing ONLY the handful of binaries the function needs,
+    # guaranteeing `uv` is genuinely unreachable.
+    local bindir="${tmpdir}/nopath-bin"
+    mkdir -p "${bindir}"
+    local prog
+    for prog in bash dirname basename mkdir pwd cd python3; do
+        local src
+        src="$(command -v "${prog}" 2>/dev/null)" || continue
+        ln -sf "${src}" "${bindir}/${prog}" 2>/dev/null || true
+    done
+    export PATH="${bindir}"
     if command -v uv >/dev/null 2>&1; then
-        printf "SKIP: uv present on minimal PATH; cannot test no-uv branch\n" >&2
-        return 0
+        printf "ASSERT FAIL: uv still reachable on the stripped PATH\n" >&2
+        return 1
     fi
     if ezpz_setup ".venv"; then
         printf "ASSERT FAIL: expected nonzero exit when uv missing\n" >&2
@@ -164,6 +220,7 @@ test_existing_venv_not_recreated() {
 test_modules_loaded_before_venv_check() {
     _make_fake_uv "${tmpdir}"; export PATH="${tmpdir}:${PATH}"
     unset EZPZ_NO_AUTO_VENV
+    export EZPZ_ALLOW_BARE_VENV=1
     ezpz_setup ".venv" || return 1
     # order.log must show job + mods BEFORE uv-ran (creation)
     local order; order="$(tr '\n' ',' < "${ORDER_LOG}")"
@@ -179,6 +236,8 @@ run_test "auto-create when missing"          test_auto_create_when_missing
 run_test "EZPZ_NO_AUTO_VENV opt-out"         test_no_auto_venv_opt_out
 run_test "no uv available -> clean error"    test_no_uv_available_errors
 run_test "existing venv not recreated"       test_existing_venv_not_recreated
+run_test "refuses when python3 lacks torch"   test_refuses_when_python_has_no_torch
+run_test "relative path, missing parent"     test_relative_path_with_missing_parent
 run_test "modules load before venv check"    test_modules_loaded_before_venv_check
 
 rm -f "${EZPZ_SETUP_FN}"


### PR DESCRIPTION
## Summary

`source <(curl -fsSL https://bit.ly/ezpz-utils) && ezpz_setup .venv` previously
**failed** on first run because Flow B (venv-path argument) required the venv to
already exist. This makes it auto-create the venv when missing, so the one-liner
works out of the box.

## Why

The function's whole job is "land me in a working venv." When the venv was
absent it errored — and the error message literally printed the one command to
run (`uv venv ...`). `uv` and the right python3 are already on PATH by that
point, so refusing to create was friction with no safety payoff.

## What changed (`src/ezpz/bin/utils.sh`, `ezpz_setup` Flow B)

1. **Reorder** — `ezpz_setup_job` + `ezpz_load_modules` now run **before** the
   venv existence check. Creating against the bare login-node python would
   silently produce a venv without the framework (torch+xpu) build; loading
   modules first means both auto-create and manual `uv venv` use the correct
   module-provided `python3`.
2. **Auto-create** — when `<venv>/bin/activate` is missing, create it with
   `uv venv --python=<module python3> --system-site-packages` (the same recipe
   the Flow A / `ezpz_setup_uv_venv` path already uses).
3. **Opt-out** — `EZPZ_NO_AUTO_VENV=1` restores the strict "must already exist"
   behavior (e.g. CI that wants to fail loudly). Clean error if `uv` is absent.

Existing-venv behavior is unchanged (activate, never re-create). Flow A (no arg)
is untouched.

## Tests

`tests/test_ezpz_setup_venv.sh` extracts `ezpz_setup` and drives Flow B against
stubbed deps + a fake `uv` (no cluster needed): auto-create when missing,
`EZPZ_NO_AUTO_VENV` opt-out, no-`uv` clean error, existing venv left untouched,
and the module-load-before-venv-check ordering guard. Mirrors the
`test_failover_lib.sh` harness. `bash -n` clean; 5/5 pass locally.

## Compatibility note

This changes the behavior of the **published** `utils.sh` behind
`bit.ly/ezpz-utils` — everyone sourcing it gets auto-create. The one behavioral
surprise (a `curl | source` flow now creating a directory) is surfaced by a log
line and gated by the `EZPZ_NO_AUTO_VENV` opt-out.

## Test plan
- [x] `bash -n src/ezpz/bin/utils.sh`
- [x] `bash tests/test_ezpz_setup_venv.sh` (5/5)
- [ ] On a real login node: `ezpz_setup .venv` with no `.venv` present creates + activates it

## Summary by Sourcery

Enable ezpz_setup to automatically create a missing virtual environment when a venv path is provided, while preserving existing-venv behaviour and adding an opt-out for strict mode.

New Features:
- Add automatic venv creation in ezpz_setup when a specified venv does not exist, using uv with system site packages after loading the job and module environment.
- Introduce the EZPZ_NO_AUTO_VENV environment variable to disable auto-creation and enforce failure when the venv is absent.

Tests:
- Add a dedicated bash test harness for ezpz_setup Flow B to cover auto-creation, opt-out behaviour, missing-uv error handling, non-recreation of existing venvs, and module-load ordering.