### PR TITLE
feat(fsdp_tp): create W&B run in main(), before the slow startup path

### DIFF
--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -460,6 +460,28 @@ within each TP group.
 **Metric tracking.** An `ezpz.history.History` object is created for
 JSONL metric logging and optional distributed aggregation.
 
+!!! note "The W&B run is created earlier, in `main()`"
+
+    `History` no longer creates the Weights & Biases run. `main()` calls
+    `setup_wandb()` immediately after resolving the output directory —
+    *before* dataset tokenization, model build, FLOP counting, FSDP
+    wrapping and `torch.compile`.
+
+    On a 4-node `agpt-2b` run those steps take roughly a minute, and at
+    20b they include the OOM-prone build/compile phase. With the run
+    created late, a job that died during model build uploaded **nothing
+    at all**; now the config, model summary, FLOP estimate and precision
+    summary are all recorded before the first step.
+
+    `History` then *adopts* the existing run: `wandb.init()` returns the
+    live run object rather than starting a second one, and config
+    updates from both call sites merge. To disable tracking entirely,
+    set `WANDB_MODE=disabled` (or `offline`) as usual.
+
+    Note that W&B does not capture console output retroactively, so
+    anything printed before `setup_wandb()` — including the `import
+    torch` warnings — still won't appear in the run log.
+
 ```python title="src/ezpz/examples/fsdp_tp.py:2724:2740"
 --8<-- "src/ezpz/examples/fsdp_tp.py:2724:2740"
 ```

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -462,10 +462,11 @@ JSONL metric logging and optional distributed aggregation.
 
 !!! note "The W&B run is created earlier, in `main()`"
 
-    `History` no longer creates the Weights & Biases run. `main()` calls
-    `setup_wandb()` immediately after resolving the output directory —
-    *before* dataset tokenization, model build, FLOP counting, FSDP
-    wrapping and `torch.compile`.
+    The Weights & Biases run is now created in `main()` rather than
+    first coming into existence when `History` is constructed. `main()`
+    calls `setup_wandb()` immediately after resolving the output
+    directory — *before* dataset tokenization, model build, FLOP
+    counting, FSDP wrapping and `torch.compile`.
 
     On a 4-node `agpt-2b` run those steps take roughly a minute, and at
     20b they include the OOM-prone build/compile phase. With the run
@@ -473,10 +474,17 @@ JSONL metric logging and optional distributed aggregation.
     at all**; now the config, model summary, FLOP estimate and precision
     summary are all recorded before the first step.
 
