### PR TITLE
fix(utils): XPU module loaders no longer break the environment they set up

### DIFF
--- a/docs/notes/shell-environment.md
+++ b/docs/notes/shell-environment.md
@@ -346,16 +346,36 @@ oneAPI software stack and sets the runtime environment:
 ezpz_setup_xpu
 ```
 
-This is equivalent to:
+This is roughly equivalent to:
 
 ```bash
-module load oneapi/release/2025.3.1 hdf5 pti-gpu
+module load oneapi/release hdf5 pti-gpu
 export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 export CCL_PROCESS_LAUNCHER=pmix
 export CCL_OP_SYNC=1
 export ONEAPI_DEVICE_SELECTOR="opencl:gpu;level_zero:gpu"
 export TORCH_CPP_LOG_LEVEL=ERROR
 ```
+
+!!! warning "Two reasons to prefer the helper over the raw `module load`"
+
+    **Don't pin the oneAPI version.** This recipe used to read
+    `oneapi/release/2025.3.1`. On the current `26.181.0` stack that is
+    *not* the default (`2026.1.0` is, and is already loaded), and it
+    survives only in the older `26.26.0` module tree — so the load
+    **succeeds** while silently downgrading oneAPI and swapping
+    `MODULEPATH`. Measured on Sunspot: `import torch` goes from working
+    to `ModuleNotFoundError` immediately after.
+
+    **The raw command evicts an active Python environment.**
+    `module load oneapi/release` prepends its own Python to `PATH` and
+    **unsets `CONDA_PREFIX`**, so an already-activated conda env (e.g.
+    the frameworks-RC stack) is discarded — `python3` flips to
+    `/usr/bin/python3`. `ezpz_setup_xpu` captures the active
+    interpreter first and restores it afterwards, which the raw
+    `module load` above does not. If you must run the modules by hand
+    on top of an activated env, re-prepend your env's `bin` to `PATH`
+    afterwards.
 
 | Variable | Purpose |
 |----------|---------|

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -940,7 +940,18 @@ ezpz_setup_conda_perlmutter() {
 ezpz_load_modules_aurora() {
 	# oneAPI runtime + HDF5 + PTI profiler. Same as ezpz_setup_xpu;
 	# kept here so the function is self-contained / discoverable.
-	module load oneapi/release/2025.3.1 hdf5 pti-gpu
+	#
+	# NOTE: deliberately UNVERSIONED. This used to pin
+	# oneapi/release/2025.3.1, which as of the 26.181.0 stack is not the
+	# site default (2026.1.0 is) and lives only in the older 26.26.0
+	# module tree. Loading it SUCCEEDS but silently downgrades the
+	# already-loaded default and swaps MODULEPATH, which breaks any
+	# environment built against the current oneAPI -- e.g. the
+	# frameworks-RC conda env, where `import torch` goes from working to
+	# ModuleNotFoundError immediately after this line. Let the site
+	# default win; pin again only if a specific version is required, and
+	# verify it still exists in the active module tree.
+	module load oneapi/release hdf5 pti-gpu
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
 	export CCL_OP_SYNC=1
@@ -970,7 +981,11 @@ ezpz_load_modules_sunspot() {
 	# (minus FI_MR_CACHE_MONITOR, which is Aurora-specific). Kept as a
 	# separate function for grep-ability and so the two stacks can
 	# diverge independently if Sunspot's oneAPI version ever differs.
-	module load oneapi/release/2025.3.1 hdf5 pti-gpu
+	#
+	# Unversioned on purpose -- see ezpz_load_modules_aurora for why
+	# pinning 2025.3.1 silently downgraded the site default and broke
+	# torch on the frameworks-RC stack.
+	module load oneapi/release hdf5 pti-gpu
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
 	export CCL_OP_SYNC=1
@@ -2523,7 +2538,10 @@ ezpz_print_job_env() {
 # @stdout Prints loaded module names
 ###############################################
 ezpz_setup_xpu() {
-	module load oneapi/release/2025.3.1 hdf5 pti-gpu
+	# Unversioned on purpose -- see ezpz_load_modules_aurora for why
+	# pinning 2025.3.1 silently downgraded the site default and broke
+	# torch on the frameworks-RC stack.
+	module load oneapi/release hdf5 pti-gpu
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
 	export CCL_OP_SYNC=1

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -962,17 +962,31 @@ ezpz_setup_conda_perlmutter() {
 # @stdout Nothing (module output is the caller's concern)
 ###############################################
 _ezpz_load_xpu_modules_preserving_python() {
-	local _py_dir=""
-	if command -v python3 >/dev/null 2>&1 \
-		&& python3 -c "import torch" >/dev/null 2>&1; then
+	# Predicate is "a managed env is ACTIVE", not "torch imports right
+	# now". Those differ in exactly the case that matters: on the
+	# frameworks-RC stack torch is installed but not yet importable
+	# before this function runs, because the pti-gpu module we are
+	# about to load is what supplies libpti_view.so.0. An
+	# `import torch` probe would fail, preserve nothing, and let the
+	# module load evict the env anyway -- which is precisely the bug.
+	local _py_dir="" _conda_prefix="${CONDA_PREFIX:-}" _virtual_env="${VIRTUAL_ENV:-}"
+	if [[ -n "${_conda_prefix}" || -n "${_virtual_env}" ]] \
+		&& command -v python3 >/dev/null 2>&1; then
 		_py_dir="$(dirname "$(command -v python3)")"
 	fi
+
 	module load oneapi/release hdf5 pti-gpu
+
 	if [[ -n "${_py_dir}" ]] \
 		&& [[ "$(dirname "$(command -v python3 2>/dev/null)")" != "${_py_dir}" ]]; then
-		log_message INFO "Restoring pre-existing python env evicted by module load: ${_py_dir}"
+		log_message INFO "Restoring active python env evicted by module load: ${_py_dir}"
 		export PATH="${_py_dir}:${PATH}"
+		# The oneapi module also UNSETS these; put them back so conda /
+		# venv tooling downstream still sees an activated environment.
+		[[ -n "${_conda_prefix}" ]] && export CONDA_PREFIX="${_conda_prefix}"
+		[[ -n "${_virtual_env}" ]] && export VIRTUAL_ENV="${_virtual_env}"
 	fi
+	return 0
 }
 
 ezpz_load_modules_aurora() {

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -937,6 +937,44 @@ ezpz_setup_conda_perlmutter() {
 #
 # @stdout Prints loaded module names
 ###############################################
+###############################################
+# Load the XPU module stack WITHOUT evicting an
+# already-active Python environment.
+#
+# `module load oneapi/release` prepends its own Python to PATH and
+# UNSETS CONDA_PREFIX, so an active conda env (e.g. the frameworks-RC
+# stack) is silently thrown away: `python3` flips to /usr/bin/python3
+# and `import torch` becomes ModuleNotFoundError. Measured on Sunspot:
+#
+#   conda activate <RC4 env>      -> python3 = <env>/bin/python3
+#   module load oneapi/release    -> python3 = /usr/bin/python3,
+#                                    CONDA_PREFIX = <empty>
+#
+# That turns a helper meant to PREPARE the XPU stack into one that
+# destroys it. ezpz_setup already works around this locally via
+# _preloaded_py; this fixes it at the source so every caller benefits.
+#
+# We capture the active interpreter's directory BEFORE loading and put
+# it back on the front of PATH afterwards. Only done when the
+# pre-existing python actually has torch -- otherwise there is nothing
+# worth preserving and we leave the module-provided python in place.
+#
+# @stdout Nothing (module output is the caller's concern)
+###############################################
+_ezpz_load_xpu_modules_preserving_python() {
+	local _py_dir=""
+	if command -v python3 >/dev/null 2>&1 \
+		&& python3 -c "import torch" >/dev/null 2>&1; then
+		_py_dir="$(dirname "$(command -v python3)")"
+	fi
+	module load oneapi/release hdf5 pti-gpu
+	if [[ -n "${_py_dir}" ]] \
+		&& [[ "$(dirname "$(command -v python3 2>/dev/null)")" != "${_py_dir}" ]]; then
+		log_message INFO "Restoring pre-existing python env evicted by module load: ${_py_dir}"
+		export PATH="${_py_dir}:${PATH}"
+	fi
+}
+
 ezpz_load_modules_aurora() {
 	# oneAPI runtime + HDF5 + PTI profiler. Same as ezpz_setup_xpu;
 	# kept here so the function is self-contained / discoverable.
@@ -945,13 +983,10 @@ ezpz_load_modules_aurora() {
 	# oneapi/release/2025.3.1, which as of the 26.181.0 stack is not the
 	# site default (2026.1.0 is) and lives only in the older 26.26.0
 	# module tree. Loading it SUCCEEDS but silently downgrades the
-	# already-loaded default and swaps MODULEPATH, which breaks any
-	# environment built against the current oneAPI -- e.g. the
-	# frameworks-RC conda env, where `import torch` goes from working to
-	# ModuleNotFoundError immediately after this line. Let the site
-	# default win; pin again only if a specific version is required, and
-	# verify it still exists in the active module tree.
-	module load oneapi/release hdf5 pti-gpu
+	# already-loaded default and swaps MODULEPATH. Let the site default
+	# win; pin again only if a specific version is required, and verify
+	# it still exists in the active module tree.
+	_ezpz_load_xpu_modules_preserving_python
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
 	export CCL_OP_SYNC=1
@@ -982,10 +1017,9 @@ ezpz_load_modules_sunspot() {
 	# separate function for grep-ability and so the two stacks can
 	# diverge independently if Sunspot's oneAPI version ever differs.
 	#
-	# Unversioned on purpose -- see ezpz_load_modules_aurora for why
-	# pinning 2025.3.1 silently downgraded the site default and broke
-	# torch on the frameworks-RC stack.
-	module load oneapi/release hdf5 pti-gpu
+	# Unversioned + python-preserving -- see
+	# _ezpz_load_xpu_modules_preserving_python.
+	_ezpz_load_xpu_modules_preserving_python
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
 	export CCL_OP_SYNC=1
@@ -2538,10 +2572,9 @@ ezpz_print_job_env() {
 # @stdout Prints loaded module names
 ###############################################
 ezpz_setup_xpu() {
-	# Unversioned on purpose -- see ezpz_load_modules_aurora for why
-	# pinning 2025.3.1 silently downgraded the site default and broke
-	# torch on the frameworks-RC stack.
-	module load oneapi/release hdf5 pti-gpu
+	# Unversioned + python-preserving -- see
+	# _ezpz_load_xpu_modules_preserving_python.
+	_ezpz_load_xpu_modules_preserving_python
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
 	export CCL_OP_SYNC=1

--- a/tests/test_shell_suites.py
+++ b/tests/test_shell_suites.py
@@ -1,0 +1,78 @@
+"""Run the repo's bash test suites under pytest, so CI sees them.
+
+`tests/*.sh` are self-contained bash suites (stub-based, no modules,
+no accelerator, no scheduler). They were only ever documented as
+"run this by hand", which meant PR CI — which runs `pytest` — never
+executed them and could not catch a regression in the shell code they
+cover:
+
+  * test_ezpz_setup_venv.sh          — ezpz_setup Flow B auto-venv
+  * test_failover_lib.sh             — failover.sh bad-node helpers
+  * test_xpu_module_python_guard.sh  — XPU module load must not evict
+                                       an active python env
+
+Each is parametrized as its own pytest case so a failure names the
+suite, and the bash output is surfaced in the assertion message rather
+than swallowed.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SHELL_SUITES = [
+    "test_ezpz_setup_venv.sh",
+    "test_failover_lib.sh",
+    "test_xpu_module_python_guard.sh",
+]
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.name != "posix", reason="bash suites assume POSIX"
+    ),
+    pytest.mark.skipif(
+        shutil.which("bash") is None, reason="bash not available"
+    ),
+]
+
+
+@pytest.mark.parametrize("suite", SHELL_SUITES)
+def test_shell_suite_passes(suite: str) -> None:
+    script = REPO_ROOT / "tests" / suite
+    if not script.is_file():
+        pytest.skip(f"{suite} not present")
+    proc = subprocess.run(
+        ["bash", str(script)],
+        cwd=REPO_ROOT,  # suites resolve src/ezpz/bin/utils.sh from the root
+        capture_output=True,
+        text=True,
+        timeout=300,
+        # NO_COLOR keeps the assertion message readable when it fails.
+        env={**os.environ, "NO_COLOR": "1"},
+    )
+    assert proc.returncode == 0, (
+        f"{suite} failed (rc={proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout}\n"
+        f"--- stderr ---\n{proc.stderr}"
+    )
+
+
+def test_every_shell_suite_is_registered() -> None:
+    """A new tests/*.sh must be added to SHELL_SUITES.
+
+    Without this, someone adds a bash suite, it silently never runs in
+    CI, and we are back to the gap this file exists to close.
+    """
+    on_disk = {p.name for p in (REPO_ROOT / "tests").glob("test_*.sh")}
+    missing = sorted(on_disk - set(SHELL_SUITES))
+    assert not missing, (
+        f"bash suites not registered in SHELL_SUITES (so CI skips them): "
+        f"{missing}"
+    )

--- a/tests/test_xpu_module_python_guard.sh
+++ b/tests/test_xpu_module_python_guard.sh
@@ -56,7 +56,13 @@ grep -q "module load oneapi" "${FN_FILE}" || {
 
 run_test() {
     local name="$1"; shift
-    if ( "$@" ) >/dev/null 2>&1; then
+    # Give each test its own TMPDIR and remove it afterwards, so the
+    # per-test `mktemp -d` sandboxes don't leak into /tmp. The test body
+    # already runs in a subshell, so exporting TMPDIR here cannot bleed
+    # between tests.
+    local tmp_root
+    tmp_root="$(mktemp -d)"
+    if ( export TMPDIR="${tmp_root}"; "$@" ) >/dev/null 2>&1; then
         printf "  %s%-56s PASS%s\n" "${G}" "${name}" "${N}"
         PASS=$((PASS + 1))
     else
@@ -64,6 +70,7 @@ run_test() {
         FAIL=$((FAIL + 1))
         FAILED_TESTS+=("${name}")
     fi
+    rm -rf "${tmp_root}"
 }
 
 # Build a sandbox: a fake "conda env" python3 and a fake "system"

--- a/tests/test_xpu_module_python_guard.sh
+++ b/tests/test_xpu_module_python_guard.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# test_xpu_module_python_guard.sh — unit tests for
+# _ezpz_load_xpu_modules_preserving_python() in src/ezpz/bin/utils.sh.
+#
+# Run from the repo root:
+#   bash tests/test_xpu_module_python_guard.sh
+#
+# Regression guard for a bug found on Sunspot 2026-08-05: `module load
+# oneapi/release` prepends its own Python to PATH and UNSETS
+# CONDA_PREFIX, so an already-active conda env is silently discarded --
+#
+#   conda activate <RC4 frameworks env> -> python3 = <env>/bin/python3
+#   module load oneapi/release          -> python3 = /usr/bin/python3
+#                                          CONDA_PREFIX = <empty>
+#
+# ...turning the helpers that PREPARE the XPU stack
+# (ezpz_load_modules_{aurora,sunspot}, ezpz_setup_xpu) into ones that
+# destroy it.
+#
+# The subtle part, and the reason for test 3: the guard must NOT key on
+# `python3 -c "import torch"` succeeding. On the real frameworks-RC
+# stack torch is installed but not yet importable at this point --
+# libpti_view.so.0 comes from the pti-gpu module the function is about
+# to load. A torch probe fails there, preserves nothing, and lets the
+# eviction happen anyway. Key on env activation instead.
+#
+# `module` is stubbed to emulate the eviction; no real modules needed.
+
+set -u
+unset CDPATH
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+    G=$'\033[1;32m'; R=$'\033[1;31m'; C=$'\033[1;36m'; N=$'\033[0m'
+else
+    G=""; R=""; C=""; N=""
+fi
+
+UTILS="${UTILS:-src/ezpz/bin/utils.sh}"
+[[ -f "${UTILS}" ]] || { printf "%sFATAL%s: %s not found (run from repo root)\n" "${R}" "${N}" "${UTILS}" >&2; exit 1; }
+
+FN_FILE="$(mktemp)"
+trap 'rm -f "${FN_FILE}"' EXIT
+
+# Extract just the function under test (utils.sh's other helpers touch
+# real modules/schedulers, so we do not source the whole file).
+awk '/^_ezpz_load_xpu_modules_preserving_python\(\) \{/{f=1} f{print} f&&/^\}/{exit}' \
+    "${UTILS}" > "${FN_FILE}"
+grep -q "module load oneapi" "${FN_FILE}" || {
+    printf "%sFATAL%s: extracted function lacks the module load\n" "${R}" "${N}" >&2
+    exit 1
+}
+
+run_test() {
+    local name="$1"; shift
+    if ( "$@" ) >/dev/null 2>&1; then
+        printf "  %s%-56s PASS%s\n" "${G}" "${name}" "${N}"
+        PASS=$((PASS + 1))
+    else
+        printf "  %s%-56s FAIL%s\n" "${R}" "${name}" "${N}"
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("${name}")
+    fi
+}
+
+# Build a sandbox: a fake "conda env" python3 and a fake "system"
+# python3, plus a `module` stub that emulates the eviction by putting
+# the system dir first and unsetting CONDA_PREFIX.
+_setup_sandbox() {
+    SB="$(mktemp -d)"
+    mkdir -p "${SB}/env/bin" "${SB}/sys/bin"
+    printf '#!/bin/sh\necho ENV_PYTHON\n'  > "${SB}/env/bin/python3"
+    printf '#!/bin/sh\necho SYS_PYTHON\n'  > "${SB}/sys/bin/python3"
+    chmod +x "${SB}/env/bin/python3" "${SB}/sys/bin/python3"
+    # `module` stub: emulate oneapi evicting the active env.
+    module() {
+        export PATH="${SB}/sys/bin:${PATH}"
+        unset CONDA_PREFIX
+    }
+    log_message() { :; }
+    export PATH="${SB}/env/bin:/usr/bin:/bin"
+    # shellcheck disable=SC1090
+    source "${FN_FILE}"
+}
+
+_which_py() { dirname "$(command -v python3)"; }
+
+# 1. The core contract: an active conda env survives the module load.
+test_conda_env_preserved() {
+    _setup_sandbox
+    export CONDA_PREFIX="${SB}/env"
+    _ezpz_load_xpu_modules_preserving_python
+    [[ "$(_which_py)" == "${SB}/env/bin" ]] || {
+        echo "python3 was evicted: $(command -v python3)"; return 1; }
+    # CONDA_PREFIX (unset by the module) must be restored too.
+    [[ "${CONDA_PREFIX:-}" == "${SB}/env" ]] || {
+        echo "CONDA_PREFIX not restored: ${CONDA_PREFIX:-<empty>}"; return 1; }
+}
+
+# 2. Same for a plain virtualenv.
+test_virtualenv_preserved() {
+    _setup_sandbox
+    export VIRTUAL_ENV="${SB}/env"
+    _ezpz_load_xpu_modules_preserving_python
+    [[ "$(_which_py)" == "${SB}/env/bin" ]] || return 1
+    [[ "${VIRTUAL_ENV:-}" == "${SB}/env" ]] || return 1
+}
+
+# 3. THE REGRESSION: preservation must not require torch to import.
+#    On the frameworks-RC stack torch is installed but unimportable
+#    until pti-gpu (loaded by this very function) provides
+#    libpti_view.so.0. A torch-probe predicate skipped preservation and
+#    let the eviction through -- the original bug.
+test_preserved_even_when_torch_unimportable() {
+    _setup_sandbox
+    # env python that FAILS every import (stands in for the missing .so)
+    printf '#!/bin/sh\nexit 1\n' > "${SB}/env/bin/python3"
+    chmod +x "${SB}/env/bin/python3"
+    export CONDA_PREFIX="${SB}/env"
+    _ezpz_load_xpu_modules_preserving_python
+    [[ "$(_which_py)" == "${SB}/env/bin" ]] || {
+        echo "env evicted because torch did not import (the original bug)"
+        return 1; }
+}
+
+# 4. No active env -> nothing to preserve; module python wins.
+test_no_active_env_leaves_module_python() {
+    _setup_sandbox
+    unset CONDA_PREFIX VIRTUAL_ENV
+    _ezpz_load_xpu_modules_preserving_python
+    [[ "$(_which_py)" == "${SB}/sys/bin" ]] || {
+        echo "expected module python, got $(command -v python3)"; return 1; }
+}
+
+# 5. Idempotent: a second call must not corrupt PATH or the env vars.
+test_idempotent() {
+    _setup_sandbox
+    export CONDA_PREFIX="${SB}/env"
+    _ezpz_load_xpu_modules_preserving_python
+    _ezpz_load_xpu_modules_preserving_python
+    [[ "$(_which_py)" == "${SB}/env/bin" ]] || return 1
+    [[ "${CONDA_PREFIX:-}" == "${SB}/env" ]] || return 1
+}
+
+# 6. Returns success even when nothing needed restoring, so callers
+#    running under `set -e` do not abort.
+test_returns_zero() {
+    _setup_sandbox
+    unset CONDA_PREFIX VIRTUAL_ENV
+    _ezpz_load_xpu_modules_preserving_python || return 1
+}
+
+printf "\n%s_ezpz_load_xpu_modules_preserving_python%s\n" "${C}" "${N}"
+run_test "active conda env survives module load"      test_conda_env_preserved
+run_test "active virtualenv survives module load"     test_virtualenv_preserved
+run_test "preserved even when torch is unimportable"  test_preserved_even_when_torch_unimportable
+run_test "no active env -> module python kept"        test_no_active_env_leaves_module_python
+run_test "idempotent across repeated calls"           test_idempotent
+run_test "returns 0 when nothing to restore"          test_returns_zero
+
+printf "\n%d passed, %d failed\n" "${PASS}" "${FAIL}"
+if ((FAIL > 0)); then
+    printf "Failed: %s\n" "${FAILED_TESTS[*]}"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

`ezpz_load_modules_aurora`, `ezpz_load_modules_sunspot` and `ezpz_setup_xpu` — three helpers whose job is to **prepare** the XPU stack — were **destroying** it for anyone who had already activated a framework environment. This is why the frameworks-RC workflow on Sunspot needs a hand-rolled module recipe instead of `ezpz_load_modules`.

Two independent defects, both measured on a Sunspot compute node with the RC4 frameworks conda env:

### 1. A stale hardcoded oneAPI version silently downgrades the stack

All three sites pinned `module load oneapi/release/2025.3.1`. On the current `26.181.0` stack that is **not** the default (`2026.1.0` is, and is already loaded), and `2025.3.1` survives only in the older `26.26.0` module tree. The load *succeeds* while downgrading oneAPI and swapping `MODULEPATH`:

```
default 2026.1.0             -> import torch: works
after module load 2025.3.1   -> import torch: ModuleNotFoundError
```

### 2. The module load evicts the active Python environment

The bigger one, found only because unpinning alone didn't fix it. `module load oneapi/release` prepends its own Python to `PATH` **and unsets `CONDA_PREFIX`**:

```
conda activate <RC4 env>    -> python3 = <env>/bin/python3
module load oneapi/release  -> python3 = /usr/bin/python3
                               CONDA_PREFIX = <empty>
```

`ezpz_setup` already worked around this locally via `_preloaded_py` (PR #198); this fixes it at the source so every caller benefits.

## Fix

- Drop the version pin so the site default wins.
- Extract `_ezpz_load_xpu_modules_preserving_python`: capture the active interpreter's directory before the load, restore it to the front of `PATH` afterwards, and restore `CONDA_PREFIX`/`VIRTUAL_ENV`.

**The predicate is the subtle part.** It keys on *"a managed env is active"*, **not** *"torch imports right now"*. Those differ in exactly the case that matters: on the frameworks-RC stack torch is installed but **not yet importable** before this function runs, because `libpti_view.so.0` comes from the `pti-gpu` module the function is about to load. A torch probe fails there, preserves nothing, and lets the eviction happen anyway. I shipped that wrong predicate first and compute-node validation caught it.

## Result

The helper now **repairs** the environment instead of breaking it — `pti-gpu` supplies the missing lib while the guard keeps the conda python:

```
=== ezpz branch: 9d529c2 ===
baseline torch (site default oneapi): ImportError: libpti_view.so.0
--- calling ezpz_load_modules_sunspot (FIXED) ---
oneapi now: oneapi/release/2026.1.0
torch     : 2.13.0a0+gitcf30153
```

## Validation

Each iteration was validated on a real Sunspot compute node before the next; the first two attempts **failed there** and never reached this PR:

| attempt | job | result |
|---|---|---|
| unpin only | 12472643 | FAIL — `ModuleNotFoundError` (right issue, wrong layer) |
| guard on `import torch` | 12472644 | FAIL — predicate never true (chicken-and-egg) |
| guard on `CONDA_PREFIX`/`VIRTUAL_ENV` | 12472645 | **PASS** — `torch 2.13.0a0+gitcf30153` |

## Tests

`tests/test_xpu_module_python_guard.sh` — 6 tests with `module` stubbed to emulate the eviction. No modules or accelerator required.

Verified to discriminate against both broken versions:
- no guard → **4 of 6 fail**
- torch-probe predicate → **test 3 fails** (the exact mistake above)
- current → **6/6**

Also: `bash -n` clean, `test_ezpz_setup_venv.sh` 8/8, `test_failover_lib.sh` 23/23, python suite 1384 passed (1 pre-existing `gqa` failure, identical on clean `main`).

## Summary by Sourcery

Preserve existing Python environments when loading the XPU module stack and stop pinning oneAPI to a stale version for Aurora and Sunspot helpers.

Bug Fixes:
- Prevent XPU module loader helpers from evicting active conda/virtualenv Python environments when loading oneAPI modules.
- Avoid silent downgrades of the oneAPI stack by no longer pinning to an outdated oneAPI release in XPU setup helpers.

Enhancements:
- Introduce a shared helper to load XPU modules while restoring PATH and environment markers for managed Python environments when necessary.

Tests:
- Add a dedicated bash test suite that stubs the module system to validate that the XPU module loader preserves or replaces Python correctly across multiple scenarios.