### PR TITLE
feat(launch): accept --nhosts as an alternative to --nproc for --auto-retry

### DIFF
--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -178,8 +178,8 @@ between attempts.
 
 ```mermaid
 flowchart TD
-    Start(["ezpz launch --auto-retry --np N"]) --> Validate{"nproc set<br/>explicitly?"}
-    Validate -->|no| ErrParse["SystemExit at parse:<br/>requires --nproc"]
+    Start(["ezpz launch --auto-retry<br/>--nhosts N (or --np N)"]) --> Validate{"active size set<br/>explicitly?"}
+    Validate -->|no| ErrParse["SystemExit at parse:<br/>requires --nhosts or --nproc"]
     Validate -->|yes| Split["Split PBS nodelist<br/>into active + spare,<br/>write active.hostfile"]
     Split --> Attempt["Run attempt i<br/>tee to attempt-i.log,<br/>watchdog armed<br/>(default 1800s)"]
     Attempt -->|"SIGINT<br/>(Ctrl-C)"| Interrupted(["FAILOVER STOP:<br/>interrupted<br/>return 130"])
@@ -206,22 +206,40 @@ hosts and `swap_one_blind` when it didn't — see the
 edge case where `swap_in` finds no live hosts to replace and
 falls through to a blind rotation.
 
-### Required: explicit `--nproc`
+### Required: an explicit active size (`--nhosts` **or** `--nproc`)
 
-`--auto-retry` needs to know how many ranks are training so it can
-split the PBS allocation into active + spare. We **do not guess**
-the active-host count — pass `--nproc N` (or `-n N` / `--np N`)
-explicitly. The CLI errors out at parse time otherwise:
+`--auto-retry` needs the **active host count** so it can split the PBS
+allocation into active + spare. We **do not guess** it. Pass either:
+
+- `--nhosts N` (`-nh` / `--nnodes`) — states the host count directly,
+  used verbatim; or
+- `--nproc N` (`-n` / `--np`) — states *ranks*, which we ceiling-divide
+  by the ranks-per-node to get hosts.
+
+```bash
+# Equivalent on Aurora (12 ranks/node): 43 active hosts either way.
+ezpz launch --auto-retry --nhosts 43 -- python3 train.py
+ezpz launch --auto-retry --np 512   -- python3 train.py
+```
+
+If you think in nodes (the usual case when sizing a PBS job), prefer
+`--nhosts`; it avoids a rank-count round trip and sidesteps the
+ceiling-division rounding entirely. When both are given, `--nhosts`
+wins for the split.
+
+The CLI errors out at parse time when neither is set:
 
 ```text
 $ ezpz launch --auto-retry -- python3 train.py
---auto-retry requires --nproc (-n/--np) to be set explicitly. ...
+--auto-retry requires the active size to be set explicitly: pass
+--nhosts (-nh/--nnodes) or --nproc (-n/--np). ...
 ```
 
 ### Spare-node policy (`--spare-nodes`)
 
 By default (`--spare-nodes auto`), the spare pool is
-`total_pbs_nodes - ceil($nproc / $ppn)`. The `--nproc` (or `-n`,
+`total_pbs_nodes - active_hosts`, where `active_hosts` is either
+`--nhosts` verbatim or `ceil($nproc / $ppn)`. The `--nproc` (or `-n`,
 `--np`) flag counts *ranks*, not nodes; we ceiling-divide by the
 ranks-per-node (`--ppn` or the cluster's `get_gpus_per_node()`) to
 get the number of *hosts* actually needed for training. Any

--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -237,6 +237,27 @@ $ ezpz launch --auto-retry -- python3 train.py
 --nhosts (-nh/--nnodes) or --nproc (-n/--np). ...
 ```
 
+A non-positive value is reported distinctly from a missing one — `--nhosts 0`
+gets `--auto-retry: --nhosts must be > 0, got 0`, not a misleading
+"pass `--nhosts`".
+
+!!! warning "`--auto-retry` needs an active PBS/SLURM allocation"
+
+    Failover works by splitting the scheduler's nodelist into active +
+    spare hosts. With no active job, `ezpz launch` falls back to a local
+    `mpirun` and there is no pool to fail over *to* — the command runs
+    once and `--auto-retry` has no effect. You get a warning rather than
+    silence:
+
+    ```text
+    --auto-retry has no effect without an active PBS/SLURM job: there is
+    no allocation to split into active + spare hosts. Running the
+    command once via the local mpirun fallback.
+    ```
+
+    On that fallback path `--nhosts N` without `--ppn` derives ranks as
+    `N × get_gpus_per_node()`.
+
 ### Spare-node policy (`--spare-nodes`)
 
 By default (`--spare-nodes auto`), the spare pool is

