### PR TITLE
feat(llama): use enable_gqa for SDPA instead of materializing repeat_kv

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,6 +190,8 @@ MLFLOW_TRACKING_INSECURE_TLS=true
 | Variable | Purpose | Values / Default |
 |----------|---------|-----------------|
 | `EZPZ_ATTENTION_FP32` | Force FP32 attention in LLaMA models. | Set to `1` to enable. |
+| `EZPZ_SDPA_ENABLE_GQA` | Let SDPA broadcast the kv heads (`enable_gqa=True`) instead of materializing them with `repeat_kv`. Saves memory/bandwidth and avoids an XPU `torch.compile` backward stride assert. | `1` (default). Set to `0` to use `repeat_kv`. |
+| `EZPZ_SDPA_CONTIGUOUS` | Force `q`/`k`/`v` contiguous before SDPA. Alternative workaround for the same XPU `torch.compile` stride assert; costs an extra copy. | Set to `1` to enable. |
 | `EZPZ_DEBUG_NAN` | Enable NaN debugging in model forward pass. | Set to `1` to enable. |
 | `PYINSTRUMENT_PROFILER` | Enable pyinstrument profiling. | Set to `1` to enable. |
 

--- a/src/ezpz/models/llama.py
+++ b/src/ezpz/models/llama.py
@@ -386,25 +386,48 @@ class Attention(nn.Module):
             xq, xk, freqs_cis=freqs_cis, theta=self.rope_theta
         )
 
-        keys = repeat_kv(
-            xk, self.n_rep
-        )  # (bs, seqlen, n_local_heads, head_dim)
-        values = repeat_kv(
-            xv, self.n_rep
-        )  # (bs, seqlen, n_local_heads, head_dim)
+        # `enable_gqa=True` lets SDPA broadcast the kv heads internally, so we
+        # skip materializing the repeated heads. Besides saving the memory and
+        # bandwidth of the expanded k/v, this avoids the expand+reshape that
+        # triggers the XPU backward stride assert described below. Set
+        # EZPZ_SDPA_ENABLE_GQA=0 to fall back to the explicit `repeat_kv`.
+        enable_gqa = os.environ.get("EZPZ_SDPA_ENABLE_GQA", "1") == "1"
+        if enable_gqa:
+            keys, values = xk, xv
+        else:
+            keys = repeat_kv(
+                xk, self.n_rep
+            )  # (bs, seqlen, n_local_heads, head_dim)
+            values = repeat_kv(
+                xv, self.n_rep
+            )  # (bs, seqlen, n_local_heads, head_dim)
 
         xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        xk = keys.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        xv = values.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xk = keys.transpose(1, 2)  # (bs, n_local_kv_heads, seqlen, head_dim)
