### PR TITLE
fix(distributed): cleanup() must never fail a successful run

### DIFF
--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -828,8 +828,28 @@ def setup_torch(
 
 
 def cleanup() -> None:
-    """Destroy the ``torch.distributed`` process group if active."""
-    import torch.distributed
+    """Destroy the ``torch.distributed`` process group if active.
+
+    Teardown must never turn a SUCCESSFUL run into a failure. This used
+    to `import torch.distributed` unguarded, so on a broken torch
+    install the import raised, the traceback escaped
+    `ezpz.launch.run()`, and a job that had already logged
+    "Execution finished with 0" exited 1. Observed on Sunspot with a
+    torch/oneAPI skew:
+
+        launch.py:1012 in run -> ezpz.distributed.cleanup()
+        distributed.py:832    -> import torch.distributed
+        ImportError: libsycl.so.9: undefined symbol: urDeviceWaitExp
+
+    There is also nothing to destroy when torch cannot be imported, so
+    failing here is doubly pointless. The wandb block below has always
+    been defensive; the torch import now matches.
+    """
+    try:
+        import torch.distributed
+    except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+        logger.debug("cleanup: torch unavailable (%s); nothing to tear down", exc)
+        return
 
     if get_rank() == 0 and verify_wandb():
         try:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1456,6 +1456,55 @@ class TestCleanup:
         ):
             dist.cleanup()  # Should not raise
 
+    def test_broken_torch_import_does_not_raise(self):
+        """Teardown must not turn a SUCCESSFUL run into a failure.
+
+        Regression guard: `cleanup()` used to `import torch.distributed`
+        unguarded. On a torch/oneAPI skew that import raises, the
+        traceback escaped `ezpz.launch.run()`, and a job that had
+        already logged "Execution finished with 0" exited 1. Observed on
+        Sunspot as:
+
+            ImportError: libsycl.so.9: undefined symbol: urDeviceWaitExp
+
+        There is also nothing to destroy when torch will not import, so
+        failing here is doubly pointless.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _broken_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                raise ImportError(
+                    "libsycl.so.9: undefined symbol: urDeviceWaitExp"
+                )
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", _broken_torch):
+            dist.cleanup()  # must NOT raise
+
+    def test_broken_torch_import_skips_destroy(self):
+        """With torch unimportable there is nothing to destroy; we must
+        return early rather than fall through to destroy_process_group."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _broken_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                raise ImportError("boom")
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch.object(
+                torch.distributed, "destroy_process_group"
+            ) as mock_destroy,
+            patch.object(builtins, "__import__", _broken_torch),
+        ):
+            dist.cleanup()
+        mock_destroy.assert_not_called()
+
 
 # ===================================================================
 # wrap_model / wrap_model_for_ddp


### PR DESCRIPTION
## Problem

Found while validating #204 on Sunspot: every `--auto-retry` scenario expecting `rc=0` exited **1**, even though the loop and `launch()` had both already succeeded:

```
[auto-retry] FAILOVER STOP: success (attempt 1)
Execution finished with 0.        <- launch() returned 0
$? == 1                           <- process still exited 1
```

The traceback pins it exactly:

```
launch.py:1012 in run  ->  ezpz.distributed.cleanup()
distributed.py:832     ->  import torch.distributed
ImportError: libsycl.so.9: undefined symbol: urDeviceWaitExp
```

`cleanup()` is **pure teardown**, but its unguarded `import torch.distributed` let a broken torch install convert an already-successful run into a failure on the way out. A launcher shouldn't need torch to shut down — and when torch won't import there is nothing to destroy anyway, so raising is doubly pointless.

Note the `wandb` block immediately below has always been defensive (`except Exception: pass`); the torch import was the odd one out.

## Fix

Guard the import and return early. Done **inside `cleanup()`** rather than at the two `launch.py` call sites (`:1012`, `:1056`), so every caller benefits rather than just the two I happened to find.

## Not a regression from #204

Verified by A/B on a real allocation — the identical command on branch `f9960ae` and on `main` `b9a7f60`:

```
=== BRANCH: f9960ae ===   shell_rc=1
=== MAIN   : b9a7f60 ===  shell_rc=1
```

Both exit 1. The underlying torch/oneAPI skew in that venv is a separate environment issue; this change just stops ezpz from **reporting failure** because of it.

## Validation

Sunspot compute node, job 12472771, at `78adc5a` — the same command that exited 1 on both revisions above:

```
shell_rc=0
[auto-retry] FAILOVER STOP: success (attempt 1)
Execution finished with 0.
```

## Tests

2 new in `TestCleanup`, both verified to **fail against the unguarded version**:

- `test_broken_torch_import_does_not_raise` — monkeypatches `__import__` to raise the real `libsycl` error; `cleanup()` must not propagate it
- `test_broken_torch_import_skips_destroy` — with torch unimportable we must return early, not fall through to `destroy_process_group`

Full suite: 1397 passed, 1 pre-existing `gqa` failure (the #199 `atol=1e-6` FLASH-vs-MATH issue, identical on clean `main`).

## Merge order

Worth merging **before** #204. The same teardown fault was failing auto-retry scenarios A/B/C/F/G/H in the PBS driver; with this in, those should go green legitimately rather than #204 relaxing its assertions to work around a real bug.

## Summary by Sourcery

Allow auto-retry to be driven by explicit host counts and make distributed cleanup resilient to broken torch installs so successful runs are not turned into failures on teardown.

New Features:
- Support specifying the active size for --auto-retry via nhosts as a first-class alternative to nproc in both the CLI and launch(auto_retry=True).

Bug Fixes:
- Prevent distributed.cleanup() from raising when torch.distributed cannot be imported, ensuring teardown does not convert a successful run into a failed job.

Enhancements:
- Improve auto-retry validation and error messaging to require an explicit active size (nhosts or nproc) instead of nproc alone, with nhosts taking precedence when both are provided.
- Log a debug message when cleanup skips teardown due to unavailable torch.distributed for better diagnosability.

Documentation:
- Update launch CLI documentation to describe nhosts and nproc as equivalent sources of the active host count for --auto-retry, and document the expanded auto-retry PBS driver scenarios including nhosts and missing active size cases.

Tests:
- Add tests covering argparse validation for auto-retry with nhosts and combinations of nhosts/nproc, and the internal resolution of the active host count from nhosts or ngpus.
- Add regression tests ensuring distributed.cleanup() does not raise and does not attempt to destroy the process group when torch fails to import.