### PR TITLE
fix(distributed): fail clearly when the MASTER_PORT broadcast degenerates

### DIFF
--- a/src/ezpz/distributed.py
+++ b/src/ezpz/distributed.py
@@ -1984,6 +1984,33 @@ def _setup_ddp(
         master_addr = broadcast(master_addr, root=0)
         master_port = broadcast(master_port, root=0)
 
+        # Non-zero ranks start with None and depend on the broadcast to
+        # deliver rank 0's values. If it degenerates -- every rank its
+        # own COMM_WORLD, which is what happens when mpi4py loads an MPI
+        # that cannot reach the launcher's PMI -- the None survives and
+        # `str(None)` hands torch the literal "None". torch then fails
+        # eleven frames down in rendezvous.py with `invalid literal for
+        # int() with base 10: 'None'`, naming neither MPI nor the
+        # broadcast. Fail here, where we know what actually went wrong.
+        if master_addr is None or master_port is None:
+            missing = ", ".join(
+                n
+                for n, v in (
+                    ("MASTER_ADDR", master_addr),
+                    ("MASTER_PORT", master_port),
+                )
+                if v is None
+            )
+            raise RuntimeError(
+                f"{missing} is still None on rank {rank} after the MPI "
+                "broadcast from rank 0. The broadcast did not propagate, "
+                "which usually means each rank is its own COMM_WORLD "
+                "(mpi4py loaded an MPI that cannot reach the launcher's "
+                "PMI -- check that libmpi matches the launcher, e.g. "
+                "MPICH with PALS). Workaround: set MASTER_ADDR and "
+                "MASTER_PORT in the environment to skip this path."
+            )
+
     os.environ["MASTER_ADDR"] = str(master_addr)
     os.environ["MASTER_PORT"] = str(master_port)
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -2761,3 +2761,70 @@ class TestFlattenDeviceMeshSafe:
             "Workaround leaked: bound_device_id stayed cleared after a "
             "_flatten failure."
         )
