### PR TITLE
fix(wandb): survive setup_wandb() being called twice in one job

### DIFF
--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -1658,48 +1658,84 @@ def setup_wandb(
             except Exception:
                 pass
 
-            # num_nodes / gpus_per_node have their own getters that
-            # already swallow failures internally (return 1 / fall
-            # back). Safe to call directly.
-            run.config.update(
-                {
-                    # "DIST_INFO": get_dist_info(),
-                    # --- existing fields (unchanged) ---
-                    "hostname": get_hostname(),
-                    "pytorch_backend": get_torch_backend(),
-                    "torch_version": torch.__version__,
-                    "world_size": get_world_size(),
-                    "ezpz_version": ezpz.__version__,
-                    "machine": get_machine(),
-                    "working_directory": os.getcwd(),
-                    "year": now.year,
-                    "month": now.month,
-                    "day": now.day,
-                    "tstamp": now.isoformat(),
-                    # --- new dimensions for filtering / grouping ---
-                    # Pivot from a wandb run → the cluster job that
-                    # ran it. None when not inside a PBS/SLURM job.
-                    "jobid": jobid,
-                    # "pbs" / "slurm" / "" — useful when you have
-                    # runs from both systems in the same project.
-                    "scheduler": get_scheduler(),
-                    # Distinct from world_size: same world_size can be
-                    # 8x8 or 4x16, lets you separate the two.
-                    "num_nodes": get_num_nodes(),
-                    "ranks_per_node": get_gpus_per_node(),
-                    # "cuda" / "xpu" / "mps" / "cpu" — at-a-glance
-                    # distinction between Aurora vs NVIDIA vs CPU runs.
-                    "device_type": get_torch_device_type(),
-                    # --- debugging / postmortems ---
-                    "python_version": sys.version.split()[0],
-                    # None when ezpz is a pip-install, not a git
-                    # checkout. Disambiguates dev branches sharing the
-                    # same ezpz_version.
-                    "ezpz_git_sha": _get_ezpz_git_sha(),
-                }
-            )
-            if config is not None:
-                run.config.update({"config": config})
+            # Everything from here on is *bookkeeping on an
+            # already-created run*. Scoped try/except: a failure here
+            # must not propagate to the outer handler, which returns
+            # None -- that makes WandbBackend set _run=None, and
+            # WandbBackend.log() early-returns on that, so the run stays
+            # visible in the W&B UI while silently receiving zero
+            # metrics for the whole job. A live run with stale metadata
+            # beats a live run with no data. (A failure of wandb.init()
+            # itself is different: there is no usable run, so it still
+            # falls through to the outer handler and returns None.)
+            try:
+                # num_nodes / gpus_per_node have their own getters that
+                # already swallow failures internally (return 1 / fall
+                # back). Safe to call directly.
+                run.config.update(
+                    {
+                        # "DIST_INFO": get_dist_info(),
+                        # --- existing fields (unchanged) ---
+                        "hostname": get_hostname(),
+                        "pytorch_backend": get_torch_backend(),
+                        "torch_version": torch.__version__,
+                        "world_size": get_world_size(),
+                        "ezpz_version": ezpz.__version__,
+                        "machine": get_machine(),
+                        "working_directory": os.getcwd(),
+                        "year": now.year,
+                        "month": now.month,
+                        "day": now.day,
+                        "tstamp": now.isoformat(),
+                        # --- new dimensions for filtering / grouping ---
+                        # Pivot from a wandb run → the cluster job that
+                        # ran it. None when not inside a PBS/SLURM job.
+                        "jobid": jobid,
+                        # "pbs" / "slurm" / "" — useful when you have
+                        # runs from both systems in the same project.
+                        "scheduler": get_scheduler(),
+                        # Distinct from world_size: same world_size can be
+                        # 8x8 or 4x16, lets you separate the two.
+                        "num_nodes": get_num_nodes(),
+                        "ranks_per_node": get_gpus_per_node(),
+                        # "cuda" / "xpu" / "mps" / "cpu" — at-a-glance
+                        # distinction between Aurora vs NVIDIA vs CPU runs.
+                        "device_type": get_torch_device_type(),
+                        # --- debugging / postmortems ---
+                        "python_version": sys.version.split()[0],
+                        # None when ezpz is a pip-install, not a git
+                        # checkout. Disambiguates dev branches sharing the
+                        # same ezpz_version.
+                        "ezpz_git_sha": _get_ezpz_git_sha(),
+                    },
+                    # setup_wandb may legitimately be called more than
+                    # once in a job: callers create the run early (so
+                    # startup work is recorded) and a later
+                    # WandbBackend re-enters here and adopts the same
+                    # run. The wall-clock keys above ("tstamp",
+                    # "year"/"month"/"day") differ between those calls,
+                    # and without allow_val_change wandb raises
+                    #   ConfigError: Attempted to change value of key
+                    #   "tstamp" from ... to ...
+                    # Re-stamping the metadata is what we want.
+                    allow_val_change=True,
+                )
+                if config is not None:
+                    run.config.update(
+                        {"config": config}, allow_val_change=True
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "wandb post-init config update failed on rank=%d "
+                    "(%s); keeping the active run %s -- metrics will "
+                    "still be logged.",
+                    rank,
+                    exc,
+                    getattr(run, "name", "?"),
+                )
+                logger.debug(
+                    "wandb post-init config traceback", exc_info=True
+                )
         return wandb.run
     except Exception as exc:
         logger.exception("wandb.init() failed from rank=%d: %s", rank, exc)

--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -1633,42 +1633,51 @@ def setup_wandb(
             **kwargs,
         )
         if run is not None:
-            logger.info("wandb.run=[%s](%s)", run.name, run.url)
-            import sys  # noqa: PLC0415
-            import torch  # noqa: PLC0415
-
-            import ezpz  # noqa: PLC0415
-            from ezpz.configs import get_scheduler  # noqa: PLC0415
-
-            now = datetime.datetime.now()
-
-            # Best-effort resolution of the active scheduler jobid.
-            # ezpz.launch.get_active_jobid imports ezpz.pbs / ezpz.slurm
-            # lazily and returns None when no job is detected. Wrapped
-            # in try/except because the launch module pulls a non-
-            # trivial chain on first import — any failure here should
-            # NOT block the wandb run from being created.
-            jobid: str | None = None
+            # EVERYTHING below this point is bookkeeping on an
+            # already-created run, so it all lives inside one scoped
+            # try/except. A failure here must not reach the outer
+            # handler, which returns None -- that makes WandbBackend set
+            # _run=None, and WandbBackend.log() early-returns on that,
+            # so the run stays visible in the W&B UI while silently
+            # receiving zero metrics for the whole job. A live run with
+            # stale metadata beats a live run with no data.
+            #
+            # The scope starts here, not at the config.update() below,
+            # because the bookkeeping imports can themselves fail: torch
+            # is an OPTIONAL extra while wandb is a base dependency
+            # (pyproject.toml), so a torch-less install would raise on
+            # `import torch` with a perfectly good run already live.
+            #
+            # A failure of wandb.init() itself is different: there is no
+            # usable run to salvage, so it still falls through to the
+            # outer handler and returns None (callers rely on that to
+            # no-op -- see test_tracker.py's
+            # test_init_failure_all_methods_noop).
             try:
-                from ezpz.launch import (
-                    get_active_jobid,
-                )  # noqa: PLC0415
+                logger.info("wandb.run=[%s](%s)", run.name, run.url)
+                import sys  # noqa: PLC0415
+                import torch  # noqa: PLC0415
 
-                jobid = get_active_jobid()
-            except Exception:
-                pass
+                import ezpz  # noqa: PLC0415
+                from ezpz.configs import get_scheduler  # noqa: PLC0415
 
-            # Everything from here on is *bookkeeping on an
-            # already-created run*. Scoped try/except: a failure here
-            # must not propagate to the outer handler, which returns
-            # None -- that makes WandbBackend set _run=None, and
-            # WandbBackend.log() early-returns on that, so the run stays
-            # visible in the W&B UI while silently receiving zero
-            # metrics for the whole job. A live run with stale metadata
-            # beats a live run with no data. (A failure of wandb.init()
-            # itself is different: there is no usable run, so it still
-            # falls through to the outer handler and returns None.)
-            try:
+                now = datetime.datetime.now()
+
+                # Best-effort resolution of the active scheduler jobid.
+                # ezpz.launch.get_active_jobid imports ezpz.pbs /
+                # ezpz.slurm lazily and returns None when no job is
+                # detected. Wrapped in its own try/except because the
+                # launch module pulls a non-trivial import chain.
+                jobid: str | None = None
+                try:
+                    from ezpz.launch import (
+                        get_active_jobid,
+                    )  # noqa: PLC0415
+
+                    jobid = get_active_jobid()
+                except Exception:
+                    pass
+
                 # num_nodes / gpus_per_node have their own getters that
                 # already swallow failures internally (return 1 / fall
                 # back). Safe to call directly.

--- a/tests/test_setup_wandb_reinit.py
+++ b/tests/test_setup_wandb_reinit.py
@@ -117,6 +117,14 @@ class TestDoubleInit:
         assert second is not None, (
             "re-supplying config= with a changed value must not kill the run"
         )
+        # ...and the new value must actually land, not just survive.
+        nested = dict(second.config).get("config")
+        assert isinstance(nested, dict), (
+            f"expected config= nested under 'config', got {nested!r}"
+        )
+        assert nested.get("lr") == 0.003, (
+            "the second call's config value must overwrite the first"
+        )
 
 
 class TestLiveRunSurvivesPostInitFailure:
@@ -152,6 +160,36 @@ class TestLiveRunSurvivesPostInitFailure:
             "fails; returning None silently disables all metric logging"
         )
         second.log({"loss": 0.5})  # still usable