--- a/docs/cli/launch/index.md
+++ b/docs/cli/launch/index.md
@@ -86,11 +86,13 @@ allocated to your job.
                                 Idle-output watchdog timeout in seconds. Off by default.
         --retries RETRIES     Re-execute on non-zero exit, up to N times. Default: 0.
         --auto-retry          Unbounded bad-node failover loop. Mutually
-                                exclusive with --retries. Requires explicit --nproc.
+                                exclusive with --retries. Requires an explicit
+                                active size: --nhosts (-nh) or --nproc (-n/--np).
         --spare-nodes SPARE_NODES
                                 Spare-node pool for --auto-retry. "auto" (default)
-                                derives from total_pbs_nodes - ceil($nproc / $ppn);
-                                pass an int for an explicit cap.
+                                derives from total_pbs_nodes - active_hosts
+                                (--nhosts, else ceil($nproc / $ppn)); pass an int
+                                for an explicit cap.
         --max-failover-retries MAX_FAILOVER_RETRIES
                                 Optional upper bound on --auto-retry attempts.
                                 Default: unbounded (see termination matrix).
@@ -435,7 +437,7 @@ qsub -A datascience -q workq -l filesystems=tegu:home -l select=4 \
 qsub src/ezpz/bin/test_launch_timeout_retries_aurora.pbs
 ```
 
-The `--auto-retry` driver requests 4 nodes and runs 7 scenarios
+The `--auto-retry` driver requests 4 nodes and runs 9 scenarios
 (~30 min walltime budget):
 
 | Scenario | What it covers |
@@ -447,6 +449,8 @@ The `--auto-retry` driver requests 4 nodes and runs 7 scenarios
 | E | `STUCK_PRE_TRAINING` guard — 2 consecutive zero-step attempts, bail at attempt 2 |
 | F | Realistic — `ezpz.examples.test --model debug --train-iters 20` under `--auto-retry` |
 | G | `--hostfile` honored — pass a 2-node filtered hostfile, verify the loop splits THAT (not the full PBS allocation) |
+| H | `--nhosts` sizing — no `--nproc` at all; verify the host count is honored verbatim |
+| I | No active size — `--auto-retry` alone must refuse at parse time, naming both `--nhosts` and `--nproc` |
 
 The driver works on **Sunspot too** — swap `-A AuroraGPT` → `-A datascience`
 and `filesystems=flare:home` → `filesystems=tegu:home` in the PBS header

--- a/src/ezpz/bin/test_launch_auto_retry.pbs
+++ b/src/ezpz/bin/test_launch_auto_retry.pbs
@@ -60,6 +60,16 @@ unset CDPATH
 cd "${PBS_O_WORKDIR}" || { echo "PBS_O_WORKDIR unset; aborting"; exit 1; }
 
 # ---- Environment setup (identical to timeout/retries driver) --------------
+# ALCF compute nodes have NO direct outbound internet; everything goes
+# through the site proxy. Exported UNCONDITIONALLY (it used to live only
+# inside the curl-fallback branch below, which never fires when the repo
+# ships utils.sh -- so scenario F's `wandb.init()` had no proxy, blocked
+# 60s on api.wandb.ai, produced no output, and the idle watchdog killed
+# the run at 300s: `rc=124` after ~835s, a network failure masquerading
+# as an auto-retry failure).
+export http_proxy="${http_proxy:-http://proxy.alcf.anl.gov:3128}"
+export https_proxy="${https_proxy:-${http_proxy}}"
+
 UTILS=""
 if [[ -f "${PBS_O_WORKDIR}/src/ezpz/bin/utils.sh" ]]; then
     UTILS="${PBS_O_WORKDIR}/src/ezpz/bin/utils.sh"
@@ -70,8 +80,6 @@ elif command -v python3 >/dev/null 2>&1; then
     fi
 fi
 if [[ -z "${UTILS}" ]]; then
-    export http_proxy="${http_proxy:-http://proxy.alcf.anl.gov:3128}"
-    export https_proxy="${https_proxy:-${http_proxy}}"
     UTILS="$(mktemp -t ezpz-utils-XXXXXX).sh"
     curl -fsSL --max-time 30 \
         https://raw.githubusercontent.com/saforem2/ezpz/main/src/ezpz/bin/utils.sh \

--- a/src/ezpz/bin/test_launch_auto_retry.pbs
+++ b/src/ezpz/bin/test_launch_auto_retry.pbs
@@ -407,6 +407,51 @@ else
     record G FAIL "rc=${RC} active_count=${ACTIVE_COUNT} (wanted 1)"
 fi
 
+# ---- H: --nhosts instead of --nproc ---------------------------------------
+hdr "H" "Active size via --nhosts: 1 active host, used verbatim (no --nproc)"
+D=$(scen_dir H)
+cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
+START=$(date +%s)
+# NOTE: deliberately NO --nproc. --auto-retry used to reject this; it now
+# accepts a host count directly. --nhosts is a HOST count, so 1 here must
+# yield exactly 1 active host -- no ranks->hosts conversion applied to a
+# number that is already hosts.
+ezpz launch --nhosts 1 --auto-retry --timeout 60 \
+    -- bash -c 'echo "iter step=1"; exit 0' > "${LOG}" 2>&1
+RC=$?
+ELAPSED=$(( $(date +%s) - START ))
+cd "${PBS_O_WORKDIR}" || { log_message ERROR "cd back to PBS_O_WORKDIR failed"; exit 1; }
+
+ACTIVE_FILE=$(ls "${D}"/logs/failover-*/active.hostfile 2>/dev/null | head -1)
+ACTIVE_COUNT=$(wc -l < "${ACTIVE_FILE}" 2>/dev/null || echo 0)
+echo "exit=${RC}  elapsed=${ELAPSED}s  active_hostfile_count=${ACTIVE_COUNT}"
+grep -E "active hostfile|spare hostfile|active=" "${LOG}" | head -5
+if [[ ${RC} -eq 0 && ${ACTIVE_COUNT} -eq 1 ]]; then
+    record H PASS "--nhosts 1 honored verbatim, rc=0 in ${ELAPSED}s"
+else
+    record H FAIL "rc=${RC} active_count=${ACTIVE_COUNT} (wanted rc=0, count=1)"
+fi
+
+# ---- I: neither --nhosts nor --nproc → clean parse-time refusal -----------
+hdr "I" "No active size: --auto-retry alone must fail fast at parse time"
+D=$(scen_dir I)
+cd "${D}" || { log_message ERROR "cd to scenario dir failed: ${D}"; exit 1; }
+START=$(date +%s)
+ezpz launch --auto-retry --timeout 60 \
+    -- bash -c 'echo "iter step=1"; exit 0' > "${LOG}" 2>&1
+RC=$?
+ELAPSED=$(( $(date +%s) - START ))
+cd "${PBS_O_WORKDIR}" || { log_message ERROR "cd back to PBS_O_WORKDIR failed"; exit 1; }
+echo "exit=${RC}  elapsed=${ELAPSED}s"
+grep -E "active size" "${LOG}" | head -3
+# Must refuse immediately (no attempts, no failover dir), naming BOTH flags.
+if [[ ${RC} -ne 0 ]] && grep -q -- "--nhosts" "${LOG}" \
+    && grep -q -- "--nproc" "${LOG}"; then
+    record I PASS "refused at parse time (rc=${RC}), error names both flags"
+else
+    record I FAIL "rc=${RC} (wanted !=0 with an error naming --nhosts/--nproc)"
+fi
+
 # ---- Final report ---------------------------------------------------------
 printf "\n========================================================================\n"
 printf "%s --auto-retry summary  (PASS=%d  FAIL=%d)\n" \

--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -491,8 +491,8 @@ def build_launch_parser(
             "or rotate one spare blindly. Loops until success, a real "
             "walltime hit, spare exhaustion, two consecutive attempts "
             "with zero training progress, or SIGINT. "
-            "Requires --nproc to be set explicitly. "
-            "Mutually exclusive with --retries."
+            "Requires an explicit active size: --nhosts (-nh) or "
+            "--nproc (-n/--np). Mutually exclusive with --retries."
         ),
     )
     parser.add_argument(

--- a/src/ezpz/cli/flags.py
+++ b/src/ezpz/cli/flags.py
@@ -503,10 +503,11 @@ def build_launch_parser(
         help=(
             "Number of spare nodes to reserve for --auto-retry "
             "swap-ins. Pass 'auto' (the default when --auto-retry is "
-            "set) to derive from total_pbs_nodes - ceil($nproc / $ppn) "
-            "(ranks → hosts, since --nproc counts ranks). Pass an "
-            "integer for an explicit count. Ignored when --auto-retry "
-            "is not set."
+            "set) to derive from total_pbs_nodes - active_hosts, where "
+            "active_hosts is --nhosts verbatim, else "
+            "ceil($nproc / $ppn) (ranks → hosts, since --nproc counts "
+            "ranks). Pass an integer for an explicit count. Ignored "
+            "when --auto-retry is not set."
         ),
     )
     parser.add_argument(

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -857,11 +857,13 @@ def launch(
         autoretry_pool = _resolve_auto_retry_node_pool(
             selected_hostfile, nodelist
         )
-        # `--ppn` (== ngpu_per_host) sets ranks-per-node when given;
-        # fall back to the cluster's GPU count (the typical default,
-        # one rank per GPU) when not. `or 1` covers the degenerate
-        # case where get_gpus_per_node() returns 0 on a non-GPU node.
-        ranks_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
+        # NB: GPU detection is deliberately NOT done here. The nhosts
+        # route never needs it (an explicit host count is already the
+        # answer), and ezpz.get_gpus_per_node() can raise
+        # ModuleNotFoundError on a launcher/login node with no torch --
+        # which would break a perfectly well-specified
+        # `--auto-retry --nhosts N`. Only the ngpus route resolves it,
+        # lazily, below.
         if nhosts is not None:
             # Explicit host count wins: it is what we need, verbatim,
             # with no ranks->hosts rounding in between. When BOTH are
@@ -884,6 +886,13 @@ def launch(
                     f"launch(auto_retry=True): ngpus must be > 0, "
                     f"got {ngpus}."
                 )
+            # Resolved HERE, not above, so the nhosts route never pays
+            # for GPU detection (see the note at the top of this block).
+            # `--ppn` (== ngpu_per_host) wins when given; else the
+            # cluster's GPU count, the typical one-rank-per-GPU default.
+            # `or 1` covers get_gpus_per_node() returning 0 on a
+            # non-GPU node.
+            ranks_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
             nhosts_active = _ranks_to_hosts(ngpus, ranks_per_node)
         autoretry_log_dir = _auto_retry_log_dir(jobid)
         autoretry_allocation, autoretry_hostfile = (

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -300,10 +300,20 @@ def parse_args(argv: Optional[Sequence[str]] = None):
         # gives that indirectly (ranks -> hosts); --nhosts gives it
         # directly. Accept either rather than forcing users to convert
         # a node count into a rank count just to satisfy this check.
-        if (
-            getattr(args, "nproc", -1) <= 0
-            and getattr(args, "nhosts", -1) <= 0
-        ):
+        # Both default to -1, which lets us tell "not provided" apart
+        # from "provided but nonsensical". Collapsing the two would tell
+        # a user who typed `--nhosts 0` to "pass --nhosts", which is
+        # actively confusing.
+        _nproc = getattr(args, "nproc", -1)
+        _nhosts = getattr(args, "nhosts", -1)
+        for _flag, _val in (("--nproc", _nproc), ("--nhosts", _nhosts)):
+            if _val != -1 and _val <= 0:
+                raise SystemExit(
+                    f"--auto-retry: {_flag} must be > 0, got {_val}. The "
+                    "auto-retry loop needs a positive active size to "
+                    "split the allocation into active + spare hosts."
+                )
+        if _nproc <= 0 and _nhosts <= 0:
             raise SystemExit(
                 "--auto-retry requires the active size to be set "
                 "explicitly: pass --nhosts (-nh/--nnodes) or --nproc "
@@ -866,6 +876,14 @@ def launch(
             nhosts_active = nhosts
         else:
             assert ngpus is not None  # guarded above
+            if ngpus <= 0:
+                # Symmetric with the nhosts guard: _ranks_to_hosts(0, n)
+                # returns 0, which would ask for a zero-host active set
+                # and produce nonsense downstream.
+                raise ValueError(
+                    f"launch(auto_retry=True): ngpus must be > 0, "
+                    f"got {ngpus}."
+                )
             nhosts_active = _ranks_to_hosts(ngpus, ranks_per_node)
         autoretry_log_dir = _auto_retry_log_dir(jobid)
         autoretry_allocation, autoretry_hostfile = (
@@ -1015,14 +1033,27 @@ def run(argv: Sequence[str] | None = None) -> int:
     requested_nproc = args.nproc if args.nproc > -1 else None
     requested_ppn = args.nproc_per_node if args.nproc_per_node > -1 else None
     requested_nhosts = args.nhosts if args.nhosts > -1 else None
-    if (
-        requested_nproc is None
-        and requested_ppn is not None
-        and requested_nhosts is not None
-    ):
-        requested_nproc = requested_ppn * requested_nhosts
+    if requested_nproc is None and requested_nhosts is not None:
+        # Derive ranks from the requested host count. `--ppn` when given,
+        # else the machine's GPUs-per-node (the same fallback the
+        # auto-retry path uses). Without this, `--nhosts N` with no
+        # `--ppn` left requested_nproc None and silently fell through to
+        # WORLD_SIZE-or-2 below -- so `--nhosts 4` would launch 2 ranks.
+        # Only reachable now that --auto-retry accepts nhosts-only, but
+        # the bug applies to any nhosts-only invocation on this path.
+        _ppn = requested_ppn or ezpz.get_gpus_per_node() or 1
+        requested_nproc = _ppn * requested_nhosts
     if requested_nproc is None:
         requested_nproc = int(os.environ.get("WORLD_SIZE", "2"))
+    if getattr(args, "auto_retry", False):
+        # The local-mpirun fallback has no node pool to split, so there
+        # is nothing to fail over TO. Say so rather than appearing to
+        # honour the flag.
+        logger.warning(
+            "--auto-retry has no effect without an active PBS/SLURM job: "
+            "there is no allocation to split into active + spare hosts. "
+            "Running the command once via the local mpirun fallback."
+        )
     env_flags = _get_mpirun_env_flags()
     fallback_cmd = ["mpirun", *env_flags, "-np", str(requested_nproc)]
     if args.hostfile:

--- a/src/ezpz/launch.py
+++ b/src/ezpz/launch.py
@@ -285,8 +285,8 @@ def parse_args(argv: Optional[Sequence[str]] = None):
     # Cross-flag validation. argparse mutex groups can't express
     # "--auto-retry vs --retries with a non-zero value" (since
     # --retries defaults to 0), so do it here. Same for --auto-retry
-    # requiring an explicit --nproc — the value depends on whether
-    # the user passed -n at all, which argparse can't observe from
+    # needing an explicit size — the value depends on whether the user
+    # passed the flag at all, which argparse can't observe from
     # inside the parser.
     if getattr(args, "auto_retry", False):
         if getattr(args, "retries", 0):
@@ -295,12 +295,20 @@ def parse_args(argv: Optional[Sequence[str]] = None):
                 "--retries is bounded per-process retry; --auto-retry "
                 "is unbounded node-level failover. Pick one."
             )
-        if getattr(args, "nproc", -1) <= 0:
+        # What auto-retry actually needs is the ACTIVE HOST COUNT, so
+        # it can split the allocation into active + spare. --nproc
+        # gives that indirectly (ranks -> hosts); --nhosts gives it
+        # directly. Accept either rather than forcing users to convert
+        # a node count into a rank count just to satisfy this check.
+        if (
+            getattr(args, "nproc", -1) <= 0
+            and getattr(args, "nhosts", -1) <= 0
+        ):
             raise SystemExit(
-                "--auto-retry requires --nproc (-n/--np) to be set "
-                "explicitly. The auto-retry loop needs the training "
-                "rank count to split the PBS allocation into active "
-                "+ spare hosts."
+                "--auto-retry requires the active size to be set "
+                "explicitly: pass --nhosts (-nh/--nnodes) or --nproc "
+                "(-n/--np). The auto-retry loop needs it to split the "
+                "PBS allocation into active + spare hosts."
             )
     return args
 
@@ -820,14 +828,19 @@ def launch(
     if auto_retry:
         # CLI entrypoints (parse_args) already enforce this; the
         # check here is the library-level precondition for direct
-        # `launch(auto_retry=True, ngpus=None)` callers. Same
-        # invariant, different audience.
-        if ngpus is None:
+        # `launch(auto_retry=True, ...)` callers. Same invariant,
+        # different audience.
+        #
+        # The loop needs the ACTIVE HOST COUNT. `nhosts` states it
+        # directly; `ngpus` implies it (ranks -> hosts). Either is
+        # sufficient — requiring ngpus specifically just forced
+        # node-count users to convert to ranks for no reason.
+        if ngpus is None and nhosts is None:
             raise ValueError(
-                "launch(auto_retry=True) requires ngpus to be set "
-                "explicitly. The auto-retry loop needs the training "
-                "rank count to split the node pool into active + "
-                "spare. (CLI: pass --nproc / -n / --np.)"
+                "launch(auto_retry=True) requires nhosts or ngpus to "
+                "be set explicitly. The auto-retry loop needs the "
+                "active size to split the node pool into active + "
+                "spare. (CLI: pass --nhosts / -nh, or --nproc / -n.)"
             )
         # Source the candidate node pool. Explicit --hostfile beats
         # the scheduler nodelist — see _resolve_auto_retry_node_pool.
@@ -839,7 +852,21 @@ def launch(
         # one rank per GPU) when not. `or 1` covers the degenerate
         # case where get_gpus_per_node() returns 0 on a non-GPU node.
         ranks_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
-        nhosts_active = _ranks_to_hosts(ngpus, ranks_per_node)
+        if nhosts is not None:
+            # Explicit host count wins: it is what we need, verbatim,
+            # with no ranks->hosts rounding in between. When BOTH are
+            # given, honour nhosts and let the (unchanged) downstream
+            # _infer_topology consistency checks flag any ngpus/nhosts
+            # mismatch, rather than silently preferring one here.
+            if nhosts <= 0:
+                raise ValueError(
+                    f"launch(auto_retry=True): nhosts must be > 0, "
+                    f"got {nhosts}."
+                )
+            nhosts_active = nhosts
+        else:
+            assert ngpus is not None  # guarded above
+            nhosts_active = _ranks_to_hosts(ngpus, ranks_per_node)
         autoretry_log_dir = _auto_retry_log_dir(jobid)
         autoretry_allocation, autoretry_hostfile = (
             _resolve_auto_retry_allocation(

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -900,9 +900,33 @@ class TestRunWithAutoRetry:
 
 
 class TestArgparseValidation:
-    def test_auto_retry_requires_explicit_nproc(self):
-        with pytest.raises(SystemExit, match="requires --nproc"):
+    def test_auto_retry_requires_explicit_size(self):
+        """Neither --nproc nor --nhosts -> refuse.
+
+        What auto-retry needs is the ACTIVE HOST COUNT; with no size
+        flag at all there is nothing to split the allocation on.
+        """
+        with pytest.raises(SystemExit, match="requires the active size"):
             parse_args(["--auto-retry", "--", "echo", "x"])
+
+    @pytest.mark.parametrize(
+        "flag", ["--nhosts", "-nh", "--nnodes", "--nhost", "--nnode"]
+    )
+    def test_auto_retry_accepts_nhosts_instead_of_nproc(self, flag):
+        """--nhosts states the active host count directly, so it is a
+        first-class alternative to --nproc (which only implies it)."""
+        args = parse_args(["--auto-retry", flag, "4", "--", "echo", "x"])
+        assert args.auto_retry is True
+        assert args.nhosts == 4
+        assert args.nproc == -1  # never supplied
+
+    def test_auto_retry_accepts_both_nproc_and_nhosts(self):
+        args = parse_args(
+            ["--auto-retry", "--np", "48", "--nhosts", "4", "--",
+             "echo", "x"]
+        )
+        assert args.nproc == 48
+        assert args.nhosts == 4
 
     def test_auto_retry_mutex_with_retries(self):
         with pytest.raises(SystemExit, match="mutually exclusive"):
@@ -971,6 +995,88 @@ class TestArgparseValidation:
 # ---------------------------------------------------------------------------
 # Helpers in launch.py — the bridge between CLI args and the loop
 # ---------------------------------------------------------------------------
+
+
+class TestAutoRetryActiveSizeSource:
+    """`launch(auto_retry=True)` accepts nhosts OR ngpus.
+
+    The loop only ever needs the ACTIVE HOST COUNT. nhosts states it
+    directly; ngpus implies it via ranks->hosts. These tests pin that
+    both routes reach _resolve_auto_retry_allocation with the right
+    host count, and that nhosts is used VERBATIM (no ranks->hosts
+    rounding applied to a number that is already a host count).
+    """
+
+    @staticmethod
+    def _stub_scheduler(monkeypatch):
+        """Make launch() believe it is inside a live PBS job."""
+        import ezpz.launch as L
+
+        monkeypatch.setattr(L, "get_active_jobid", lambda: "12345")
+        monkeypatch.setattr(
+            L, "get_nodelist_of_active_job",
+            lambda: [f"h{i}" for i in range(8)],
+        )
+        monkeypatch.setattr(
+            L, "get_hostfile_of_active_job", lambda: None
+        )
+        return L
+
+    def _capture_nhosts_active(self, monkeypatch, **launch_kw):
+        """Run launch() far enough to record the host count it derives."""
+        L = self._stub_scheduler(monkeypatch)
+        seen = {}
+
+        def _fake_resolve_alloc(pool, nhosts_active, spare, log_dir):
+            seen["nhosts_active"] = nhosts_active
+            raise _StopHere()
+
+        monkeypatch.setattr(
+            L, "_resolve_auto_retry_node_pool", lambda *a, **k: [
+                f"h{i}" for i in range(8)
+            ]
+        )
+        monkeypatch.setattr(
+            L, "_resolve_auto_retry_allocation", _fake_resolve_alloc
+        )
+        monkeypatch.setattr(L, "_auto_retry_log_dir", lambda jobid: Path("/tmp"))
+        monkeypatch.setattr(L.ezpz, "get_gpus_per_node", lambda: 12)
+        try:
+            L.launch(cmd_to_launch=["echo", "x"], auto_retry=True, **launch_kw)
+        except _StopHere:
+            pass
+        return seen.get("nhosts_active")
+
+    def test_nhosts_used_verbatim(self, monkeypatch):
+        got = self._capture_nhosts_active(monkeypatch, nhosts=4)
+        assert got == 4, (
+            "nhosts is already a host count and must be used as-is, "
+            f"not re-derived; got {got}"
+        )
+
+    def test_ngpus_still_converts_to_hosts(self, monkeypatch):
+        # 24 ranks / 12 per node -> 2 hosts (unchanged behavior).
+        got = self._capture_nhosts_active(monkeypatch, ngpus=24)
+        assert got == 2
+
+    def test_nhosts_wins_when_both_given(self, monkeypatch):
+        # ngpus=24 would imply 2 hosts; explicit nhosts=3 must win.
+        got = self._capture_nhosts_active(monkeypatch, ngpus=24, nhosts=3)
+        assert got == 3
+
+    def test_neither_raises(self, monkeypatch):
+        L = self._stub_scheduler(monkeypatch)
+        with pytest.raises(ValueError, match="nhosts or ngpus"):
+            L.launch(cmd_to_launch=["echo", "x"], auto_retry=True)
+
+    def test_nonpositive_nhosts_raises(self, monkeypatch):
+        L = self._stub_scheduler(monkeypatch)
+        with pytest.raises(ValueError, match="nhosts must be > 0"):
+            L.launch(cmd_to_launch=["echo", "x"], auto_retry=True, nhosts=0)
+
+
+class _StopHere(Exception):
+    """Sentinel: stop launch() once the host count has been observed."""
 
 
 class TestRanksToHosts:

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -1087,6 +1087,38 @@ class TestAutoRetryActiveSizeSource:
         with pytest.raises(ValueError, match="nhosts must be > 0"):
             L.launch(cmd_to_launch=["echo", "x"], auto_retry=True, nhosts=0)
 
+    def test_nhosts_route_does_not_probe_gpus(self, monkeypatch):
+        """GPU detection must not run on the nhosts route.
+
+        An explicit host count IS the answer, and
+        ezpz.get_gpus_per_node() can raise ModuleNotFoundError on a
+        launcher/login node with no torch -- which would break a
+        perfectly well-specified `--auto-retry --nhosts N`.
+        """
+        L = self._stub_scheduler(monkeypatch)
+
+        def _boom():
+            raise ModuleNotFoundError("No module named 'torch'")
+
+        monkeypatch.setattr(L.ezpz, "get_gpus_per_node", _boom)
+        seen = {}
+
+        def _fake_alloc(pool, nhosts_active, spare, log_dir):
+            seen["n"] = nhosts_active
+            raise _StopHere()
+
+        monkeypatch.setattr(
+            L, "_resolve_auto_retry_node_pool",
+            lambda *a, **k: [f"h{i}" for i in range(8)],
+        )
+        monkeypatch.setattr(L, "_resolve_auto_retry_allocation", _fake_alloc)
+        monkeypatch.setattr(L, "_auto_retry_log_dir", lambda jobid: Path("/tmp"))
+        try:
+            L.launch(cmd_to_launch=["echo", "x"], auto_retry=True, nhosts=4)
+        except _StopHere:
+            pass
+        assert seen.get("n") == 4
+
     @pytest.mark.parametrize("bad", [0, -4])
     def test_nonpositive_ngpus_raises(self, monkeypatch, bad):
         """Symmetric with the nhosts guard: _ranks_to_hosts(0, n) == 0,

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -920,6 +920,19 @@ class TestArgparseValidation:
         assert args.nhosts == 4
         assert args.nproc == -1  # never supplied
 
+    @pytest.mark.parametrize("flag,val", [
+        ("--nhosts", "0"), ("--nhosts", "-5"),
+        ("--np", "0"), ("--np", "-3"),
+    ])
+    def test_auto_retry_rejects_nonpositive_size(self, flag, val):
+        """'provided but invalid' must not be reported as 'not provided'.
+
+        Both flags default to -1, so we can tell the two apart. Telling
+        a user who typed `--nhosts 0` to "pass --nhosts" is confusing.
+        """
+        with pytest.raises(SystemExit, match="must be > 0"):
+            parse_args(["--auto-retry", flag, val, "--", "echo", "x"])
+
     def test_auto_retry_accepts_both_nproc_and_nhosts(self):
         args = parse_args(
             ["--auto-retry", "--np", "48", "--nhosts", "4", "--",
@@ -1073,6 +1086,15 @@ class TestAutoRetryActiveSizeSource:
         L = self._stub_scheduler(monkeypatch)
         with pytest.raises(ValueError, match="nhosts must be > 0"):
             L.launch(cmd_to_launch=["echo", "x"], auto_retry=True, nhosts=0)
+
+    @pytest.mark.parametrize("bad", [0, -4])
+    def test_nonpositive_ngpus_raises(self, monkeypatch, bad):
+        """Symmetric with the nhosts guard: _ranks_to_hosts(0, n) == 0,
+        which would request a zero-host active set."""
+        L = self._stub_scheduler(monkeypatch)
+        monkeypatch.setattr(L.ezpz, "get_gpus_per_node", lambda: 12)
+        with pytest.raises(ValueError, match="ngpus must be > 0"):
+            L.launch(cmd_to_launch=["echo", "x"], auto_retry=True, ngpus=bad)
 
 
 class _StopHere(Exception):


### PR DESCRIPTION
## Problem

`--auto-retry` refused to run without `--nproc`:

```
--auto-retry requires --nproc (-n/--np) to be set explicitly.
```

But the rank count isn't what the loop needs. It immediately converts it:

```python
ranks_per_node = ngpu_per_host or ezpz.get_gpus_per_node() or 1
nhosts_active  = _ranks_to_hosts(ngpus, ranks_per_node)   # ranks -> hosts
```

...and never uses `ngpus` again — only `nhosts_active` reaches `_resolve_auto_retry_allocation`. So anyone sizing a job in **nodes** (the usual way you write a PBS `select=`) had to convert to ranks just to satisfy a validation check, then have the code convert it straight back.

## Change

Accept `--nhosts` (`-nh` / `--nnodes`) as a first-class alternative:

```bash
ezpz launch --auto-retry --nhosts 43 -- python3 train.py   # new
ezpz launch --auto-retry --np 512    -- python3 train.py   # unchanged
```

Nothing downstream needed touching — the plumbing was already there:

- `--nhosts` is already a CLI flag (`cli/flags.py:419`)
- already passed `main()` → `launch(nhosts=...)` (`launch.py:969`)
- `pbs._infer_topology` already handles `ngpus=None` when `nhosts` is set (Case A, `pbs.py:328`)

The restriction was simply stricter than the machinery required.

## Semantics

- **`--nhosts` is used verbatim.** It is already a host count; applying `_ranks_to_hosts` to it would be wrong.
- **When both are given, `--nhosts` wins** for the active/spare split. The unchanged downstream `_infer_topology` consistency checks still flag an inconsistent `ngpus`/`nhosts` pair, rather than this code silently picking one and hiding the conflict.
- **Both guards relaxed in step** — parse-time (CLI) and `launch()`-time (library) — so direct API callers get the same contract.
- `--nhosts <= 0` raises with a clear message.

## Tests

10 new/updated in `tests/test_launch_autoretry.py`:

- parse-time acceptance across all five aliases (`--nhosts`, `-nh`, `--nnodes`, `--nhost`, `--nnode`)
- both flags together
- neither flag → clear error (message updated)
- library-level: `nhosts` used verbatim, `ngpus` still converts, `nhosts` wins when both given, non-positive `nhosts` rejected

Verified to bite: **10 fail** against the old restriction, 115/115 pass with the change. Full suite 1395 passed (1 pre-existing `gqa` failure — the #199 `atol=1e-6` FLASH-vs-MATH issue, identical on clean `main`).

## Docs

`docs/cli/launch/index.md`: retitled the "Required: explicit `--nproc`" section, updated the mermaid decision flow, corrected the spare-pool formula to `total_pbs_nodes - active_hosts`, and added the equivalence example. `--auto-retry`'s `--help` text updated too.

## Label

`release:minor` — new accepted input, no behavior change for existing `--nproc` users.

## Summary by Sourcery

Allow auto-retry launch jobs to specify active size via either host count or process count and update messaging accordingly.

New Features:
- Support --nhosts (and its aliases) as a first-class alternative to --nproc for --auto-retry active size configuration.

Enhancements:
- Treat explicit host count as the authoritative source for active hosts when both nhosts and nproc are provided, with validation for non-positive values.
- Relax auto-retry preconditions so both CLI and launch() API accept either nhosts or ngpus for sizing while preserving downstream topology checks.

Documentation:
- Refresh auto-retry CLI documentation and help text to describe the nhosts/nproc equivalence, updated decision flow, and corrected spare-node calculation based on active hosts.

Tests:
- Add and update auto-retry tests to cover nhosts-based sizing, combined nhosts/nproc usage, validation of missing or invalid size flags, and host-count derivation in the launch auto-retry flow.