### PR TITLE
docs(examples): fix bullet lists rendering as run-on paragraphs

### DIFF
--- a/docs/examples/diffusion.md
+++ b/docs/examples/diffusion.md
@@ -82,6 +82,7 @@ Toward the end of the run, decoded samples are logged on rank 0 (look for
 
   Presets live in `MODEL_PRESETS` near the top of
   `src/ezpz/examples/diffusion.py`.
+
 - **Tune the diffusion process** — `--timesteps`, `--seq-len`, `--train-steps`
   control the noise schedule length, sequence length, and total optimizer
   steps. Explicit flags override the preset.

--- a/docs/examples/fsdp-tp.md
+++ b/docs/examples/fsdp-tp.md
@@ -57,6 +57,7 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
 
   > **Breaking change**: `--model small` now resolves to ~125M (was a
   > toy ~6M). Use `--model debug` for laptop-runnable smoke tests.
+
 - **AuroraGPT presets** — `--model agpt-2b` or `--model agpt-20b` reproduce
   torchtitan's `agpt_configs` registry exactly (`dim`, `n_layers`, `n_heads`,
   `n_kv_heads`, `vocab_size`, `hidden_dim`, `rope_theta` all match). Useful
@@ -88,6 +89,7 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
   torchtitan's `data_parallel_replicate_degree` / `data_parallel_shard_degree`.
   (The legacy `--sharding-strategy hybrid_shard*` names have been **removed**
   — they now hard-error. Use `--dp-replicate` / `--dp-shard` for HSDP.)
+
 - **Activation checkpointing** — `--ac {none,block,full,selective}` (or
   `--activation-checkpoint`) trades compute for memory during training.
   `block`/`full` wraps each TransformerBlock (~30-40 pct activation-memory
@@ -134,6 +136,7 @@ ezpz launch python3 -m ezpz.examples.fsdp_tp \
       replicated logits). ~23 GiB/rank, ~34% MFU at tp=2.
 
   See [Matching torchtitan](#matching-torchtitan).
+
 - **Activation-memory budget** — `--act-mem-budget <float>` (default `1.0`,
   only active with `--compile`). Sets
   `torch._functorch.config.activation_memory_budget`: `1.0` saves every

--- a/docs/examples/fsdp.md
+++ b/docs/examples/fsdp.md
@@ -92,6 +92,7 @@ log captured on Sunspot).
   of dense linear weights). The CNN is intentionally trivial — sizes
   mainly stress-test FSDP wrapping, not real CNN topology. Presets live
   in `MODEL_PRESETS` near the top of `src/ezpz/examples/fsdp.py`.
+
 - **Train on a bigger dataset** — `--dataset {MNIST,OpenImages,ImageNet,ImageNet1k}`
   routes through `get_data()` to dataset-specific loaders in `ezpz.data.vision`.
 - **Switch the FSDP compute dtype** — pass `--dtype {bf16,fp16,fp32}`. The value

--- a/docs/examples/test.md
+++ b/docs/examples/test.md
@@ -44,6 +44,7 @@ ezpz launch python3 -m ezpz.examples.test
   batch sizes halve at each rung to compensate. The MLP is
   architecturally trivial — depth/width is the only knob, so layer_sizes
   grows aggressively at the top of the ladder.
+
 - **Override individual dims** — `--layer-sizes 4096 2048 1024` overrides
   the preset's hidden-layer widths; `--batch-size N` overrides batch.
 - **Compile with torch.compile** — pass `--compile` to wrap the model with

--- a/docs/examples/vit.md
+++ b/docs/examples/vit.md
@@ -93,6 +93,7 @@ specializes kernels — subsequent steps drop to the steady-state `dt`. See the
 
   Presets live in `MODEL_PRESETS` near the top of
   `src/ezpz/examples/vit.py`; tweak the dict to add your own.
+
 - **Tune individual architecture knobs** — `--img_size`, `--patch_size`,
   `--num_heads`, `--head_dim`, `--depth`, `--embed_dim` all override the preset.
 - **Enable FSDP** — pass `--fsdp` (and optionally `--fsdp_sharding_strategy`)


### PR DESCRIPTION
The "Common modifications" list on five example pages renders as a
single run-on paragraph, with literal `- **Next item**` appearing
mid-sentence instead of as bullets.

## Cause

Markdown **lazy continuation**. Once a list item contains a blank line
— because it holds a table, a fenced code block, a blockquote, or a
second paragraph — the *next* top-level bullet must be preceded by a
blank line. Without one it is absorbed into the preceding block, and
so is every bullet after it.

On `fsdp-tp.md` the trigger is the blockquote at L58 inside the first
item; rendering that range produced exactly one `<li>` for eight
source bullets.

## Fix

Seven inserted blank lines. Nothing else.

Rendered `<li>` before → after, counted depth-aware against the source
bullets in each list run:

| page | before | after |
|---|---|---|
| `diffusion.md` | 1 | 6 |
| `fsdp.md` | 1 | 6 |
| `test.md` | 1 | 3 |
| `vit.md` | 1 | 5 |
| `fsdp-tp.md` | 1 | 8 top-level + 6 nested |

## Verification

- Each page rendered with the project's own extension set; source
  bullet count now equals rendered `<li>` count at every nesting depth.
- `git diff --numstat` is 7 added / 0 removed.
- Every file is byte-identical to `main` once blank lines are
  stripped, so no prose changed.

## Summary by Sourcery

Documentation:
- Correct bullet list formatting in several example docs so items render as separate list entries instead of a single run-on paragraph.