+
+    def test_bookkeeping_import_failure_keeps_run(
+        self, wandb_offline, tmp_path, monkeypatch
+    ):
+        """The recovery scope must start right after wandb.init().
+
+        ``wandb`` is a base dependency while ``torch`` is an optional
+        extra (pyproject.toml), so on a torch-less install the
+        post-init ``import torch`` raises with a perfectly good run
+        already live. If the scope began at ``config.update()`` instead,
+        that ImportError would reach the outer handler and discard the
+        run — the exact failure this PR fixes.
+        """
+        import builtins
+
+        setup_wandb = _setup_wandb()
+        real_import = builtins.__import__
+
+        def _no_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                raise ImportError("No module named 'torch'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_torch)
+        run = setup_wandb(project_name="p", dir=str(tmp_path), mode="offline")
+        monkeypatch.undo()
+        assert run is not None, (
+            "a failed bookkeeping import must not discard a live run"
+        )
+        run.log({"loss": 0.25})  # still usable
 
     def test_init_failure_itself_still_returns_none(
         self, wandb_offline, tmp_path, monkeypatch

--- a/tests/test_setup_wandb_reinit.py
+++ b/tests/test_setup_wandb_reinit.py
@@ -1,0 +1,178 @@
+"""Tests that ``setup_wandb`` survives being called twice in one job.
+
+Regression guard for a bug shipped in v0.24.2: ``fsdp_tp`` began
+creating its W&B run early (in ``main()``), so ``setup_wandb`` ran a
+second time when ``History``'s ``WandbBackend`` later adopted the run.
+The post-init ``run.config.update({...})`` writes wall-clock keys
+(``tstamp``, ``year``/``month``/``day``) and passed no
+``allow_val_change``, so the second call raised::
+
+    ConfigError: Attempted to change value of key "tstamp"
+                 from 2026-08-05T16:56:09 to 2026-08-05T16:56:57
+
+The blanket ``except Exception`` then swallowed it and returned
+``None``, which made ``WandbBackend._run = None`` -- and
+``WandbBackend.log()`` early-returns on that. Net effect: a run visible
+in the W&B UI that silently received **zero metrics** for the entire
+job. Strictly worse than the startup lag the early init was meant to
+fix.
+
+Two independent guards are pinned here:
+  1. the config update tolerates value changes, so no raise; and
+  2. even if post-init bookkeeping *does* raise, an already-live run is
+     returned rather than ``None``.
+
+Runs fully offline (``WANDB_MODE=offline``); no account needed.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def wandb_offline(monkeypatch, tmp_path):
+    """Force wandb fully offline and hand back a clean module."""
+    wandb = pytest.importorskip("wandb")
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_SILENT", "true")
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+    # Never inherit a run leaked by another test.
+    if getattr(wandb, "run", None) is not None:
+        wandb.finish()
+    yield wandb
+    if getattr(wandb, "run", None) is not None:
+        wandb.finish()
+
+
+def _setup_wandb():
+    mod = importlib.import_module("ezpz.distributed")
+    return mod.setup_wandb
+
+
+class TestDoubleInit:
+    """setup_wandb() called twice must yield one live, logging run."""
+
+    def test_second_call_returns_live_run(self, wandb_offline, tmp_path):
+        setup_wandb = _setup_wandb()
+        first = setup_wandb(project_name="p", dir=str(tmp_path), mode="offline")
+        if first is None:
+            pytest.skip("wandb unavailable in this environment")
+        second = setup_wandb(
+            project_name="p", dir=str(tmp_path), mode="offline"
+        )
+        assert second is not None, (
+            "setup_wandb returned None on re-entry. WandbBackend sets "
+            "_run=None from that, and WandbBackend.log() early-returns "
+            "on _run=None -- the job would log NO metrics at all."
+        )
+        assert second is first, "expected the same run object, not a new one"
+
+    def test_second_call_does_not_raise_on_wall_clock_keys(
+        self, wandb_offline, tmp_path
+    ):
+        """`tstamp` necessarily differs between calls; that must be fine."""
+        setup_wandb = _setup_wandb()
+        first = setup_wandb(project_name="p", dir=str(tmp_path), mode="offline")
+        if first is None:
+            pytest.skip("wandb unavailable in this environment")
+        before = dict(first.config).get("tstamp")
+        # No sleep needed: the guard is allow_val_change, and datetime
+        # resolution makes a differing value overwhelmingly likely. The
+        # contract under test is "does not raise" either way.
+        second = setup_wandb(
+            project_name="p", dir=str(tmp_path), mode="offline"
+        )
+        assert second is not None
+        after = dict(second.config).get("tstamp")
+        assert after is not None
+        if before != after:
+            # Re-stamping is the intended behaviour when it does change.
+            assert isinstance(after, str)
+
+    def test_logging_works_after_second_call(self, wandb_offline, tmp_path):
+        """The end-to-end symptom: metrics must actually reach the run."""
+        setup_wandb = _setup_wandb()
+        if setup_wandb(project_name="p", dir=str(tmp_path), mode="offline") is None:
+            pytest.skip("wandb unavailable in this environment")
+        run = setup_wandb(project_name="p", dir=str(tmp_path), mode="offline")
+        assert run is not None
+        run.log({"loss": 1.23})  # must not raise
+
+    def test_config_kwarg_survives_second_call(self, wandb_offline, tmp_path):
+        """The `config=` branch updates the same key twice across calls."""
+        setup_wandb = _setup_wandb()
+        first = setup_wandb(
+            project_name="p", dir=str(tmp_path), mode="offline",
+            config={"lr": 0.001},
+        )
+        if first is None:
+            pytest.skip("wandb unavailable in this environment")
+        second = setup_wandb(
+            project_name="p", dir=str(tmp_path), mode="offline",
+            config={"lr": 0.003},  # different value, same key
+        )
+        assert second is not None, (
+            "re-supplying config= with a changed value must not kill the run"
+        )
+
+
+class TestLiveRunSurvivesPostInitFailure:
+    """Defence in depth, independent of the allow_val_change fix.
+
+    Scope matters: a failure of ``wandb.init()`` *itself* leaves no
+    usable run and must still return ``None`` (pinned by
+    ``test_tracker.py::test_init_failure_all_methods_noop``). Only
+    *post-init* bookkeeping on an already-created run is recoverable.
+    """
+
+    def test_post_init_exception_returns_existing_run(
+        self, wandb_offline, tmp_path, monkeypatch
+    ):
+        setup_wandb = _setup_wandb()
+        first = setup_wandb(project_name="p", dir=str(tmp_path), mode="offline")
+        if first is None:
+            pytest.skip("wandb unavailable in this environment")
+
+        # Force ANY post-init bookkeeping to blow up.
+        import ezpz.distributed as dmod
+
+        def _boom():
+            raise RuntimeError("simulated post-init failure")
+
+        monkeypatch.setattr(dmod, "get_hostname", _boom)
+
+        second = setup_wandb(
+            project_name="p", dir=str(tmp_path), mode="offline"
+        )
+        assert second is not None, (
+            "a live run must be returned even when post-init bookkeeping "
+            "fails; returning None silently disables all metric logging"
+        )
+        second.log({"loss": 0.5})  # still usable
+
+    def test_init_failure_itself_still_returns_none(
+        self, wandb_offline, tmp_path, monkeypatch
+    ):
+        """The recovery must NOT extend to wandb.init() failing.
+
+        With no usable run there is nothing to salvage, and callers
+        (WandbBackend) rely on None to fall back to a silent no-op.
+        Guards against 'fixing' the post-init case by broadening the
+        outer handler.
+        """
+        setup_wandb = _setup_wandb()
+        import ezpz.distributed as dmod
+
+        monkeypatch.setattr(dmod, "verify_wandb", lambda: True)
+        monkeypatch.setattr(
+            wandb_offline,
+            "init",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        assert (
+            setup_wandb(project_name="p", dir=str(tmp_path), mode="offline")
+            is None
+        )


### PR DESCRIPTION
## Regression from #201 (v0.24.2) — reported from a live Sunspot run

Creating the W&B run early in `main()` made `setup_wandb` run a **second** time when `History`'s `WandbBackend` later adopted it. Nothing had exercised that path before.

```
wandb: wandb.init() called while a run is active and reinit is set to 'default', so returning the previous run.
[...] wandb.run=[devout-totem-1112](https://wandb.ai/aurora_gpt/.../sdkpnx4k)
[...][E][ezpz/distributed:1705:setup_wandb] wandb.init() failed from rank=0:
    Attempted to change value of key "tstamp"
    from 2026-08-05T16:56:09.118208 to 2026-08-05T16:56:57.869198
[...][W][ezpz/distributed:1706:setup_wandb] Continuing without wandb logging.
```

### Why this is worse than the bug it replaced

The post-init `run.config.update({...})` (`distributed.py:1664`) writes wall-clock keys — `tstamp`, `year`/`month`/`day` — and passed **no** `allow_val_change`. On re-entry `tstamp` differs by the ~48 s of startup, so wandb raises `ConfigError`.

The blanket `except Exception` then swallowed it and returned `None`. `WandbBackend.__init__` sets `_run = None` from that (`tracker.py:230`), and `WandbBackend.log()` **early-returns on `_run=None`** (`tracker.py:249`).

Net effect: **a run visible in the W&B UI that silently receives zero metrics for the entire job.** No loss, no MFU, nothing. The early-init change was meant to record *more*; instead it recorded nothing.

Reproduced locally against the shipped code — same `ConfigError`, same `:1706` warning, `call 2 -> None`.

## Fixes

**1. `allow_val_change=True` on the post-init update** (and the `config=` branch). Re-stamping metadata on re-entry is the intended behaviour. Notably, all three later `config.update` sites in `fsdp_tp.py` already passed this flag — `setup_wandb` was the one place that didn't.

**2. Scope the failure handling.** Only the post-init bookkeeping is wrapped in its own `try/except` that keeps the live run. A live run with stale metadata beats a live run with no data.

Deliberately **not** applied to `wandb.init()` itself: with no usable run there's nothing to salvage, and callers rely on `None` to no-op. My first attempt was too broad and broke `test_tracker.py::test_init_failure_all_methods_noop` — that test was right, and a new test now pins the distinction so the handler can't be re-broadened.

## Tests

`tests/test_setup_wandb_reinit.py` — 6 tests, offline, no account needed:

- second call returns a live run (not `None`)
- second call doesn't raise on wall-clock keys
- `log()` works after the second call — the actual end-to-end symptom
- `config=` with a changed value survives re-entry
- post-init failure keeps the run
- **`wandb.init()` failure still returns `None`** (guards the scope)

Verified to bite: all 5 double-init tests fail against shipped v0.24.2.

Full suite: 1383 passed, 1 pre-existing `gqa` failure (the #199 `atol=1e-6` FLASH-vs-MATH issue, identical on clean `main`).

## Summary by Sourcery

Ensure setup_wandb can be safely called multiple times in a single job without breaking WandB logging.

Bug Fixes:
- Allow WandB run config updates to change timestamp and related fields on re-entry without raising errors or dropping the run.
- Scope post-init WandB config update failures so that an already-active run is preserved and metric logging continues, while genuine init failures still return None as before.

Tests:
- Add regression tests verifying setup_wandb survives double initialization, preserves a live run on post-init failures, and still returns None when wandb.init() itself fails.