+        xv = values.transpose(1, 2)  # (bs, n_local_kv_heads, seqlen, head_dim)
+
+        # The transpose above (plus rotary flatten and GQA repeat_kv) leaves
+        # q/k/v non-contiguous. Under torch.compile on XPU the flash-attention
+        # backward meta kernel mispredicts the output strides for such inputs,
+        # tripping an assert_size_stride guard in the generated backward. Making
+        # the inputs contiguous keeps the layout the meta kernel expects.
+        if os.environ.get("EZPZ_SDPA_CONTIGUOUS") == "1":
+            xq = xq.contiguous()
+            xk = xk.contiguous()
+            xv = xv.contiguous()
 
         # we use casual mask for training
         if os.environ.get("EZPZ_ATTENTION_FP32") == "1":
             output = F.scaled_dot_product_attention(
-                xq.float(), xk.float(), xv.float(), is_causal=True
+                xq.float(),
+                xk.float(),
+                xv.float(),
+                is_causal=True,
+                enable_gqa=enable_gqa,
             ).to(xq.dtype)
         else:
             output = F.scaled_dot_product_attention(
-                xq, xk, xv, is_causal=True
+                xq, xk, xv, is_causal=True, enable_gqa=enable_gqa
             )
         output = output.transpose(
             1, 2

--- a/tests/test_llama_attention_gqa.py
+++ b/tests/test_llama_attention_gqa.py
@@ -1,0 +1,113 @@
+"""Tests for the GQA path in `ezpz.models.llama.Attention`.
+
+`Attention.forward` can either materialize the repeated kv heads with
+`repeat_kv` or let SDPA broadcast them via `enable_gqa=True`. The two are
+mathematically equivalent; these tests pin that equivalence (forward and
+backward) and pin `enable_gqa` as the default.
+"""
+
+import pytest
+import torch
+
+from ezpz.models import llama
+from ezpz.models.llama import Attention, ModelArgs, precompute_freqs_cis
+
+
+def _build_attention(n_heads: int, n_kv_heads: int, head_dim: int = 16):
+    torch.manual_seed(0)
+    args = ModelArgs(
+        dim=n_heads * head_dim,
+        n_layers=1,
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        vocab_size=32,
+        multiple_of=8,
+        batch_size=2,
+        max_seq_len=32,
+        depth_init=True,
+    )
+    return Attention(args), args
+
+
+def _run_forward(attn, args, seq_len=16, batch_size=2):
+    torch.manual_seed(1)
+    x = torch.randn(batch_size, seq_len, args.dim, requires_grad=True)
+    freqs_cis = precompute_freqs_cis(
+        args.dim // args.n_heads, seq_len, theta=args.rope_theta
+    )
+    return x, attn(x, freqs_cis)
+
+
+@pytest.mark.parametrize(("n_heads", "n_kv_heads"), [(4, 1), (8, 2), (4, 4)])
+def test_gqa_matches_repeat_kv_forward(monkeypatch, n_heads, n_kv_heads):
+    """Broadcasting the kv heads gives the same output as repeating them."""
+    attn, args = _build_attention(n_heads, n_kv_heads)
+
+    monkeypatch.setenv("EZPZ_SDPA_ENABLE_GQA", "1")
+    _, out_gqa = _run_forward(attn, args)
+
+    monkeypatch.setenv("EZPZ_SDPA_ENABLE_GQA", "0")
+    _, out_repeat = _run_forward(attn, args)
+
+    torch.testing.assert_close(out_gqa, out_repeat, rtol=1e-5, atol=1e-6)
+
+
+def test_gqa_matches_repeat_kv_backward(monkeypatch):
+    """Gradients agree between the two paths."""
+    attn, args = _build_attention(n_heads=4, n_kv_heads=1)
+
+    grads = {}
+    for flag in ("1", "0"):
+        monkeypatch.setenv("EZPZ_SDPA_ENABLE_GQA", flag)
+        attn.zero_grad(set_to_none=True)
+        x, out = _run_forward(attn, args)
+        out.sum().backward()
+        grads[flag] = (
+            x.grad.clone(),
+            {name: p.grad.clone() for name, p in attn.named_parameters()},
+        )
+
+    x_grad_gqa, param_grads_gqa = grads["1"]
+    x_grad_repeat, param_grads_repeat = grads["0"]
+    torch.testing.assert_close(x_grad_gqa, x_grad_repeat, rtol=1e-5, atol=1e-6)
+    for name, grad in param_grads_gqa.items():
+        torch.testing.assert_close(
+            grad, param_grads_repeat[name], rtol=1e-5, atol=1e-6
+        )
+
+
+def test_gqa_is_the_default(monkeypatch):
+    """With the env var unset, `repeat_kv` is not called."""
+    attn, args = _build_attention(n_heads=4, n_kv_heads=1)
+    monkeypatch.delenv("EZPZ_SDPA_ENABLE_GQA", raising=False)
+
+    calls = []
+    real_repeat_kv = llama.repeat_kv
+
+    def _counting_repeat_kv(x, n_rep):
+        calls.append(n_rep)
+        return real_repeat_kv(x, n_rep)
+
+    monkeypatch.setattr(llama, "repeat_kv", _counting_repeat_kv)
+    _run_forward(attn, args)
+
+    assert calls == []
+
+
+def test_repeat_kv_used_when_gqa_disabled(monkeypatch):
+    """`EZPZ_SDPA_ENABLE_GQA=0` restores the explicit `repeat_kv` path."""
+    attn, args = _build_attention(n_heads=4, n_kv_heads=1)
+    monkeypatch.setenv("EZPZ_SDPA_ENABLE_GQA", "0")
+
+    calls = []
+    real_repeat_kv = llama.repeat_kv
+
+    def _counting_repeat_kv(x, n_rep):
+        calls.append(n_rep)
+        return real_repeat_kv(x, n_rep)
+
+    monkeypatch.setattr(llama, "repeat_kv", _counting_repeat_kv)
+    _run_forward(attn, args)
+
+    # once for the keys, once for the values
+    assert calls == [4, 4]


### PR DESCRIPTION
`Attention.forward` expanded the kv heads with `repeat_kv` before calling SDPA. Passing `enable_gqa=True` instead lets SDPA broadcast them internally: mathematically identical, but it avoids materializing the n_rep-times expanded k/v.

It also sidesteps a torch.compile failure on XPU. The flash-attention backward meta kernel predicts its output strides with `empty_like` on q/k/v, so when those are non-contiguous the prediction disagrees with what the XPU backend produces and Inductor's guard fires:

  assert_size_stride(buf4, (4, 4, 4096, 128), (2097152, 524288, 128, 1),
      'torch.ops.aten._scaled_dot_product_flash_attention_backward.default')
  AssertionError: expected size 4==4, stride 128==524288 at dim=1

The trigger is `repeat_kv`'s expand+reshape combined with the rotary `view_as_real(...).flatten(3)` and the `transpose(1, 2)`; q's transpose alone is not enough. Eager passes on XPU, and CUDA passes compiled, so this is specific to XPU Inductor layout planning at the SDPA fallback boundary (reproduced on torch 2.13 and 2.14 nightly). Dropping the `repeat_kv` removes the trigger at its source.

Measured on a 10-iteration agpt-2b run (TP=4, dp-replicate=3, max-autotune): peak memory 26.69 GiB vs 27.16 GiB, compile step 226s vs 242s, steady-state throughput unchanged (~52-54 TFLOPS, ~17-18% MFU).

Two env vars, both documented in docs/configuration.md:
- EZPZ_SDPA_ENABLE_GQA=0 restores the previous `repeat_kv` behavior.
- EZPZ_SDPA_CONTIGUOUS=1 is an alternative workaround for the same XPU assert, forcing q/k/v contiguous at the cost of an extra copy.

Note: `enable_gqa` requires torch >= 2.5, which `pyproject.toml` does not currently pin.

## Summary by Sourcery

Switch LLaMA attention to use SDPA’s generalized grouped query attention path by default instead of materializing repeated KV heads, adding XPU-focused workarounds and tests to ensure behavioral parity.

New Features:
- Add configuration flag to toggle SDPA GQA broadcasting versus explicit KV head repetition in LLaMA attention.
- Add optional configuration to force q/k/v tensors contiguous before SDPA as an XPU torch.compile workaround.

Enhancements:
- Reduce memory usage and compilation overhead in LLaMA attention by avoiding materialized repeated KV heads when using SDPA with GQA enabled.

Documentation:
- Document new EZPZ_SDPA_ENABLE_GQA and EZPZ_SDPA_CONTIGUOUS environment variables and their effects on LLaMA attention and XPU behavior.

Tests:
- Add tests that verify forward and backward equivalence between SDPA GQA broadcasting and repeat_kv, confirm GQA is the default, and ensure repeat_kv is used when GQA is disabled.