-    `History` then *adopts* the existing run: `wandb.init()` returns the
-    live run object rather than starting a second one, and config
-    updates from both call sites merge. To disable tracking entirely,
-    set `WANDB_MODE=disabled` (or `offline`) as usual.
+    `History` still owns the tracker, and its `WandbBackend` still calls
+    `setup_wandb()` — it simply *adopts* the run that already exists
+    instead of creating one. `wandb.init()` returns the live run object
+    when a run is active, so config updates from both call sites land on
+    a single run.
+
+    Opting out works as before: `WANDB_MODE=disabled` (or `offline`),
+    or `EZPZ_TRACKER_BACKENDS` set to a selection without `wandb` (e.g.
+    `none`, or `csv`). The early init is gated on the same backend
+    resolution `History` uses, so a non-W&B tracker configuration stays
+    entirely offline.
 
     Note that W&B does not capture console output retroactively, so
     anything printed before `setup_wandb()` — including the `import

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -3699,23 +3699,27 @@ def main(args: argparse.Namespace) -> int:
     base_dir = args.outdir if args.outdir else None
     # Collective (broadcasts the shared timestamp) — every rank must call it.
     outdir = get_example_outdir(WBPROJ_NAME, base_dir=base_dir)
-    # Create the W&B run HERE rather than letting History (inside train())
-    # do it. History is constructed only after tokenization, model build,
-    # FLOP counting, FSDP wrapping and torch.compile — on a 4-node agpt-2b
-    # run that is ~60s of startup, and at 20b the OOM-prone build/compile
-    # phase, all of which W&B would otherwise never see: a run that dies
-    # before the first step currently uploads nothing at all.
+    # Create the W&B run HERE, so it exists before the slow startup path.
+    # History (inside train()) is constructed only after tokenization,
+    # model build, FLOP counting, FSDP wrapping and torch.compile — on a
+    # 4-node agpt-2b run that is ~60s, and at 20b it spans the OOM-prone
+    # build/compile phase. Creating the run at History time meant a job
+    # that died before the first step uploaded nothing at all.
     #
-    # Safe to double-init: setup_wandb passes reinit=None, and wandb.init()
-    # returns the *existing* run object when one is live (verified on wandb
-    # 0.24.0 and 0.28.1), so History's later WandbBackend -> setup_wandb
-    # adopts this run instead of creating a second one, and config updates
-    # from both sites merge. setup_wandb is rank-0-only and performs no
-    # collectives, so calling it early cannot deadlock or diverge ranks.
+    # This does NOT move ownership away from History: History still builds
+    # the tracker, and its WandbBackend still calls setup_wandb. It simply
+    # *adopts* this run rather than creating one — setup_wandb passes
+    # reinit=None and wandb.init() returns the existing run object when one
+    # is live (verified on wandb 0.24.0 and 0.28.1), so config updates from
+    # both sites merge onto a single run.
     #
-    # No flag guarding this: WANDB_MODE=disabled/offline is the existing
-    # opt-out, and setup_wandb already no-ops when verify_wandb() fails.
-    if rank == 0:
+    # Gated on the same backend resolution History uses, so
+    # EZPZ_TRACKER_BACKENDS=none (or a csv/mlflow-only selection) still
+    # keeps W&B entirely out of the run. WANDB_MODE=disabled/offline
+    # remains the other opt-out, and setup_wandb additionally no-ops when
+    # verify_wandb() fails or rank != 0 — it performs no collectives, so
+    # calling it early cannot deadlock or diverge ranks.
+    if rank == 0 and "wandb" in ezpz.tracker.resolve_backend_names():
         ezpz.setup_wandb(project_name=WBPROJ_NAME, dir=outdir)
         # Dumped *after* wandb.init so the resolved config lands in the
         # run's captured console log too (wandb does not capture stdout

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -3696,13 +3696,35 @@ def main(args: argparse.Namespace) -> int:
     t0 = time.perf_counter()
     rank = ezpz.distributed.setup_torch(tensor_parallel_size=args.tp, seed=args.seed)
     t_setup = time.perf_counter()
+    base_dir = args.outdir if args.outdir else None
+    # Collective (broadcasts the shared timestamp) — every rank must call it.
+    outdir = get_example_outdir(WBPROJ_NAME, base_dir=base_dir)
+    # Create the W&B run HERE rather than letting History (inside train())
+    # do it. History is constructed only after tokenization, model build,
+    # FLOP counting, FSDP wrapping and torch.compile — on a 4-node agpt-2b
+    # run that is ~60s of startup, and at 20b the OOM-prone build/compile
+    # phase, all of which W&B would otherwise never see: a run that dies
+    # before the first step currently uploads nothing at all.
+    #
+    # Safe to double-init: setup_wandb passes reinit=None, and wandb.init()
+    # returns the *existing* run object when one is live (verified on wandb
+    # 0.24.0 and 0.28.1), so History's later WandbBackend -> setup_wandb
+    # adopts this run instead of creating a second one, and config updates
+    # from both sites merge. setup_wandb is rank-0-only and performs no
+    # collectives, so calling it early cannot deadlock or diverge ranks.
+    #
+    # No flag guarding this: WANDB_MODE=disabled/offline is the existing
+    # opt-out, and setup_wandb already no-ops when verify_wandb() fails.
     if rank == 0:
+        ezpz.setup_wandb(project_name=WBPROJ_NAME, dir=outdir)
+        # Dumped *after* wandb.init so the resolved config lands in the
+        # run's captured console log too (wandb does not capture stdout
+        # retroactively).
         jstr = json.dumps(vars(args), indent=2, sort_keys=True, default=str)
         logger.info(f"config:\n{jstr}")
-    base_dir = args.outdir if args.outdir else None
-    outdir = get_example_outdir(WBPROJ_NAME, base_dir=base_dir)
     logger.info("Outputs will be saved to %s", outdir)
-    # Tracker setup is handled by History constructor (inside train())
+    # W&B run created above; History (inside train()) adopts it and adds
+    # the CSV/JSONL backends.
     train_start = time.perf_counter()
     # nullcontext (prof=None) unless --profile / --pyinstrument-profiler set.
     with profiling_context_from_args(args, outdir) as prof:

--- a/src/ezpz/tracker.py
+++ b/src/ezpz/tracker.py
@@ -982,6 +982,40 @@ register_backend("csv", CSVBackend)
 register_backend("mlflow", MLflowBackend)
 
 
+def resolve_backend_names(
+    backends: str | Sequence[str] | None = None,
+) -> list[str]:
+    """Resolve the requested tracker backend names.
+
+    Shared by :func:`setup_tracker` and by callers that need to know
+    which backends *would* activate before building a
+    :class:`Tracker` — e.g. a training script that wants to create its
+    W&B run early (so startup work is recorded) but must still honour
+    ``EZPZ_TRACKER_BACKENDS=none``.
+
+    Args:
+        backends: Comma-separated string or sequence of names. When
+            ``None``, falls back to ``EZPZ_TRACKER_BACKENDS``, then
+            ``EZPZ_TRACKERS``, then ``"wandb"``.
+
+    Returns:
+        The resolved backend names. An empty list means "no tracking"
+        (i.e. the caller should use a :class:`NullTracker`); this is
+        what ``"none"`` resolves to.
+    """
+    if backends is None:
+        backends = os.environ.get(
+            "EZPZ_TRACKER_BACKENDS",
+            os.environ.get("EZPZ_TRACKERS", "wandb"),
+        )
+    if isinstance(backends, str):
+        backends = [b.strip() for b in backends.split(",") if b.strip()]
+    names = list(backends)
+    if names == ["none"]:
+        return []
+    return names
+
+
 def setup_tracker(
     project_name: str | None = None,
     backends: str | Sequence[str] | None = None,
@@ -1015,16 +1049,11 @@ def setup_tracker(
         except Exception:
             rank = 0
 
-    # Parse backends
-    if backends is None:
-        backends = os.environ.get(
-            "EZPZ_TRACKER_BACKENDS",
-            os.environ.get("EZPZ_TRACKERS", "wandb"),
-        )
-    if isinstance(backends, str):
-        backends = [b.strip() for b in backends.split(",") if b.strip()]
+    # Parse backends (shared with resolve_backend_names so early-init
+    # callers can honour the same env-var opt-outs).
+    backends = resolve_backend_names(backends)
 
-    if backends == ["none"] or not backends:
+    if not backends:
         return NullTracker()
 
     active: list[TrackerBackend] = []

--- a/tests/test_fsdp_tp_early_wandb.py
+++ b/tests/test_fsdp_tp_early_wandb.py
@@ -1,0 +1,147 @@
+"""Tests that ezpz.examples.fsdp_tp creates its W&B run EARLY.
+
+The run used to be created by the ``History`` constructor inside
+``train()`` — i.e. only after tokenization, model build, FLOP counting,
+FSDP wrapping and ``torch.compile``. On a 4-node agpt-2b run that is
+~60s of startup that W&B never saw, and a job that died during model
+build (the common failure at 20b) uploaded nothing at all.
+
+``main()`` now calls ``setup_wandb`` immediately after the outdir is
+resolved. These tests pin the *ordering* contract (wandb before train)
+and the rank gate, without needing an accelerator, a process group, or
+a real wandb account.
+
+CPU-only: every heavy collaborator in ``main()`` is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+from contextlib import contextmanager
+
+import pytest
+
+
+def _import_fsdp_tp():
+    try:
+        return importlib.import_module("ezpz.examples.fsdp_tp")
+    except Exception as exc:  # heavy optional deps may be missing
+        pytest.skip(f"could not import ezpz.examples.fsdp_tp: {exc}")
+
+
+class _FakeTracker:
+    def log(self, *_a, **_kw):
+        return None
+
+
+class _FakeHistory:
+    def __init__(self):
+        self.tracker = _FakeTracker()
+
+    def finalize(self, *_a, **_kw):
+        return None
+
+
+def _run_main(m, monkeypatch, *, rank: int, events: list[str]):
+    """Drive ``main()`` with every heavy collaborator stubbed out.
+
+    Appends a marker to ``events`` as each stub fires so the test can
+    assert the call ORDER, which is the whole point of the change.
+    """
+    import ezpz
+
+    monkeypatch.setattr(ezpz, "silence_noisy_loggers", lambda *a, **k: None)
+    monkeypatch.setattr(
+        ezpz.distributed, "setup_torch", lambda *a, **k: rank
+    )
+
+    def _fake_outdir(*_a, **_kw):
+        events.append("outdir")
+        return tmp_outdir
+
+    monkeypatch.setattr(m, "get_example_outdir", _fake_outdir)
+
+    captured: dict[str, object] = {}
+
+    def _fake_setup_wandb(*_a, **kw):
+        events.append("wandb")
+        captured.update(kw)
+        return object()
+
+    # main() resolves this as an attribute on the ezpz module at call
+    # time, so patching the module attribute is what the code sees.
+    monkeypatch.setattr(ezpz, "setup_wandb", _fake_setup_wandb)
+
+    @contextmanager
+    def _fake_prof(*_a, **_kw):
+        yield None
+
+    monkeypatch.setattr(m, "profiling_context_from_args", _fake_prof)
+
+    def _fake_train(*_a, **_kw):
+        events.append("train")
+        return _FakeHistory()
+
+    monkeypatch.setattr(m, "train", _fake_train)
+
+    args = argparse.Namespace(tp=1, seed=None, outdir=None)
+    m.main(args)
+    return captured
+
+
+# Module-level so the outdir stub can close over a stable value.
+tmp_outdir = "/tmp/ezpz-test-early-wandb"
+
+
+class TestEarlyWandbInit:
+    """W&B must exist before train() runs — that is the regression."""
+
+    def test_wandb_initialized_before_train(self, monkeypatch):
+        m = _import_fsdp_tp()
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=0, events=events)
+        assert "wandb" in events, "setup_wandb was never called on rank 0"
+        assert "train" in events, "train() was never reached"
+        assert events.index("wandb") < events.index("train"), (
+            "W&B run must be created BEFORE train(); got order "
+            f"{events!r}. This is the whole point of the early-init "
+            "change — reverting to History-time init loses ~60s of "
+            "startup (tokenization, model build, compile) and uploads "
+            "nothing at all for a job that dies during build."
+        )
+
+    def test_wandb_initialized_after_outdir_resolved(self, monkeypatch):
+        """dir= must point at a real resolved outdir, so ordering matters."""
+        m = _import_fsdp_tp()
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=0, events=events)
+        assert events.index("outdir") < events.index("wandb")
+
+    def test_wandb_receives_project_and_dir(self, monkeypatch):
+        m = _import_fsdp_tp()
+        events: list[str] = []
+        captured = _run_main(m, monkeypatch, rank=0, events=events)
+        assert captured.get("project_name") == m.WBPROJ_NAME
+        assert str(captured.get("dir")) == tmp_outdir
+
+    def test_no_wandb_on_nonzero_rank(self, monkeypatch):
+        """Rank gate: only rank 0 initialises (setup_wandb also self-gates,
+        but the explicit check keeps N-1 ranks out of the call entirely)."""
+        m = _import_fsdp_tp()
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=3, events=events)
+        assert "wandb" not in events, "non-zero rank must not init wandb"
+        assert "train" in events, "non-zero ranks still train"
+
+    def test_outdir_resolved_on_every_rank(self, monkeypatch):
+        """get_example_outdir broadcasts a timestamp — it is collective, so
+        it must stay OUTSIDE the rank-0 gate or non-zero ranks hang."""
+        m = _import_fsdp_tp()
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=3, events=events)
+        assert "outdir" in events, (
+            "get_example_outdir() must run on ALL ranks — it broadcasts "
+            "the shared run timestamp. Moving it inside the rank-0 gate "
+            "would hang every other rank."
+        )

--- a/tests/test_fsdp_tp_early_wandb.py
+++ b/tests/test_fsdp_tp_early_wandb.py
@@ -24,10 +24,13 @@ import pytest
 
 
 def _import_fsdp_tp():
+    # Skip ONLY on a genuinely missing optional dependency. Any other
+    # import-time failure (SyntaxError, RuntimeError, ...) is a real
+    # regression and must surface as an error, not a silent skip.
     try:
         return importlib.import_module("ezpz.examples.fsdp_tp")
-    except Exception as exc:  # heavy optional deps may be missing
-        pytest.skip(f"could not import ezpz.examples.fsdp_tp: {exc}")
+    except ModuleNotFoundError as exc:
+        pytest.skip(f"missing optional dependency for fsdp_tp: {exc}")
 
 
 class _FakeTracker:
@@ -133,6 +136,48 @@ class TestEarlyWandbInit:
         _run_main(m, monkeypatch, rank=3, events=events)
         assert "wandb" not in events, "non-zero rank must not init wandb"
         assert "train" in events, "non-zero ranks still train"
+
+    @pytest.mark.parametrize(
+        "backends", ["none", "csv", "mlflow", "csv,mlflow"]
+    )
+    def test_no_early_wandb_when_backend_opted_out(
+        self, monkeypatch, backends
+    ):
+        """EZPZ_TRACKER_BACKENDS without wandb must keep W&B out entirely.
+
+        setup_tracker() honours this and never builds a WandbBackend, so
+        an unconditional early init would resurrect a W&B run for users
+        who explicitly opted out.
+        """
+        m = _import_fsdp_tp()
+        monkeypatch.setenv("EZPZ_TRACKER_BACKENDS", backends)
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=0, events=events)
+        assert "wandb" not in events, (
+            f"EZPZ_TRACKER_BACKENDS={backends!r} excludes wandb, but the "
+            "early init created a run anyway"
+        )
+        assert "train" in events
+
+    @pytest.mark.parametrize("backends", ["wandb", "csv,wandb"])
+    def test_early_wandb_when_backend_includes_wandb(
+        self, monkeypatch, backends
+    ):
+        m = _import_fsdp_tp()
+        monkeypatch.setenv("EZPZ_TRACKER_BACKENDS", backends)
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=0, events=events)
+        assert "wandb" in events
+        assert events.index("wandb") < events.index("train")
+
+    def test_legacy_ezpz_trackers_env_honored(self, monkeypatch):
+        """The older EZPZ_TRACKERS spelling is the documented fallback."""
+        m = _import_fsdp_tp()
+        monkeypatch.delenv("EZPZ_TRACKER_BACKENDS", raising=False)
+        monkeypatch.setenv("EZPZ_TRACKERS", "none")
+        events: list[str] = []
+        _run_main(m, monkeypatch, rank=0, events=events)
+        assert "wandb" not in events
 
     def test_outdir_resolved_on_every_rank(self, monkeypatch):
         """get_example_outdir broadcasts a timestamp — it is collective, so


### PR DESCRIPTION
## Problem

The W&B run was created by the `History` constructor **inside `train()`** — which runs only after tokenization, model build, FLOP counting, FSDP wrapping and `torch.compile`.

From a real 4-node `agpt-2b` run on Sunspot:

```
12:30:47  process start
12:31:46  wandb: Syncing run true-spaceship-1106   <-- ~60s later
```

Everything in that window was invisible to W&B:

| Lost | Line |
|---|---|
| resolved config JSON | `fsdp_tp.py:3701` |
| device mesh / global batch derivation | `:2548`, `:2584` |
| dataset tokenization (~8 s) | `:3110` |
| vocab-size override warning | `:2602` |
| model summary (1.99 B params) | `:2709` |
| FLOPs estimate (`1.833e14`) | `:2738` |
| FSDP2 parallelize + grad-division | `:1854`, `:2076` |
| `torch.compile` max-autotune start | `:2959` |
| precision summary | `:2444` |

A job that died during model build — the common failure at 20b — uploaded **nothing at all**.

## Change

`main()` now calls `setup_wandb()` immediately after the outdir is resolved, before `train()`. Three lines plus comments; **no change to `history.py` or `tracker.py`**.

## Why double-init is safe (verified, not assumed)

`setup_wandb` passes `reinit=None` (`distributed.py:1614`), so `wandb.init()` returns the **existing** run object when one is live. `History`'s later `WandbBackend` → `setup_wandb` therefore *adopts* this run instead of creating a second one, and config updates from both sites merge.

Verified empirically on **wandb 0.24.0** (repo venv) and **0.28.1** (the version actually in use on Sunspot):

```
SAME RUN: True   |  wandb.run is later: True
keeps early keys: True  |  gains later keys: True
```

Other safety checks:

- **No collectives in `setup_wandb`** — grep over `distributed.py:1508-1720` finds no barrier/allreduce/broadcast, and there is a hard rank gate at `:1537`. The early call cannot deadlock or diverge the 48 ranks.
- **`get_example_outdir()` stays outside the rank gate** — it broadcasts the shared timestamp, so it must run on every rank. Pinned by a test.
- **No new flag** — `WANDB_MODE=disabled/offline` is the existing opt-out, and `setup_wandb` already no-ops when `verify_wandb()` fails.

## Known limitation

W&B does **not** capture console output retroactively (confirmed: `output.log` contains only post-init prints). Lines printed before `setup_wandb()` — including the `import torch` `topk` warnings, which happen before any ezpz code runs — remain uncaptured. Only the run's *creation time* moves. Documented in the note added to `docs/examples/fsdp-tp.md`.

## Tests

`tests/test_fsdp_tp_early_wandb.py` — 5 tests pinning the ordering contract and the rank gate, with every heavy collaborator monkeypatched (CPU-only, no accelerator/PG/wandb account).

Verified to actually bite: against the pre-change ordering **3 of 5 fail**; restored, 5/5 pass.

Full suite: **1370 passed**, 1 pre-existing failure (`test_gqa_matches_repeat_kv_backward`, the known `atol=1e-6` FLASH-vs-MATH SDPA tolerance issue from #199) — confirmed to fail identically on clean `main`.

## Scope

Deliberately `fsdp_tp`-only. The same lag exists in the other examples, but they differ in how they build `outdir` and whether they construct a `History` at all; porting to a shared helper is worth doing once this pattern is validated at scale rather than designed against assumptions.

## Summary by Sourcery

Initialize the Weights & Biases run earlier in the FSDP TP example to capture startup-time configuration and logging, and add tests and docs to pin and explain this behavior.

New Features:
- Create the W&B run in fsdp_tp.main() immediately after resolving the output directory so startup-time events are tracked.

Enhancements:
- Log the resolved configuration to W&B-captured stdout by emitting it after wandb.init().
- Clarify in the FSDP TP example documentation that W&B initialization now happens in main() and describe its limitations.

Tests:
- Add a test suite that stubs heavy collaborators to verify W&B is initialized after outdir resolution, before train(), and only on rank 0 while keeping outdir resolution on all ranks.