### PR TITLE
feat(export): publish ezpz runs to the AmSC at-scale benchmarks

### DIFF
--- a/docs/cli/export-amsc.md
+++ b/docs/cli/export-amsc.md
@@ -1,0 +1,98 @@
+# `ezpz export-amsc`
+
+Turn a finished run directory into one CSV row for the
+[AmSC at-scale benchmarks](https://gitlab.com/amsc2/ai-services/at-scale-services/amsc-atscale-benchmarks),
+whose [dashboard](https://amsc-atscale-benchmarks-42b223.gitlab.io/)
+reads `benchmarks/<category>/<name>/results/runs.csv`.
+
+```bash
+ezpz export-amsc outputs/ezpz.examples.fsdp_tp/2026-08-11-171117 \
+    --config agpt-2b/bs1/seq2048/tp1
+```
+
+```text
+timestamp,system,config,nodes,gpus,status,wall_time_sec,throughput_tokens_per_sec,...
+2026-08-11T17:12:30Z,SunSpot,agpt-2b/bs1/seq2048/tp1,1,12,pass,12.739,61216.953,...
+```
+
+Append straight into a checked-out benchmark repo — the header is
+written only when the file is new:
+
+```bash
+ezpz export-amsc <run-dir> --config agpt-2b/bs1/seq2048/tp1 \
+    --append benchmarks/training/llm-finetuning/results/runs.csv
+```
+
+## Where the numbers come from
+
+| Column | ezpz metric | Note |
+|---|---|---|
+| `throughput_tokens_per_sec` | `train/tps` | **global** across ranks |
+| `throughput_tokens_per_sec_per_gpu` | `train/tps_per_gpu` | per-GPU (torchtitan's `tgs`) |
+| `mfu` | `train/mfu` | **percent (0–100)**, per-GPU |
+| `tflops` | `train/tflops` | **per-GPU**, not aggregate |
+| `final_loss` | last `train/loss` | |
+| `wall_time_sec` | `sum(train/dt)` | excludes setup — see below |
+| `nodes` / `gpus` | `WORLD_SIZE_IN_USE` | what ran, not what was allocated |
+
+## Three defaults that were measured, not chosen
+
+!!! warning "Throughput is a post-warmup median"
+
+    Step 1 is routinely an order of magnitude slower — compile,
+    allocator warmup, lazy init. A real Sunspot `agpt-2b` series:
+
+    ```text
+    1045, 34601, 34686, 34715, 34833, 34650
+    ```
+
+    Averaging all six reports **29,088** against a true **~34,700** —
+    a 16% understatement. The default drops one warmup step and takes
+    the median, which is also robust to a mid-run straggler. Change
+    with `--warmup` / `--reducer {median,mean,max,min,last}`.
+
+!!! warning "`wall_time_sec` undercounts the job"
+
+    It sums instrumented step time, so model construction, dataset
+    load and distributed init are excluded. The JSONL timestamp span
+    is *worse* — records exist only for logged steps, so it covered
+    1.18 s of a 6.76 s run — and `timings/*` never reach the JSONL at
+    all (they go to `tracker.log()`). Pass `--wall-time-sec` with the
+    scheduler's figure when you need a true wall time.
+
+!!! note "`nodes`/`gpus` describe the run, not the allocation"
+
+    `NUM_NODES`/`NGPUS` come from the scheduler. A 1-node
+    configuration run inside a 4-node allocation reports `NUM_NODES=4,
+    NGPUS=48` while only 12 ranks participate — publishing that would
+    make a 1-node result look like a catastrophically slow 4-node one.
+    The exporter derives from `WORLD_SIZE_IN_USE` and falls back to the
+    allocation only when that is unavailable.
+
+## Provenance
+
+Facility, node and GPU counts are recovered in this order:
+
+1. `run_info.json` — written by `History.finalize()` (preferred)
+2. `config.json` — only present under the non-default `csv` tracker backend
+3. the `### Distributed` section of `report-*.md` — covers older runs
+
+If none is available the command **errors naming the flags to pass**
+rather than guessing. In particular `gpus` is never inferred from the
+number of rank files: those count ranks, which equals GPUs only at one
+rank per GPU, and a wrong GPU count corrupts every per-GPU comparison
+on the dashboard.
+
+## Options
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--config` | *required* | Configuration label, e.g. `agpt-2b/bs1/seq2048/tp1` |
+| `--system` / `--nodes` / `--gpus` | auto | Override the detected provenance |
+| `--status {pass,fail}` | `pass` | **Cannot be inferred** from a run directory |
+| `--error` | empty | Note for a failed run |
+| `--warmup` | `1` | Leading steps dropped before reducing |
+| `--reducer` | `median` | `median`, `mean`, `max`, `min`, `last` |
+| `--wall-time-sec` | derived | Override with the scheduler's figure |
+| `--append PATH` | stdout | Append to a `runs.csv` |
+| `--no-header` | off | Omit the header on stdout |

--- a/docs/cli/export-amsc.md
+++ b/docs/cli/export-amsc.md
@@ -40,7 +40,9 @@ ezpz export-amsc <run-dir> --config agpt-2b/bs1/seq2048/tp1 \
 !!! warning "Throughput is a post-warmup median"
 
     Step 1 is routinely an order of magnitude slower — compile,
-    allocator warmup, lazy init. A real Sunspot `agpt-2b` series:
+    allocator warmup, lazy init. A real `agpt-2b` series from Sunspot
+    (which `get_machine()` reports as the literal `SunSpot`, hence the
+    `system` value above):
 
     ```text
     1045, 34601, 34686, 34715, 34833, 34650

--- a/src/ezpz/cli/__init__.py
+++ b/src/ezpz/cli/__init__.py
@@ -192,9 +192,23 @@ def kill_cmd(args: tuple[str, ...]) -> None:
     required=True,
     help="Benchmark configuration label, e.g. agpt-2b/bs1/seq2048/tp1.",
 )
-@click.option("--system", default=None, help="Facility name (default: MACHINE).")
-@click.option("--nodes", type=int, default=None, help="Node count (default: NUM_NODES).")
-@click.option("--gpus", type=int, default=None, help="GPU count (default: NGPUS).")
+@click.option(
+    "--system",
+    default=None,
+    help="Facility name (default: detected MACHINE).",
+)
+@click.option(
+    "--nodes",
+    type=int,
+    default=None,
+    help="Node count (default: derived from the run's world size).",
+)
+@click.option(
+    "--gpus",
+    type=int,
+    default=None,
+    help="GPU count (default: the run's world size).",
+)
 @click.option(
     "--status",
     type=click.Choice(["pass", "fail"]),

--- a/src/ezpz/cli/__init__.py
+++ b/src/ezpz/cli/__init__.py
@@ -263,6 +263,7 @@ def export_amsc_cmd(
       * `status` cannot be inferred from a run directory.
     """
     from ezpz.export.amsc import (
+        AMSC_COLUMNS,
         AmscExportError,
         DEFAULT_WARMUP,
         format_csv,
@@ -298,6 +299,29 @@ def export_amsc_cmd(
 
     if append_to is not None:
         exists = append_to.exists() and append_to.stat().st_size > 0
+        if exists:
+            # Refuse to append under a header we do not match. We write
+            # values positionally, so a file whose columns differ (or are
+            # merely ordered differently) would silently take our numbers
+            # into the wrong fields -- and a corrupted results file is
+            # worse than a failed export.
+            import csv as _csv
+
+            with append_to.open(encoding="utf-8", newline="") as fh:
+                existing = next(_csv.reader(fh), [])
+            expected = list(AMSC_COLUMNS)
+            if existing != expected:
+                click.echo(
+                    f"error: {append_to} has a different header, so "
+                    "appending would put values in the wrong columns.\n"
+                    f"  file:     {','.join(existing)}\n"
+                    f"  exporter: {','.join(expected)}\n"
+                    "Reconcile the columns, or write to stdout and merge "
+                    "by hand.",
+                    err=True,
+                )
+                _handle_exit_code(1)
+                return
         append_to.parent.mkdir(parents=True, exist_ok=True)
         with append_to.open("a", encoding="utf-8") as fh:
             fh.write(format_csv([row], header=not exists))

--- a/src/ezpz/cli/__init__.py
+++ b/src/ezpz/cli/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Iterable, Sequence
 
 import click
@@ -179,3 +180,127 @@ def kill_cmd(args: tuple[str, ...]) -> None:
 
     rc = kill_module.run(list(args) if args else None)
     _handle_exit_code(rc)
+
+
+@main.command(name="export-amsc")
+@click.argument(
+    "rundir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--config",
+    required=True,
+    help="Benchmark configuration label, e.g. agpt-2b/bs1/seq2048/tp1.",
+)
+@click.option("--system", default=None, help="Facility name (default: MACHINE).")
+@click.option("--nodes", type=int, default=None, help="Node count (default: NUM_NODES).")
+@click.option("--gpus", type=int, default=None, help="GPU count (default: NGPUS).")
+@click.option(
+    "--status",
+    type=click.Choice(["pass", "fail"]),
+    default="pass",
+    help="Run outcome. NOT inferable from a run dir -- set it yourself.",
+)
+@click.option("--error", default="", help="Error note for a failed run.")
+@click.option(
+    "--warmup",
+    type=int,
+    default=None,
+    help="Leading steps to drop before reducing throughput (default: 1).",
+)
+@click.option(
+    "--reducer",
+    type=click.Choice(["median", "mean", "max", "min", "last"]),
+    default="median",
+    help="How to reduce the per-step series (default: median).",
+)
+@click.option(
+    "--wall-time-sec",
+    type=float,
+    default=None,
+    help="Override wall time with the scheduler's figure (recommended).",
+)
+@click.option(
+    "--append",
+    "append_to",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Append to this runs.csv (header written only if new).",
+)
+@click.option("--no-header", is_flag=True, help="Omit the header on stdout.")
+def export_amsc_cmd(
+    rundir: Path,
+    config: str,
+    system: str | None,
+    nodes: int | None,
+    gpus: int | None,
+    status: str,
+    error: str,
+    warmup: int | None,
+    reducer: str,
+    wall_time_sec: float | None,
+    append_to: Path | None,
+    no_header: bool,
+) -> None:
+    """Export a finished run as one AmSC at-scale benchmarks CSV row.
+
+    Reads a run directory's metrics JSONL, reduces it to the schema
+    used by the AmSC benchmarks dashboard, and writes one CSV row.
+
+    \b
+    Examples:
+      ezpz export-amsc outputs/ezpz.examples.fsdp_tp/2026-08-10-201958 \\
+          --config agpt-2b/bs1/seq2048/tp1
+      ezpz export-amsc <rundir> --config agpt-2b/... \\
+          --append benchmarks/training/llm-finetuning/results/runs.csv
+
+    \b
+    Notes:
+      * `mfu` is a PERCENTAGE (0-100), not a fraction.
+      * `mfu`/`tflops` are per-GPU; `throughput_tokens_per_sec` is global.
+      * wall_time_sec is the sum of measured step times and EXCLUDES
+        setup; pass --wall-time-sec for the scheduler's real figure.
+      * `status` cannot be inferred from a run directory.
+    """
+    from ezpz.export.amsc import (
+        AmscExportError,
+        DEFAULT_WARMUP,
+        format_csv,
+        load_run_metrics,
+        load_run_provenance,
+        summarize_run,
+        to_amsc_row,
+    )
+
+    try:
+        records = load_run_metrics(rundir)
+        summary = summarize_run(
+            records,
+            warmup=DEFAULT_WARMUP if warmup is None else warmup,
+            reducer=reducer,
+        )
+        if wall_time_sec is not None:
+            summary["wall_time_sec"] = wall_time_sec
+        row = to_amsc_row(
+            summary,
+            config=config,
+            system=system,
+            nodes=nodes,
+            gpus=gpus,
+            provenance=load_run_provenance(rundir),
+            status=status,
+            error=error,
+        )
+    except AmscExportError as exc:
+        click.echo(f"error: {exc}", err=True)
+        _handle_exit_code(1)
+        return
+
+    if append_to is not None:
+        exists = append_to.exists() and append_to.stat().st_size > 0
+        append_to.parent.mkdir(parents=True, exist_ok=True)
+        with append_to.open("a", encoding="utf-8") as fh:
+            fh.write(format_csv([row], header=not exists))
+        click.echo(f"appended 1 row to {append_to}", err=True)
+    else:
+        click.echo(format_csv([row], header=not no_header), nl=False)

--- a/src/ezpz/export/__init__.py
+++ b/src/ezpz/export/__init__.py
@@ -1,0 +1,28 @@
+"""Export finished ezpz runs into external result formats.
+
+Each submodule targets one consumer's schema. The parsing lives here,
+next to the code that defines what the metrics mean, rather than in the
+consuming repo -- so a change to (say) how ``train/tps`` is computed and
+the exporter that publishes it move together, and the mapping is unit
+testable without a cluster.
+"""
+
+from ezpz.export.amsc import (
+    AMSC_REQUIRED_COLUMNS,
+    AmscExportError,
+    format_csv,
+    load_run_metrics,
+    load_run_provenance,
+    summarize_run,
+    to_amsc_row,
+)
+
+__all__ = [
+    "AMSC_REQUIRED_COLUMNS",
+    "AmscExportError",
+    "format_csv",
+    "load_run_metrics",
+    "load_run_provenance",
+    "summarize_run",
+    "to_amsc_row",
+]

--- a/src/ezpz/export/amsc.py
+++ b/src/ezpz/export/amsc.py
@@ -1,0 +1,457 @@
+"""Turn a finished ezpz run into an AmSC at-scale benchmark CSV row.
+
+The `AmSC at-scale benchmarks
+<https://gitlab.com/amsc2/ai-services/at-scale-services/amsc-atscale-benchmarks>`_
+collect cross-facility results and publish them to a dashboard. Its
+contract, read from that repo's ``build_dashboard.py`` rather than
+inferred:
+
+* a benchmark is discovered iff it has BOTH ``benchmark.yaml`` and
+  ``results/runs.csv``;
+* ``runs.csv`` must carry ``timestamp, system, config, nodes, gpus,
+  status, wall_time_sec``;
+* every other column is coerced to ``float`` when possible, empty
+  meaning "not measured" (``None``), not zero.
+
+Two measurements from real Sunspot runs shaped the defaults here, and
+both are the kind of thing that silently produces a wrong-but-plausible
+number:
+
+**Warmup dominates.** ``train/tps`` over an ``agpt-2b`` run reads
+``1045, 34601, 34686, 34715, 34833, 34650`` -- step 1 is a 33x outlier
+(compile, allocator warmup, lazy init). A mean over all steps reports
+~29k against a true ~34.7k. Hence :data:`DEFAULT_WARMUP` = 1 and a
+*median* reducer, which is additionally robust to a straggler step.
+
+**Wall time is not the timestamp span.** JSONL records only exist for
+logged steps, so first-to-last spans 1.18 s of a 6.76 s run. ezpz's
+``timings/*`` go to ``tracker.log()`` and never reach the JSONL, so they
+cannot be recovered offline either. ``sum(train/dt)`` is the honest
+measure of time spent in measured steps, and is what this reports. It
+still EXCLUDES setup (model build, dist init, dataset load), so it
+under-reports true job wall time; pass ``--wall-time-sec`` with the
+scheduler's figure when that matters.
+
+Two unit traps, both verified against the source rather than assumed:
+
+* ``train/mfu`` is a **percentage 0-100**, not a fraction --
+  ``ezpz.flops.compute_mfu`` returns ``(...) * 100.0``. The manifest
+  must say ``unit: "%"`` or every chart is off by 100x.
+* ``train/mfu`` and ``train/tflops`` are **per-GPU** (``flops_per_gpu =
+  _model_flops / args.tp``), while ``train/tps`` is **global across all
+  ranks**. That mix is deliberate -- it matches how both ezpz and
+  torchtitan report -- but a row mixing them needs the column names to
+  say so, which is why the per-GPU throughput column is named
+  explicitly.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+__all__ = [
+    "AMSC_REQUIRED_COLUMNS",
+    "AMSC_COLUMNS",
+    "AmscExportError",
+    "DEFAULT_WARMUP",
+    "REDUCERS",
+    "format_csv",
+    "load_run_metrics",
+    "load_run_provenance",
+    "summarize_run",
+    "to_amsc_row",
+]
+
+
+class AmscExportError(RuntimeError):
+    """Raised when a run cannot be exported (missing data, bad inputs)."""
+
+
+#: Columns ``build_dashboard.py`` requires of every ``runs.csv``.
+AMSC_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "timestamp",
+    "system",
+    "config",
+    "nodes",
+    "gpus",
+    "status",
+    "wall_time_sec",
+)
+
+#: Full column order we emit. The metric names follow the convention the
+#: published manifests already use (``throughput_<unit>_per_sec``, as in
+#: vllm-bench and mldocking); ``error`` is last in every published
+#: ``runs.csv``.
+AMSC_COLUMNS: tuple[str, ...] = AMSC_REQUIRED_COLUMNS + (
+    "throughput_tokens_per_sec",
+    "throughput_tokens_per_sec_per_gpu",
+    "mfu",
+    "tflops",
+    "final_loss",
+    "steps",
+    "error",
+)
+
+DEFAULT_WARMUP: int = 1
+
+REDUCERS: dict[str, Callable[[Sequence[float]], float]] = {
+    "median": statistics.median,
+    "mean": statistics.fmean,
+    "max": max,
+    "min": min,
+    "last": lambda xs: xs[-1],
+}
+
+# ezpz metric key -> AmSC column.
+_METRIC_MAP: dict[str, str] = {
+    "train/tps": "throughput_tokens_per_sec",
+    "train/tps_per_gpu": "throughput_tokens_per_sec_per_gpu",
+    "train/mfu": "mfu",
+    "train/tflops": "tflops",
+}
+
+
+def load_run_metrics(run_dir: Path | str) -> list[dict[str, Any]]:
+    """Read every per-step metrics record under ``run_dir``.
+
+    Handles both layouts ezpz produces: ``metrics-<rank>.jsonl`` (one
+    file per rank -- fsdp_tp, fsdp, diffusion) and a single
+    ``metrics.jsonl`` (vit, test, minimal, hf).
+
+    Returns records sorted by ``train/iter`` then timestamp, each a dict
+    with ``timestamp``, ``rank`` and a flattened ``metrics`` mapping.
+    Records carrying no numeric metrics are dropped -- notably the
+    ``precision/*`` record ``fsdp_tp`` writes directly through
+    ``History._write_jsonl_entry``, whose values are strings.
+    """
+    root = Path(run_dir)
+    if not root.is_dir():
+        raise AmscExportError(f"not a directory: {root}")
+
+    files = sorted(root.rglob("metrics-*.jsonl")) or sorted(
+        root.rglob("metrics.jsonl")
+    )
+    if not files:
+        raise AmscExportError(
+            f"no metrics JSONL found under {root}. Expected "
+            "metrics-<rank>.jsonl or metrics.jsonl -- is this an ezpz "
+            "run directory?"
+        )
+
+    records: list[dict[str, Any]] = []
+    for path in files:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                # A run killed mid-write leaves a truncated final line.
+                continue
+            metrics = payload.get("metrics")
+            if not isinstance(metrics, dict):
+                continue
+            numeric = {
+                k: v
+                for k, v in metrics.items()
+                if isinstance(v, (int, float)) and not isinstance(v, bool)
+            }
+            if not numeric:
+                continue  # e.g. the all-strings precision/* record
+            records.append(
+                {
+                    "timestamp": payload.get("timestamp"),
+                    "rank": payload.get("rank", 0),
+                    "metrics": numeric,
+                }
+            )
+
+    if not records:
+        raise AmscExportError(f"no numeric metric records under {root}")
+    records.sort(
+        key=lambda r: (
+            r["metrics"].get("train/iter", 0),
+            r["timestamp"] or 0,
+        )
+    )
+    return records
+
+
+def _provenance_from_report(root: Path) -> dict[str, Any]:
+    """Scrape the ``### Distributed`` bullets out of ``report-*.md``.
+
+    The fallback that makes this usable on runs that already exist.
+    ``run_info.json`` is new, and ``config.json`` only appears under the
+    non-default ``csv`` tracker backend -- but ``History.finalize`` has
+    always rendered ``get_dist_info()`` into the report as::
+
+        ### Distributed
+
+        - **MACHINE**: SunSpot
+        - **NUM_NODES**: 1
+        - **NGPUS**: 12
+
+    Parsing prose is not how this should work long-term, which is why
+    ``run_info.json`` now exists and is preferred; this tier keeps the
+    exporter useful for everything already on disk.
+    """
+    for report in sorted(root.rglob("report*.md")):
+        try:
+            text = report.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "### Distributed" not in text:
+            continue
+        section = text.split("### Distributed", 1)[1]
+        # Stop at the next heading of any level.
+        for line in section.splitlines()[1:]:
+            if line.startswith("#"):
+                break
+        section = section.split("\n#", 1)[0]
+        found: dict[str, Any] = {}
+        for line in section.splitlines():
+            line = line.strip()
+            if not line.startswith("- **") or "**:" not in line:
+                continue
+            key, _, value = line[4:].partition("**:")
+            found[key.strip()] = value.strip()
+        if found:
+            return found
+    return {}
+
+
+def load_run_provenance(run_dir: Path | str) -> dict[str, Any]:
+    """Recover ``get_dist_info()`` for a finished run, best source first.
+
+    1. ``run_info.json`` -- written by ``History.finalize`` (structured,
+       preferred, present on runs from this version onward).
+    2. ``config.json`` -- only written when the non-default ``csv``
+       tracker backend is active, but structured when it is there.
+    3. ``report*.md`` -- the ``### Distributed`` markdown section, which
+       covers the runs that predate the other two.
+
+    Returns ``{}`` when none is available; callers must then require
+    explicit ``--system``/``--nodes``/``--gpus`` rather than guess.
+    """
+    root = Path(run_dir)
+
+    for candidate in sorted(root.rglob("run_info.json")):
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        dist = payload.get("Distributed")
+        if isinstance(dist, dict) and dist:
+            return dict(dist)
+
+    for candidate in sorted(root.rglob("config.json")):
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict) and "MACHINE" in payload:
+            return {
+                k: v for k, v in payload.items() if not isinstance(v, dict)
+            }
+
+    return _provenance_from_report(root)
+
+
+def _series(records: Iterable[dict[str, Any]], key: str) -> list[float]:
+    return [
+        float(r["metrics"][key]) for r in records if key in r["metrics"]
+    ]
+
+
+def summarize_run(
+    records: Sequence[dict[str, Any]],
+    *,
+    warmup: int = DEFAULT_WARMUP,
+    reducer: str = "median",
+) -> dict[str, Any]:
+    """Reduce per-step records to the run-level numbers AmSC wants.
+
+    Args:
+        records: output of :func:`load_run_metrics`.
+        warmup: leading steps to drop before reducing throughput. Step 1
+            is reliably an outlier by an order of magnitude or more.
+        reducer: one of :data:`REDUCERS`.
+
+    Rank handling: prefer rank 0 when it logged anything, else fall back
+    to every rank. Under ezpz every rank writes its own metrics file with
+    near-identical values, so mixing them would inflate the sample count
+    without adding information.
+
+    ``wall_time_sec`` is ``sum(train/dt)`` over ALL steps including
+    warmup -- that time was really spent. Only the throughput reduction
+    trims warmup.
+    """
+    if reducer not in REDUCERS:
+        raise AmscExportError(
+            f"unknown reducer {reducer!r}; choose from "
+            f"{sorted(REDUCERS)}"
+        )
+    if warmup < 0:
+        raise AmscExportError(f"warmup must be >= 0, got {warmup}")
+    if not records:
+        raise AmscExportError("no records to summarize")
+
+    rank0 = [r for r in records if r.get("rank") == 0]
+    chosen = rank0 or list(records)
+
+    reduce = REDUCERS[reducer]
+    summary: dict[str, Any] = {"steps": len(chosen)}
+
+    # Wall time over every step, warmup included.
+    dts = _series(chosen, "train/dt")
+    summary["wall_time_sec"] = round(sum(dts), 3) if dts else None
+
+    trimmed = chosen[warmup:] if len(chosen) > warmup else chosen
+    if not trimmed:  # pragma: no cover - guarded by the len() check
+        trimmed = chosen
+    summary["steps_used"] = len(trimmed)
+    summary["warmup_dropped"] = len(chosen) - len(trimmed)
+
+    for metric_key, column in _METRIC_MAP.items():
+        values = _series(trimmed, metric_key)
+        # Absent (e.g. tflops/mfu when the model FLOPs are unknown) must
+        # stay None -> an empty CSV cell, never 0.0, which would read as
+        # a measured zero.
+        summary[column] = round(reduce(values), 3) if values else None
+
+    losses = _series(chosen, "train/loss")
+    summary["final_loss"] = round(losses[-1], 6) if losses else None
+
+    stamps = [r["timestamp"] for r in chosen if r.get("timestamp")]
+    summary["started_at"] = min(stamps) if stamps else None
+    return summary
+
+
+def _iso(epoch: Optional[float]) -> str:
+    if epoch is None:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.fromtimestamp(float(epoch), tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def to_amsc_row(
+    summary: dict[str, Any],
+    *,
+    config: str,
+    system: Optional[str] = None,
+    nodes: Optional[int] = None,
+    gpus: Optional[int] = None,
+    provenance: Optional[dict[str, Any]] = None,
+    status: str = "pass",
+    error: str = "",
+    timestamp: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build one schema-valid row.
+
+    Explicit arguments win over ``provenance``; anything still missing
+    raises rather than being guessed. In particular ``gpus`` is NOT
+    inferred from the number of rank files: those count ranks, which
+    equals GPUs only at one rank per GPU, and a silently wrong GPU count
+    corrupts every per-GPU comparison on the dashboard.
+    """
+    prov = provenance or {}
+
+    def _prov_int(key: str) -> Optional[int]:
+        raw = prov.get(key)
+        try:
+            return int(raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+
+    system = system or (str(prov["MACHINE"]) if prov.get("MACHINE") else None)
+
+    # Report what the RUN used, not what the JOB was allocated.
+    #
+    # `NUM_NODES`/`NGPUS` come from the scheduler's allocation, so a
+    # 4-node job that runs a 1-node configuration reports NUM_NODES=4,
+    # NGPUS=48 while WORLD_SIZE_IN_USE=12. Publishing the allocation
+    # would make a 1-node result look like a catastrophically bad
+    # 4-node one -- observed exactly this on Sunspot job 12473020,
+    # where a scaling sweep ran 1/2/4 nodes inside one 4-node
+    # allocation.
+    #
+    # So derive from the ranks actually participating, and only fall
+    # back to the allocation when that is unavailable.
+    in_use = _prov_int("WORLD_SIZE_IN_USE") or _prov_int("world_size")
+    per_node = _prov_int("GPUS_PER_NODE")
+    if gpus is None:
+        gpus = in_use if in_use is not None else _prov_int("NGPUS")
+    if nodes is None:
+        if in_use is not None and per_node:
+            # ceil: a partially-filled last node is still a node.
+            nodes = -(-in_use // per_node)
+        else:
+            nodes = _prov_int("NUM_NODES")
+
+    missing = [
+        name
+        for name, value in (
+            ("system", system),
+            ("nodes", nodes),
+            ("gpus", gpus),
+        )
+        if value in (None, "")
+    ]
+    if missing:
+        flags = " ".join(f"--{m}" for m in missing)
+        raise AmscExportError(
+            f"cannot determine {', '.join(missing)} for this run. "
+            f"run_info.json is absent or incomplete (runs from before it "
+            f"existed, or a non-rank-0 directory), so pass {flags} "
+            f"explicitly."
+        )
+    if not config:
+        raise AmscExportError("config is required (e.g. agpt-2b/bs1/seq2048)")
+
+    row: dict[str, Any] = {c: "" for c in AMSC_COLUMNS}
+    row.update(
+        {
+            "timestamp": timestamp or _iso(summary.get("started_at")),
+            "system": system,
+            "config": config,
+            "nodes": nodes,
+            "gpus": gpus,
+            "status": status,
+            "error": error,
+        }
+    )
+    for column in (
+        "wall_time_sec",
+        "throughput_tokens_per_sec",
+        "throughput_tokens_per_sec_per_gpu",
+        "mfu",
+        "tflops",
+        "final_loss",
+        "steps",
+    ):
+        value = summary.get(column)
+        row[column] = "" if value is None else value
+    return row
+
+
+def format_csv(
+    rows: Sequence[dict[str, Any]], *, header: bool = True
+) -> str:
+    """Render rows in :data:`AMSC_COLUMNS` order."""
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf, fieldnames=list(AMSC_COLUMNS), lineterminator="\n"
+    )
+    if header:
+        writer.writeheader()
+    for row in rows:
+        writer.writerow({c: row.get(c, "") for c in AMSC_COLUMNS})
+    return buf.getvalue()

--- a/src/ezpz/export/amsc.py
+++ b/src/ezpz/export/amsc.py
@@ -117,6 +117,33 @@ _METRIC_MAP: dict[str, str] = {
 }
 
 
+def _looks_like_metrics(path: Path, *, probe_lines: int = 5) -> bool:
+    """Does this JSONL hold metric records rather than log lines?
+
+    ``finalize`` symlinks the structured LOG into the run directory
+    alongside the metrics, and both are ``*.jsonl``. Log records have
+    ``message``/``levelname`` and no ``metrics`` key, so a few lines are
+    enough to tell them apart without reading the whole file.
+    """
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for _, line in zip(range(probe_lines), handle):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict) and isinstance(
+                    payload.get("metrics"), dict
+                ):
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 def load_run_metrics(run_dir: Path | str) -> list[dict[str, Any]]:
     """Read every per-step metrics record under ``run_dir``.
 
@@ -134,44 +161,62 @@ def load_run_metrics(run_dir: Path | str) -> list[dict[str, Any]]:
     if not root.is_dir():
         raise AmscExportError(f"not a directory: {root}")
 
+    # Three naming schemes are in play: `metrics-<rank>.jsonl` (fsdp_tp,
+    # fsdp, diffusion), `metrics.jsonl` (vit, test, minimal, hf), and
+    # `<run_id>.jsonl` -- what History writes when the caller does not
+    # name the file (history.py:419). Missing the last one made the
+    # exporter fail outright on any default History run.
     files = sorted(root.rglob("metrics-*.jsonl")) or sorted(
         root.rglob("metrics.jsonl")
     )
     if not files:
+        # Fall back to any JSONL that actually carries metric records,
+        # excluding the structured LOG (which has "message"/"levelname"
+        # keys and no "metrics") that finalize symlinks into the run dir.
+        files = [
+            p
+            for p in sorted(root.rglob("*.jsonl"))
+            if _looks_like_metrics(p)
+        ]
+    if not files:
         raise AmscExportError(
             f"no metrics JSONL found under {root}. Expected "
-            "metrics-<rank>.jsonl or metrics.jsonl -- is this an ezpz "
-            "run directory?"
+            "metrics-<rank>.jsonl, metrics.jsonl, or a <run_id>.jsonl "
+            "containing metric records -- is this an ezpz run directory?"
         )
 
     records: list[dict[str, Any]] = []
     for path in files:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                # A run killed mid-write leaves a truncated final line.
-                continue
-            metrics = payload.get("metrics")
-            if not isinstance(metrics, dict):
-                continue
-            numeric = {
-                k: v
-                for k, v in metrics.items()
-                if isinstance(v, (int, float)) and not isinstance(v, bool)
-            }
-            if not numeric:
-                continue  # e.g. the all-strings precision/* record
-            records.append(
-                {
-                    "timestamp": payload.get("timestamp"),
-                    "rank": payload.get("rank", 0),
-                    "metrics": numeric,
+        # Stream: a long run's JSONL is large, and reading it whole just
+        # to split it doubles peak RSS for no benefit.
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    # A killed run leaves a truncated final line.
+                    continue
+                metrics = payload.get("metrics")
+                if not isinstance(metrics, dict):
+                    continue
+                numeric = {
+                    k: v
+                    for k, v in metrics.items()
+                    if isinstance(v, (int, float))
+                    and not isinstance(v, bool)
                 }
-            )
+                if not numeric:
+                    continue  # e.g. the all-strings precision/* record
+                records.append(
+                    {
+                        "timestamp": payload.get("timestamp"),
+                        "rank": payload.get("rank", 0),
+                        "metrics": numeric,
+                    }
+                )
 
     if not records:
         raise AmscExportError(f"no numeric metric records under {root}")
@@ -209,12 +254,8 @@ def _provenance_from_report(root: Path) -> dict[str, Any]:
             continue
         if "### Distributed" not in text:
             continue
-        section = text.split("### Distributed", 1)[1]
-        # Stop at the next heading of any level.
-        for line in section.splitlines()[1:]:
-            if line.startswith("#"):
-                break
-        section = section.split("\n#", 1)[0]
+        # Take the section, stopping at the next heading of any level.
+        section = text.split("### Distributed", 1)[1].split("\n#", 1)[0]
         found: dict[str, Any] = {}
         for line in section.splitlines():
             line = line.strip()
@@ -385,7 +426,16 @@ def to_amsc_row(
     #
     # So derive from the ranks actually participating, and only fall
     # back to the allocation when that is unavailable.
-    in_use = _prov_int("WORLD_SIZE_IN_USE") or _prov_int("world_size")
+    # `WORLD_SIZE_IN_USE` is MPI-only (`get_world_size_in_use` calls
+    # `MPI.COMM_WORLD.Get_size()` and falls back to 1), so under
+    # torchrun -- where MPI may be absent or every rank is a singleton
+    # COMM_WORLD -- it reads 1 while the lowercase `world_size` field
+    # correctly reflects $WORLD_SIZE. Take the larger: both describe the
+    # same quantity, and the failure mode of each is to under-report.
+    in_use = max(
+        _prov_int("WORLD_SIZE_IN_USE") or 0,
+        _prov_int("world_size") or 0,
+    ) or None
     per_node = _prov_int("GPUS_PER_NODE")
     if gpus is None:
         gpus = in_use if in_use is not None else _prov_int("NGPUS")

--- a/src/ezpz/history.py
+++ b/src/ezpz/history.py
@@ -646,6 +646,42 @@ class History:
 
         return summary
 
+    def _write_run_info(
+        self, base_dir: Path, env_details: dict[str, Any]
+    ) -> Optional[Path]:
+        """Persist the run's provenance as JSON. Returns the path, or None.
+
+        ``_default_environment_info`` already assembles everything a
+        consumer needs -- ``get_dist_info()`` under ``Distributed``
+        (MACHINE, NUM_NODES, NGPUS, SCHEDULER, the launch command), plus
+        Python/Torch versions and W&B/MLflow ids. Until now that dict was
+        rendered into ``report-*.md`` as markdown bullets and dropped.
+
+        A finished run therefore could not be summarized offline without
+        parsing prose: ``config.json`` only appears when the *non-default*
+        ``csv`` tracker backend is enabled, so a default run left the node
+        and GPU counts recoverable only from the report text. Writing the
+        same dict as ``run_info.json`` makes a run self-describing for any
+        downstream consumer (``ezpz export-amsc``, a results dashboard, a
+        future resume) regardless of which trackers were active.
+
+        Rank 0 only, and best-effort: a failure here must never take down
+        an otherwise successful run, so it warns and returns None.
+        """
+        if get_rank() != 0:
+            return None
+        path = Path(base_dir).joinpath("run_info.json")
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(env_details, indent=2, default=str),
+                encoding="utf-8",
+            )
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning("Unable to write %s (%s)", path, exc)
+            return None
+        return path
+
     def _collect_metric_groups(
         self, dataset: xr.Dataset
     ) -> dict[str, dict[str, float]]:
@@ -2825,6 +2861,9 @@ class History:
             paths["Metrics CSV"] = str(_csv_be._csv_path)
             output_files["Metrics CSV"] = paths["Metrics CSV"]
         env_details["Paths"] = paths
+        run_info_path = self._write_run_info(base_dir, env_details)
+        if run_info_path is not None:
+            output_files["Run Info"] = str(run_info_path)
         self._write_environment_section(env_details)
         self._write_metric_summary(dataset)
         if plot and plotdir is not None:

--- a/tests/test_export_amsc.py
+++ b/tests/test_export_amsc.py
@@ -432,3 +432,100 @@ class TestCli:
         assert res.exit_code != 0
         assert "--nodes" in res.output
         assert "Traceback" not in res.output
+
+
+class TestReviewRegressions:
+    """Cases raised in review on #213, each verified before fixing."""
+
+    def test_finds_a_default_history_run_id_jsonl(self, tmp_path: Path):
+        """History names the file `<run_id>.jsonl` when the caller does
+        not pass one (history.py:419), which the metrics-*/metrics.jsonl
+        globs missed -- so export failed outright on a default run."""
+        _write_records(tmp_path / "20260811-182837.jsonl", REAL_TPS)
+        assert len(load_run_metrics(tmp_path)) == len(REAL_TPS)
+
+    def test_ignores_the_structured_log_jsonl(self, tmp_path: Path):
+        """finalize symlinks the LOG into the run dir and both are
+        *.jsonl; only one carries metric records."""
+        (tmp_path / "2026-08-11-132836-rank0.jsonl").write_text(
+            json.dumps(
+                {"timestamp": "...", "level": "INFO",
+                 "message": "hello", "module": "history"}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        _write_records(tmp_path / "20260811-182837.jsonl", REAL_TPS)
+        assert len(load_run_metrics(tmp_path)) == len(REAL_TPS)
+
+    def test_log_only_directory_still_errors(self, tmp_path: Path):
+        (tmp_path / "log.jsonl").write_text(
+            json.dumps({"level": "INFO", "message": "x"}) + "\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(AmscExportError, match="no metrics JSONL"):
+            load_run_metrics(tmp_path)
+
+    def test_torchrun_world_size_is_not_under_reported(self, run_dir: Path):
+        """`get_world_size_in_use()` is MPI-only and returns 1 under
+        torchrun, while the lowercase `world_size` reads $WORLD_SIZE.
+        Taking WORLD_SIZE_IN_USE blindly would report gpus=1."""
+        row = to_amsc_row(
+            summarize_run(load_run_metrics(run_dir), warmup=1),
+            config="c",
+            provenance={
+                "MACHINE": "Perlmutter",
+                "WORLD_SIZE_IN_USE": "1",   # MPI absent
+                "world_size": "16",         # $WORLD_SIZE
+                "GPUS_PER_NODE": "4",
+            },
+        )
+        assert (row["nodes"], row["gpus"]) == (4, 16)
+
+    def test_summarize_rejects_empty_records(self):
+        with pytest.raises(AmscExportError, match="no records"):
+            summarize_run([])
+
+
+class TestAppendHeaderGuard:
+    """Appending under a foreign header would corrupt the results file.
+
+    Values are written positionally, so a runs.csv whose columns differ
+    -- or are merely ordered differently -- would silently take our
+    numbers into the wrong fields.
+    """
+
+    def _argv(self, run_dir, dest):
+        return ["export-amsc", str(run_dir), "--config", "c",
+                "--system", "S", "--nodes", "1", "--gpus", "12",
+                "--append", str(dest)]
+
+    def test_refuses_a_mismatched_header(self, run_dir: Path, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from ezpz.cli import main
+
+        dest = tmp_path / "runs.csv"
+        dest.write_text(
+            "timestamp,system,config,nodes,gpus,status,wall_time_sec,"
+            "samples_per_sec,error\n",
+            encoding="utf-8",
+        )
+        res = CliRunner().invoke(main, self._argv(run_dir, dest))
+        assert res.exit_code != 0
+        assert "different header" in res.output
+        # and nothing was written
+        assert len(dest.read_text(encoding="utf-8").splitlines()) == 1
+
+    def test_accepts_a_matching_header(self, run_dir: Path, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from ezpz.cli import main
+
+        dest = tmp_path / "runs.csv"
+        dest.write_text(",".join(AMSC_COLUMNS) + "\n", encoding="utf-8")
+        res = CliRunner().invoke(main, self._argv(run_dir, dest))
+        assert res.exit_code == 0, res.output
+        assert len(list(csv.DictReader(io.StringIO(
+            dest.read_text(encoding="utf-8")
+        )))) == 1

--- a/tests/test_export_amsc.py
+++ b/tests/test_export_amsc.py
@@ -1,0 +1,434 @@
+"""Tests for `ezpz export-amsc`.
+
+The load-bearing test here is `TestAmscSchemaConformance`: it replicates
+the coercion the CONSUMER performs (`build_dashboard.py` in the AmSC
+benchmarks repo) rather than asserting our own output shape back at
+ourselves. A row that parses cleanly for us but not for the dashboard is
+a row that silently never appears.
+
+The throughput fixtures use the real per-step `train/tps` series from a
+Sunspot `agpt-2b` run (job 12472885): 1045, 34601, 34686, 34715, 34833,
+34650. Step 1 is a 33x outlier, which is what the warmup and reducer
+defaults exist for.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from ezpz.export.amsc import (
+    AMSC_COLUMNS,
+    AMSC_REQUIRED_COLUMNS,
+    AmscExportError,
+    format_csv,
+    load_run_metrics,
+    load_run_provenance,
+    summarize_run,
+    to_amsc_row,
+)
+
+# Real series from Sunspot job 12472885 (agpt-2b, tp=1, 12 ranks).
+REAL_TPS = [1045.1, 34600.8, 34686.4, 34715.4, 34832.8, 34650.0]
+
+
+def _write_records(path: Path, tps, *, rank=0, dt=1.0, loss_from=13.0):
+    """One JSONL file shaped like History._write_jsonl_entry output."""
+    lines = []
+    for i, v in enumerate(tps):
+        lines.append(
+            json.dumps(
+                {
+                    "timestamp": 1786393250.0 + i,
+                    "rank": rank,
+                    "metrics": {
+                        "train/iter": i + 1,
+                        "train/loss": loss_from - i * 0.01,
+                        "train/dt": dt,
+                        "train/tps": v,
+                        "train/tps_per_gpu": v / 12.0,
+                        "train/mfu": 5.8,
+                        "train/tflops": 17.4,
+                    },
+                }
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def run_dir(tmp_path: Path) -> Path:
+    _write_records(tmp_path / "metrics-0.jsonl", REAL_TPS)
+    return tmp_path
+
+
+class TestLoadRunMetrics:
+    def test_reads_per_rank_files(self, tmp_path: Path):
+        _write_records(tmp_path / "metrics-0.jsonl", REAL_TPS, rank=0)
+        _write_records(tmp_path / "metrics-1.jsonl", REAL_TPS, rank=1)
+        assert len(load_run_metrics(tmp_path)) == 2 * len(REAL_TPS)
+
+    def test_reads_single_metrics_file(self, tmp_path: Path):
+        """vit/test/minimal/hf write one metrics.jsonl, not per-rank."""
+        _write_records(tmp_path / "metrics.jsonl", REAL_TPS)
+        assert len(load_run_metrics(tmp_path)) == len(REAL_TPS)
+
+    def test_skips_the_precision_record(self, tmp_path: Path):
+        """fsdp_tp writes an all-strings `precision/*` record directly
+        through History._write_jsonl_entry (fsdp_tp.py:3575). Treating
+        it as numeric would raise on float()."""
+        p = tmp_path / "metrics-0.jsonl"
+        _write_records(p, REAL_TPS)
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "timestamp": 1786393260.0,
+                        "rank": 0,
+                        "metrics": {
+                            "precision/mixed_precision": "bf16",
+                            "precision/master_weights": "fp32",
+                        },
+                    }
+                )
+                + "\n"
+            )
+        records = load_run_metrics(tmp_path)
+        assert len(records) == len(REAL_TPS)
+        assert not any(
+            k.startswith("precision/")
+            for r in records
+            for k in r["metrics"]
+        )
+
+    def test_survives_a_truncated_final_line(self, tmp_path: Path):
+        """A killed job leaves a half-written line; that must not be
+        fatal -- the run's earlier steps are still valid data."""
+        p = tmp_path / "metrics-0.jsonl"
+        _write_records(p, REAL_TPS)
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write('{"timestamp": 1786393261.0, "rank": 0, "metr')
+        assert len(load_run_metrics(tmp_path)) == len(REAL_TPS)
+
+    def test_missing_jsonl_names_what_it_looked_for(self, tmp_path: Path):
+        with pytest.raises(AmscExportError, match="metrics"):
+            load_run_metrics(tmp_path)
+
+    def test_not_a_directory(self, tmp_path: Path):
+        f = tmp_path / "x.txt"
+        f.write_text("", encoding="utf-8")
+        with pytest.raises(AmscExportError, match="not a directory"):
+            load_run_metrics(f)
+
+
+class TestSummarize:
+    def test_default_drops_the_warmup_outlier(self, run_dir: Path):
+        """Step 1 is 1045 vs a ~34.7k steady state. Including it in a
+        MEAN understates throughput by ~16%; this is the entire reason
+        warmup trimming is on by default."""
+        records = load_run_metrics(run_dir)
+        trimmed = summarize_run(records, warmup=1, reducer="mean")
+        untrimmed = summarize_run(records, warmup=0, reducer="mean")
+        assert trimmed["throughput_tokens_per_sec"] > 34000
+        assert untrimmed["throughput_tokens_per_sec"] < 30000
+
+    def test_median_is_robust_without_trimming(self, run_dir: Path):
+        """A median survives the outlier even at warmup=0 -- which is
+        why it is the default reducer, not the mean."""
+        records = load_run_metrics(run_dir)
+        assert (
+            summarize_run(records, warmup=0, reducer="median")[
+                "throughput_tokens_per_sec"
+            ]
+            > 34000
+        )
+
+    def test_wall_time_is_sum_of_dt_including_warmup(self, run_dir: Path):
+        """Warmup time was really spent; only the throughput reduction
+        trims it. And the JSONL timestamp span is NOT usable -- records
+        exist only for logged steps."""
+        s = summarize_run(load_run_metrics(run_dir), warmup=1)
+        assert s["wall_time_sec"] == pytest.approx(len(REAL_TPS) * 1.0)
+
+    def test_final_loss_is_the_last_value(self, run_dir: Path):
+        s = summarize_run(load_run_metrics(run_dir))
+        assert s["final_loss"] == pytest.approx(13.0 - 0.05)
+
+    def test_absent_metric_is_none_not_zero(self, tmp_path: Path):
+        """mfu/tflops are absent when model FLOPs are unknown. Zero
+        would read as a measured zero on the dashboard."""
+        (tmp_path / "metrics-0.jsonl").write_text(
+            json.dumps(
+                {
+                    "timestamp": 1.0,
+                    "rank": 0,
+                    "metrics": {"train/iter": 1, "train/tps": 100.0},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        s = summarize_run(load_run_metrics(tmp_path), warmup=0)
+        assert s["mfu"] is None and s["tflops"] is None
+
+    def test_prefers_rank0_over_mixing_ranks(self, tmp_path: Path):
+        """Every rank logs near-identical values; mixing them would
+        inflate the sample count without adding information."""
+        _write_records(tmp_path / "metrics-0.jsonl", REAL_TPS, rank=0)
+        _write_records(tmp_path / "metrics-1.jsonl", REAL_TPS, rank=1)
+        s = summarize_run(load_run_metrics(tmp_path), warmup=1)
+        assert s["steps"] == len(REAL_TPS)
+
+    def test_warmup_larger_than_series_keeps_the_series(self, run_dir: Path):
+        """Better a warmup-contaminated number than an empty cell."""
+        s = summarize_run(load_run_metrics(run_dir), warmup=999)
+        assert s["throughput_tokens_per_sec"] is not None
+
+    def test_rejects_unknown_reducer(self, run_dir: Path):
+        with pytest.raises(AmscExportError, match="unknown reducer"):
+            summarize_run(load_run_metrics(run_dir), reducer="nope")
+
+    def test_rejects_negative_warmup(self, run_dir: Path):
+        with pytest.raises(AmscExportError, match="warmup"):
+            summarize_run(load_run_metrics(run_dir), warmup=-1)
+
+
+class TestProvenance:
+    def test_reads_run_info_json(self, tmp_path: Path):
+        (tmp_path / "run_info.json").write_text(
+            json.dumps(
+                {"Distributed": {"MACHINE": "Aurora", "NUM_NODES": "8",
+                                 "NGPUS": "96"}}
+            ),
+            encoding="utf-8",
+        )
+        p = load_run_provenance(tmp_path)
+        assert p["MACHINE"] == "Aurora" and p["NGPUS"] == "96"
+
+    def test_falls_back_to_the_report_markdown(self, tmp_path: Path):
+        """run_info.json is new and config.json needs the non-default
+        csv backend, but every run has ever written get_dist_info() into
+        report-*.md. Without this tier the exporter is useless on every
+        run already on disk."""
+        (tmp_path / "train").mkdir()
+        (tmp_path / "train" / "report-train.md").write_text(
+            "# Report\n\n### Distributed\n\n"
+            "- **MACHINE**: SunSpot\n"
+            "- **NUM_NODES**: 2\n"
+            "- **NGPUS**: 24\n\n"
+            "## Metric Overview\n",
+            encoding="utf-8",
+        )
+        p = load_run_provenance(tmp_path)
+        assert p["MACHINE"] == "SunSpot"
+        assert p["NUM_NODES"] == "2"
+        assert p["NGPUS"] == "24"
+        assert "Metric Overview" not in json.dumps(p)
+
+    def test_run_info_wins_over_report(self, tmp_path: Path):
+        (tmp_path / "run_info.json").write_text(
+            json.dumps({"Distributed": {"MACHINE": "Aurora",
+                                        "NUM_NODES": "8", "NGPUS": "96"}}),
+            encoding="utf-8",
+        )
+        (tmp_path / "report.md").write_text(
+            "### Distributed\n\n- **MACHINE**: Stale\n", encoding="utf-8"
+        )
+        assert load_run_provenance(tmp_path)["MACHINE"] == "Aurora"
+
+    def test_absent_is_empty_not_an_error(self, tmp_path: Path):
+        assert load_run_provenance(tmp_path) == {}
+
+
+class TestRowConstruction:
+    def _summary(self, run_dir):
+        return summarize_run(load_run_metrics(run_dir), warmup=1)
+
+    def test_explicit_flags_beat_provenance(self, run_dir: Path):
+        row = to_amsc_row(
+            self._summary(run_dir),
+            config="c",
+            system="Frontier",
+            nodes=4,
+            gpus=32,
+            provenance={"MACHINE": "SunSpot", "NUM_NODES": "1",
+                        "NGPUS": "12"},
+        )
+        assert (row["system"], row["nodes"], row["gpus"]) == ("Frontier", 4, 32)
+
+    def test_reports_what_the_run_used_not_what_it_was_allocated(
+        self, run_dir: Path
+    ):
+        """REGRESSION (Sunspot job 12473020).
+
+        A scaling sweep ran 1/2/4-node configurations inside one 4-node
+        allocation. `NUM_NODES`/`NGPUS` describe the ALLOCATION, so the
+        1-node run reported nodes=4, gpus=48 while
+        `WORLD_SIZE_IN_USE` was 12 -- which would have published a
+        1-node result as a catastrophically slow 4-node one.
+        """
+        row = to_amsc_row(
+            self._summary(run_dir),
+            config="c",
+            provenance={
+                "MACHINE": "SunSpot",
+                "NUM_NODES": "4",           # allocation
+                "NGPUS": "48",              # allocation
+                "GPUS_PER_NODE": "12",
+                "WORLD_SIZE_IN_USE": "12",  # what actually ran
+            },
+        )
+        assert (row["nodes"], row["gpus"]) == (1, 12)
+
+    def test_partial_last_node_rounds_up(self, run_dir: Path):
+        """18 ranks at 12/node is 2 nodes, not 1."""
+        row = to_amsc_row(
+            self._summary(run_dir),
+            config="c",
+            provenance={
+                "MACHINE": "S", "GPUS_PER_NODE": "12",
+                "WORLD_SIZE_IN_USE": "18",
+            },
+        )
+        assert (row["nodes"], row["gpus"]) == (2, 18)
+
+    def test_falls_back_to_allocation_when_usage_unknown(self, run_dir: Path):
+        row = to_amsc_row(
+            self._summary(run_dir),
+            config="c",
+            provenance={"MACHINE": "S", "NUM_NODES": "8", "NGPUS": "96"},
+        )
+        assert (row["nodes"], row["gpus"]) == (8, 96)
+
+    def test_missing_identity_errors_with_the_flags(self, run_dir: Path):
+        """Guessing gpus from the rank-file count would be wrong at any
+        ranks-per-GPU other than 1, and a wrong GPU count corrupts every
+        per-GPU comparison on the dashboard."""
+        with pytest.raises(AmscExportError) as ei:
+            to_amsc_row(self._summary(run_dir), config="c")
+        msg = str(ei.value)
+        assert "--system" in msg and "--nodes" in msg and "--gpus" in msg
+
+    def test_requires_a_config(self, run_dir: Path):
+        with pytest.raises(AmscExportError, match="config"):
+            to_amsc_row(
+                self._summary(run_dir), config="",
+                system="S", nodes=1, gpus=12,
+            )
+
+    def test_none_becomes_empty_cell(self, tmp_path: Path):
+        (tmp_path / "metrics-0.jsonl").write_text(
+            json.dumps({"timestamp": 1.0, "rank": 0,
+                        "metrics": {"train/iter": 1, "train/tps": 5.0}})
+            + "\n",
+            encoding="utf-8",
+        )
+        row = to_amsc_row(
+            summarize_run(load_run_metrics(tmp_path), warmup=0),
+            config="c", system="S", nodes=1, gpus=1,
+        )
+        assert row["mfu"] == "" and row["tflops"] == ""
+
+
+class TestAmscSchemaConformance:
+    """Replicate the CONSUMER's parsing, not our own.
+
+    `build_dashboard.py` in the AmSC repo does:
+
+        REQUIRED_COLS = {"timestamp","system","config","nodes","gpus",
+                         "status","wall_time_sec"}
+        int(nodes); int(gpus); float(wall_time_sec)
+        # every other non-required column -> float() when possible
+
+    A row we consider fine but it cannot coerce simply never shows up.
+    """
+
+    def _row(self, run_dir):
+        return to_amsc_row(
+            summarize_run(load_run_metrics(run_dir), warmup=1),
+            config="agpt-2b/bs1/seq512/tp1",
+            system="SunSpot", nodes=1, gpus=12,
+        )
+
+    def test_header_covers_every_required_column(self):
+        assert set(AMSC_REQUIRED_COLUMNS) <= set(AMSC_COLUMNS)
+
+    def test_round_trips_through_the_consumers_coercion(self, run_dir: Path):
+        text = format_csv([self._row(run_dir)])
+        parsed = list(csv.DictReader(io.StringIO(text)))
+        assert len(parsed) == 1
+        row = parsed[0]
+        assert set(AMSC_REQUIRED_COLUMNS) <= set(row)
+        int(row["nodes"])
+        int(row["gpus"])
+        float(row["wall_time_sec"])
+        for key, value in row.items():
+            if key in AMSC_REQUIRED_COLUMNS or value == "":
+                continue
+            float(value)  # must not raise
+
+    def test_status_is_a_value_the_dashboard_shows(self, run_dir: Path):
+        assert self._row(run_dir)["status"] == "pass"
+
+    def test_timestamp_matches_the_published_format(self, run_dir: Path):
+        """Published rows use e.g. 2025-11-13T06:01:20Z."""
+        import re
+
+        ts = self._row(run_dir)["timestamp"]
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", ts), ts
+
+    def test_header_written_once_when_appending(self, run_dir: Path):
+        row = self._row(run_dir)
+        text = format_csv([row]) + format_csv([row], header=False)
+        assert text.count("timestamp,system,config") == 1
+        assert len(list(csv.DictReader(io.StringIO(text)))) == 2
+
+
+class TestCli:
+    def test_exports_a_row(self, run_dir: Path):
+        from click.testing import CliRunner
+
+        from ezpz.cli import main
+
+        res = CliRunner().invoke(
+            main,
+            ["export-amsc", str(run_dir), "--config", "c",
+             "--system", "S", "--nodes", "1", "--gpus", "12"],
+        )
+        assert res.exit_code == 0, res.output
+        rows = list(csv.DictReader(io.StringIO(res.output)))
+        assert len(rows) == 1
+        assert float(rows[0]["throughput_tokens_per_sec"]) > 34000
+
+    def test_append_writes_header_only_once(self, run_dir: Path, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from ezpz.cli import main
+
+        dest = tmp_path / "results" / "runs.csv"
+        argv = ["export-amsc", str(run_dir), "--config", "c",
+                "--system", "S", "--nodes", "1", "--gpus", "12",
+                "--append", str(dest)]
+        runner = CliRunner()
+        assert runner.invoke(main, argv).exit_code == 0
+        assert runner.invoke(main, argv).exit_code == 0
+        text = dest.read_text(encoding="utf-8")
+        assert text.count("timestamp,system,config") == 1
+        assert len(list(csv.DictReader(io.StringIO(text)))) == 2
+
+    def test_missing_identity_fails_cleanly(self, run_dir: Path):
+        """A stack trace here would bury the actionable message."""
+        from click.testing import CliRunner
+
+        from ezpz.cli import main
+
+        res = CliRunner().invoke(
+            main, ["export-amsc", str(run_dir), "--config", "c"]
+        )
+        assert res.exit_code != 0
+        assert "--nodes" in res.output
+        assert "Traceback" not in res.output

--- a/zensical.toml
+++ b/zensical.toml
@@ -82,6 +82,7 @@ nav = [
         { "🗜️ <code>ezpz tar-env</code>" = "cli/tar-env.md" },
         { "🩺 <code>ezpz doctor</code>" = "cli/doctor.md" },
         { "💀 <code>ezpz kill</code>" = "cli/kill.md" },
+        { "📤 <code>ezpz export-amsc</code>" = "cli/export-amsc.md" },
         { "🧪 Experimental" = [
             { "✍️ <code>ezpz generate</code>" = "cli/generate.md" },
             { "🖥️ <code>ezpz generate_tui</code>" = "cli/generate-tui.md" },


### PR DESCRIPTION
Adds `ezpz export-amsc`, which turns a finished run directory into one
CSV row for the [AmSC at-scale
benchmarks](https://gitlab.com/amsc2/ai-services/at-scale-services/amsc-atscale-benchmarks).
ezpz already drives that repo's **llm-finetuning** benchmark, but only
as copy-pasteable commands — no ezpz run has ever produced a result row,
and it is the one benchmark there with no `benchmark.yaml`/`runs.csv`.

The schema was read from that repo's `build_dashboard.py`, not inferred:
seven required columns, every other column coerced to float when
possible, empty meaning "not measured" rather than zero.

## Verified against the real consumer

Not just against my own tests — I cloned the AmSC repo fresh, dropped in
a manifest plus an exported row, and ran their tooling:

```
$ python build_dashboard.py
wrote 53 runs across 4 benchmarks          # was 3
benchmarks discovered: ['llm-finetuning', 'mldocking', 'vit-weather', 'vllm-bench']

$ python results/generate.py
| Facility | Config                  | Nodes | GPUs | Throughput (tokens/s) |
| SunSpot  | agpt-2b/bs1/seq2048/tp1 |     1 |   12 |                 61217 |
```

## Three defaults set by measurement

**Warmup trimming + median.** Real `train/tps` from a Sunspot agpt-2b
run: `1045, 34601, 34686, 34715, 34833, 34650`. Step 1 is a 33x outlier,
so a mean over the untrimmed series reports **29,088 against a true
~34,700** — a 16% understatement. A median survives either way.

**`wall_time_sec = sum(train/dt)`,** not the JSONL timestamp span:
records exist only for logged steps, so the span covered 1.18 s of a
6.76 s run. `timings/*` go to `tracker.log()` and never reach the JSONL,
so they cannot be recovered offline at all — hence `--wall-time-sec` to
supply the scheduler's real figure.

**`nodes`/`gpus` from `WORLD_SIZE_IN_USE`,** not `NUM_NODES`/`NGPUS`.
Those describe the scheduler *allocation*: my first version reported a
1-node run as `nodes=4, gpus=48` because the sweep ran inside a 4-node
allocation, which would have published a 1-node result as a
catastrophically slow 4-node one. Caught on real data, pinned by a
regression test.

## Also here

`History.finalize()` now writes `run_info.json`. `_default_environment_info()`
already assembled `get_dist_info()` and rendered it into `report-*.md` as
markdown bullets, then dropped it — so a finished run could not be
summarized offline without parsing prose (`config.json` only appears
under the non-default `csv` tracker backend). The exporter still falls
back to parsing that report section, so runs predating this change work.

When no provenance is available it errors naming the flags rather than
guessing `gpus` from the rank-file count — ranks equal GPUs only at one
rank per GPU, and a wrong GPU count corrupts every per-GPU comparison.

## Tests

34 new, 1444 passing. The load-bearing one replicates the **consumer's**
coercion (`int(nodes)`, `int(gpus)`, `float()` on every non-required
column) rather than asserting our own output back at ourselves — a row
we accept but the dashboard cannot parse would simply never appear.

## Not included

Multi-node result rows. 2- and 4-node runs fail on Sunspot with
`ur_die: urEventWait must not be called for an internal event`, and the
two workarounds I tried were both strictly worse (oneCCL `allgatherv`
failure; SIGSEGV) — Level-Zero/fabric issues rather than ezpz ones. The
1-node path is clean. Tracked separately; the exporter is unaffected.

## Summary by Sourcery

Add a CLI command and export module to turn finished ezpz runs into AmSC at-scale benchmark CSV rows, and persist run provenance so exports work reliably for new and existing runs.

New Features:
- Introduce the `ezpz export-amsc` CLI command to emit a single AmSC-compatible `runs.csv` row from a finished run directory.
- Add an `ezpz.export` package with an AmSC exporter that reads metrics JSONL, summarizes run performance, and maps it into the benchmark schema.

Enhancements:
- Persist run provenance as `run_info.json` during history finalization so downstream tools can recover system, node, and GPU information without parsing reports.
- Expose the new exporter utilities via the `ezpz.export` package for reuse by other consumers.

Documentation:
- Document the `ezpz export-amsc` command, its defaults, provenance handling, and options in the CLI docs, and add it to the navigation.

Tests:
- Add a comprehensive test suite for the AmSC exporter and CLI, including schema conformance against the benchmark consumer, provenance fallbacks, warmup/reducer behavior, and append/header handling.