+
+
+class TestSetupDdpMasterPortBroadcast:
+    """`MASTER_PORT` must never reach torch as the string ``"None"``.
+
+    When `MASTER_PORT` is unset, rank 0 picks a free port and every
+    other rank starts with `None`, relying on the MPI broadcast to
+    overwrite it. If that broadcast degenerates -- each rank a
+    singleton `COMM_WORLD`, which happens when mpi4py loads an MPI that
+    cannot reach the launcher's PMI -- the `None` survives, and
+    `str(None)` hands torch the literal `"None"`:
+
+        File ".../torch/distributed/rendezvous.py", line 277
+        master_port = int(_get_env_or_raise("MASTER_PORT"))
+        ValueError: invalid literal for int() with base 10: 'None'
+
+    Eleven frames deep, naming neither MPI nor the broadcast. Observed
+    on Sunspot (job 12472873). Fail where the information is instead.
+    """
+
+    def _run(self, monkeypatch, rank, bcast):
+        import torch
+
+        for k in ("MASTER_ADDR", "MASTER_PORT"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("RANK", str(rank))
+        monkeypatch.setenv("WORLD_SIZE", "2")
+        monkeypatch.setenv("LOCAL_RANK", "0")
+        monkeypatch.setattr(dist, "get_rank", lambda: rank)
+        monkeypatch.setattr(dist, "get_world_size", lambda: 2)
+        monkeypatch.setattr(dist, "get_local_rank", lambda: 0)
+        monkeypatch.setattr(dist, "get_gpus_per_node", lambda: 1)
+        monkeypatch.setattr(dist, "get_torch_device_type", lambda: "cpu")
+        monkeypatch.setattr(dist, "get_machine", lambda: "unknown")
+        monkeypatch.setattr(dist, "broadcast", bcast)
+        monkeypatch.setattr(
+            torch.distributed, "is_initialized", lambda: False
+        )
+        monkeypatch.setattr(
+            torch.distributed, "init_process_group", lambda **kw: None
+        )
+        return dist._setup_ddp(backend="gloo")
+
+    def test_degenerate_broadcast_raises_a_named_error(self, monkeypatch):
+        # Identity bcast == every rank is its own COMM_WORLD, so a
+        # non-zero rank's None is never replaced.
+        with pytest.raises(RuntimeError, match="MASTER_PORT"):
+            self._run(monkeypatch, rank=1, bcast=lambda x, root=0: x)
+        assert os.environ.get("MASTER_PORT") != "None", (
+            "the literal string 'None' was exported to torch"
+        )
+
+    def test_error_names_the_actual_cause(self, monkeypatch):
+        with pytest.raises(RuntimeError) as ei:
+            self._run(monkeypatch, rank=1, bcast=lambda x, root=0: x)
+        msg = str(ei.value)
+        assert "broadcast" in msg.lower(), f"cause not named: {msg}"
+
+    def test_working_broadcast_is_unaffected(self, monkeypatch):
+        # A real bcast delivers rank 0's port to rank 1.
+        self._run(monkeypatch, rank=1, bcast=lambda x, root=0: x or "29500")
+        assert os.environ["MASTER_PORT"] == "29500"
+
+    def test_rank_zero_never_trips_the_guard(self, monkeypatch):
+        self._run(monkeypatch, rank=0, bcast=lambda x, root=0: x)
+        port = os.environ["MASTER_PORT"]
+        assert port.isdigit() and port != "None", port

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -2820,8 +2820,20 @@ class TestSetupDdpMasterPortBroadcast:
         assert "broadcast" in msg.lower(), f"cause not named: {msg}"
 
     def test_working_broadcast_is_unaffected(self, monkeypatch):
-        # A real bcast delivers rank 0's port to rank 1.
-        self._run(monkeypatch, rank=1, bcast=lambda x, root=0: x or "29500")
+        """A real bcast delivers rank 0's addr AND port to rank 1.
+
+        The stub must return a distinct value per call -- addr first,
+        then port, matching the two `broadcast()` calls in order. A
+        single `x or "29500"` would set MASTER_ADDR to the port string
+        too, and still pass, which would hide an addr/port mix-up.
+        """
+        delivered = iter(["host-0.example", "29500"])
+
+        def bcast(x, root=0):
+            return x if x is not None else next(delivered)
+
+        self._run(monkeypatch, rank=1, bcast=bcast)
+        assert os.environ["MASTER_ADDR"] == "host-0.example"
         assert os.environ["MASTER_PORT"] == "29500"
 
     def test_rank_zero_never_trips_the_guard(self, monkeypatch):


### PR DESCRIPTION
## The bug

When `MASTER_PORT` is unset, `_setup_ddp` has rank 0 pick a free port
while every other rank starts with `None`, then relies on the MPI
broadcast to overwrite it (`distributed.py:1979-1985`). Nothing checks
that it did.

If the broadcast degenerates — every rank its own `COMM_WORLD`, which
happens when mpi4py loads an MPI that cannot reach the launcher's PMI —
the `None` survives, `str(None)` exports the literal string `"None"`,
and torch fails eleven frames later:

```text
File ".../torch/distributed/rendezvous.py", line 277, in _env_rendezvous_handler
    master_port = int(_get_env_or_raise("MASTER_PORT"))
ValueError: invalid literal for int() with base 10: 'None'
```

That traceback names neither MPI nor the broadcast. Hit on Sunspot
(job 12472873) after an `LD_LIBRARY_PATH` change pulled in an MPI that
did not match PALS; the error pointed at torch's rendezvous code, which
is the wrong place to look.

## The fix

Check for `None` right after the broadcast and raise there, naming the
likely cause and the workaround (set `MASTER_ADDR`/`MASTER_PORT` to
skip the path entirely).

## Tests

Four new cases in `TestSetupDdpMasterPortBroadcast`. An identity
`broadcast` stub reproduces the degenerate-MPI case exactly:

- degenerate broadcast on a non-zero rank now raises, and `"None"` is
  never exported
- the message names the broadcast as the cause
- a working broadcast is unaffected (rank 1 receives rank 0's port)
- rank 0 never trips the guard

The first two fail on `main` and pass here; the last two pass on both,
confirming the harness exercises the real path.

Suite: 1414 passed, 11 skipped. The two `ruff` F401s in these files
pre-date this change (verified by stashing) and are left alone.

## Summary by Sourcery

Guard distributed DDP setup against degenerate MPI broadcasts that leave MASTER_ADDR/MASTER_PORT unset and surface the failure earlier with a clearer error message.

Bug Fixes:
- Detect and fail fast when the MPI broadcast does not propagate MASTER_ADDR or MASTER_PORT, preventing torch from receiving the literal string "None" as MASTER_PORT.

Tests:
- Add tests covering degenerate and working MASTER_PORT broadcasts during DDP setup, ensuring correct error reporting and unchanged behavior for valid broadcasts.