### PR TITLE
fix(setup): ezpz_setup_env must not report success when nothing was activated

### DIFF
--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -1839,15 +1839,60 @@ ezpz_setup_python_nersc() {
 	export PYTHON_EXEC="${python_exec}"
 }
 
+ezpz_assert_python_env_active() {
+	# Post-condition for python setup: SOMETHING must actually be active.
+	#
+	# Checking return codes is not enough on its own -- the bug in #216 was
+	# a path that returned 0 having done nothing. This verifies the
+	# OUTCOME instead of trusting the steps: if python3 is still the system
+	# interpreter and neither a venv nor a conda prefix is active, the
+	# setup did not happen, whatever it reported.
+	#
+	# The common cause on ALCF is no `frameworks` module being loaded --
+	# note `module load frameworks` with NO version silently loads nothing
+	# and exits 0, so the version must be explicit.
+	local py
+	py="$(command -v python3 2>/dev/null || true)"
+	if [[ -n "${VIRTUAL_ENV:-}" || -n "${CONDA_PREFIX:-}" ]]; then
+		return 0
+	fi
+	if [[ -n "${py}" && "${py}" != "/usr/bin/python3" && "${py}" != "/bin/python3" ]]; then
+		# A non-system python3 (e.g. a module-provided one) is acceptable.
+		return 0
+	fi
+	log_message ERROR "Python environment setup did NOT take effect."
+	log_message ERROR "  - python3          : ${py:-<not found>}"
+	log_message ERROR "  - VIRTUAL_ENV      : ${VIRTUAL_ENV:-<unset>}"
+	log_message ERROR "  - CONDA_PREFIX     : ${CONDA_PREFIX:-<unset>}"
+	log_message ERROR "  - frameworks module: ${LMOD_FAMILY_FRAMEWORKS:-<none loaded>}"
+	log_message ERROR "Load a frameworks module FIRST, with an explicit version:"
+	log_message ERROR "    module load frameworks/2026.1.0   # bare 'frameworks' loads nothing"
+	log_message ERROR "Then re-run ezpz_setup_env."
+	return 1
+}
+
 ezpz_setup_python() {
 	local venv_override="${1:-}"
 	local scheduler_type
 	scheduler_type=$(ezpz_get_scheduler_type)
 	if [[ "${scheduler_type}" == "pbs" ]]; then
-		ezpz_setup_python_alcf
+		# Propagate the return code. This used to be an unconditional
+		# `return 0`, which threw away every failure ezpz_setup_python_alcf
+		# detects -- so ezpz_setup_env printed "[OK] Finished" while
+		# nothing had been activated, and the job only failed later with
+		# `ModuleNotFoundError: No module named torch` (#216).
+		if ! ezpz_setup_python_alcf; then
+			log_message ERROR "  - ezpz_setup_python_alcf failed."
+			return 1
+		fi
+		ezpz_assert_python_env_active || return 1
 		return 0
 	elif [[ "${scheduler_type}" == "slurm" ]]; then
-		ezpz_setup_python_nersc
+		if ! ezpz_setup_python_nersc; then
+			log_message ERROR "  - ezpz_setup_python_nersc failed."
+			return 1
+		fi
+		ezpz_assert_python_env_active || return 1
 		return 0
 	else
 		# if [[ "${scheduler_type}" == "unknown" ]]; then

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -1857,14 +1857,31 @@ ezpz_assert_python_env_active() {
 	#      reproduces from a script but not from an interactive shell.
 	#   2. `module load frameworks` with NO version silently loads nothing
 	#      and exits 0, so the version must be explicit.
-	local py
+	local py py_real
 	py="$(command -v python3 2>/dev/null || true)"
-	if [[ -n "${VIRTUAL_ENV:-}" || -n "${CONDA_PREFIX:-}" ]]; then
+
+	# Accept ANY python root ezpz itself recognizes, not just a venv or
+	# conda: ezpz_get_python_root also honors PYTHON_ROOT and
+	# PYTHONUSERBASE, and a PYTHONUSERBASE-only setup (no venv) is a
+	# supported configuration. Rejecting it here would turn a working
+	# setup into a hard failure -- worse than the bug this guards.
+	if [[ -n "$(ezpz_get_python_root)" ]]; then
 		return 0
 	fi
-	if [[ -n "${py}" && "${py}" != "/usr/bin/python3" && "${py}" != "/bin/python3" ]]; then
-		# A non-system python3 (e.g. a module-provided one) is acceptable.
-		return 0
+
+	# Canonicalize before comparing: a shim or symlink such as
+	# /usr/local/bin/python3 -> /usr/bin/python3 has a non-system-looking
+	# path, and comparing the un-resolved name would accept it and
+	# reinstate the very silent-success this exists to catch.
+	if [[ -n "${py}" ]]; then
+		py_real="$(readlink -f -- "${py}" 2>/dev/null || python3 -c 'import os,sys; print(os.path.realpath(sys.executable))' 2>/dev/null || echo "${py}")"
+		case "${py_real}" in
+		/usr/bin/python3* | /bin/python3* | /usr/local/bin/python3*) ;;
+		*)
+			# A genuinely non-system python3 (e.g. module-provided).
+			return 0
+			;;
+		esac
 	fi
 	log_message ERROR "Python environment setup did NOT take effect."
 	log_message ERROR "  - python3          : ${py:-<not found>}"

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -1848,9 +1848,15 @@ ezpz_assert_python_env_active() {
 	# interpreter and neither a venv nor a conda prefix is active, the
 	# setup did not happen, whatever it reported.
 	#
-	# The common cause on ALCF is no `frameworks` module being loaded --
-	# note `module load frameworks` with NO version silently loads nothing
-	# and exits 0, so the version must be explicit.
+	# Two ways to reach this state on ALCF, both silent:
+	#
+	#   1. `bash script.sh` (no -l) does not define the `module` function,
+	#      so ezpz_setup_conda_{sunspot,aurora}'s `module load frameworks`
+	#      is a no-op -- there is no shell function to run. Under `bash -l`
+	#      the same call succeeds and setup works, which is why this
+	#      reproduces from a script but not from an interactive shell.
+	#   2. `module load frameworks` with NO version silently loads nothing
+	#      and exits 0, so the version must be explicit.
 	local py
 	py="$(command -v python3 2>/dev/null || true)"
 	if [[ -n "${VIRTUAL_ENV:-}" || -n "${CONDA_PREFIX:-}" ]]; then
@@ -1867,6 +1873,12 @@ ezpz_assert_python_env_active() {
 	log_message ERROR "  - frameworks module: ${LMOD_FAMILY_FRAMEWORKS:-<none loaded>}"
 	log_message ERROR "Load a frameworks module FIRST, with an explicit version:"
 	log_message ERROR "    module load frameworks/2026.1.0   # bare 'frameworks' loads nothing"
+	if [[ "$(type -t module 2>/dev/null || true)" == "" ]]; then
+		log_message ERROR "NOTE: \`module\` is not defined in this shell, so any"
+		log_message ERROR "      'module load' inside ezpz was a silent no-op."
+		log_message ERROR "      Run the script with \`bash -l\` (login shell), or"
+		log_message ERROR "      source your lmod init before calling ezpz_setup_env."
+	fi
 	log_message ERROR "Then re-run ezpz_setup_env."
 	return 1
 }

--- a/tests/test_setup_env_no_silent_noop.sh
+++ b/tests/test_setup_env_no_silent_noop.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# test_setup_env_no_silent_noop.sh — regression guard for issue #216.
+#
+# Run from the repo root:
+#   bash tests/test_setup_env_no_silent_noop.sh
+#
+# The bug: on ALCF (scheduler=pbs), ezpz_setup_python did
+#
+#     ezpz_setup_python_alcf
+#     return 0            # <-- unconditional
+#
+# throwing away every failure the ALCF helper detects. ezpz_setup_env saw
+# 0 and printed "[OK] Finished" while NOTHING had been activated, leaving
+# python3 as /usr/bin/python3. The job then died much later with
+# `ModuleNotFoundError: No module named 'torch'`, far from the cause.
+# Reproduced in PBS job 12473470 before fixing.
+#
+# Two properties are guarded here:
+#   1. the pbs/slurm branches PROPAGATE their helper's return code;
+#   2. ezpz_assert_python_env_active fails when nothing is active, so a
+#      silent no-op is caught even if some path wrongly returns 0.
+
+set -u
+unset CDPATH
+
+PASS=0
+FAIL=0
+
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+    G=$'\033[1;32m'; R=$'\033[1;31m'; N=$'\033[0m'
+else
+    G=""; R=""; N=""
+fi
+
+UTILS="${UTILS:-src/ezpz/bin/utils.sh}"
+[[ -f "${UTILS}" ]] || { printf "%sFATAL%s: %s not found (run from repo root)\n" "${R}" "${N}" "${UTILS}" >&2; exit 1; }
+
+FN_FILE="$(mktemp)"
+trap 'rm -f "${FN_FILE}"' EXIT
+awk '/^ezpz_assert_python_env_active\(\) \{/{f=1} f{print} f&&/^\}/{exit}' \
+    "${UTILS}" > "${FN_FILE}"
+grep -q "VIRTUAL_ENV" "${FN_FILE}" || {
+    printf "%sFATAL%s: could not extract ezpz_assert_python_env_active\n" "${R}" "${N}" >&2
+    exit 1
+}
+
+# Echo the next non-blank line after the first line that is exactly a
+# bare call to the given function (leading tabs stripped).
+_line_after() {
+    awk -v pat="$2" '
+        found && NF { gsub(/^[ \t]+/, ""); print; exit }
+        { line=$0; gsub(/^[ \t]+/, "", line); if (line ~ "^" pat) found=1 }
+    ' <<< "$1"
+}
+
+run_test() {
+    local name="$1"; shift
+    if ( "$@" ) >/dev/null 2>&1; then
+        printf "  %s%-58s PASS%s\n" "${G}" "${name}" "${N}"; PASS=$((PASS + 1))
+    else
+        printf "  %s%-58s FAIL%s\n" "${R}" "${name}" "${N}"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- the assertion helper ---------------------------------------------
+
+# Nothing active + system python => must FAIL (this is the #216 state).
+t_nothing_active_fails() {
+    # shellcheck disable=SC1090
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    ! ezpz_assert_python_env_active
+}
+
+t_venv_active_passes() {
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset CONDA_PREFIX
+    VIRTUAL_ENV="/tmp/some/venv"
+    ezpz_assert_python_env_active
+}
+
+t_conda_active_passes() {
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset VIRTUAL_ENV
+    CONDA_PREFIX="/tmp/some/conda"
+    ezpz_assert_python_env_active
+}
+
+# A module-provided python3 (not the system one) is a legitimate setup
+# even with no venv/conda -- e.g. `module load frameworks/2026.1.0`.
+t_module_python_passes() {
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    local d; d="$(mktemp -d)"
+    printf '#!/bin/sh\n' > "${d}/python3"; chmod +x "${d}/python3"
+    PATH="${d}:/usr/bin:/bin"
+    local rc=0; ezpz_assert_python_env_active || rc=1
+    rm -rf "${d}"
+    return "${rc}"
+}
+
+t_error_names_the_cause() {
+    source "${FN_FILE}"
+    local out=""
+    log_message() { out+="$* "; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    ezpz_assert_python_env_active 2>/dev/null || true
+    # Must name the fix, not just report failure.
+    [[ "${out}" == *"frameworks"* && "${out}" == *"module load"* ]]
+}
+
+# --- the call sites ----------------------------------------------------
+
+# Guard the actual bug: the pbs/slurm branches must not hardcode return 0.
+t_pbs_branch_propagates() {
+    local body
+    body="$(awk '/^ezpz_setup_python\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "${UTILS}")"
+    [[ "${body}" == *"ezpz_setup_python_alcf"* ]] || return 1
+    # The old shape was: bare call, then an unconditional `return 0` on
+    # the very next line. Portable check (no grep -P, which is GNU-only).
+    [[ "$(_line_after "${body}" 'ezpz_setup_python_alcf$')" != "return 0" ]]
+}
+
+t_slurm_branch_propagates() {
+    local body
+    body="$(awk '/^ezpz_setup_python\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "${UTILS}")"
+    [[ "$(_line_after "${body}" 'ezpz_setup_python_nersc$')" != "return 0" ]]
+}
+
+t_both_branches_assert() {
+    local body
+    body="$(awk '/^ezpz_setup_python\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "${UTILS}")"
+    [[ "$(grep -c 'ezpz_assert_python_env_active' <<< "${body}")" -ge 2 ]]
+}
+
+printf "\ntest_setup_env_no_silent_noop.sh (issue #216)\n\n"
+run_test "nothing active + system python -> FAILS"      t_nothing_active_fails
+run_test "active venv -> passes"                        t_venv_active_passes
+run_test "active conda -> passes"                       t_conda_active_passes
+run_test "module-provided python3 -> passes"            t_module_python_passes
+run_test "error message names frameworks + module load" t_error_names_the_cause
+run_test "pbs branch propagates its return code"        t_pbs_branch_propagates
+run_test "slurm branch propagates its return code"      t_slurm_branch_propagates
+run_test "both branches assert the post-condition"      t_both_branches_assert
+
+printf "\n  %s%d passed%s, %s%d failed%s\n\n" "${G}" "${PASS}" "${N}" "${R}" "${FAIL}" "${N}"
+[[ "${FAIL}" -eq 0 ]]

--- a/tests/test_setup_env_no_silent_noop.sh
+++ b/tests/test_setup_env_no_silent_noop.sh
@@ -115,6 +115,32 @@ t_error_names_the_cause() {
     [[ "${out}" == *"frameworks"* && "${out}" == *"module load"* ]]
 }
 
+# When `module` is undefined (plain `bash script.sh`), any `module load`
+# inside ezpz is a silent no-op -- the actual trigger in #216. The error
+# must say so, because the user's interactive shell would have worked.
+t_flags_undefined_module() {
+    source "${FN_FILE}"
+    local out=""
+    log_message() { out+="$* "; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    unset -f module 2>/dev/null || true
+    ezpz_assert_python_env_active 2>/dev/null || true
+    [[ "${out}" == *"not defined in this shell"* ]]
+}
+
+# ...but do NOT emit that note when `module` IS available, or it misleads.
+t_no_module_note_when_defined() {
+    source "${FN_FILE}"
+    local out=""
+    log_message() { out+="$* "; }
+    module() { :; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    ezpz_assert_python_env_active 2>/dev/null || true
+    [[ "${out}" != *"not defined in this shell"* ]]
+}
+
 # --- the call sites ----------------------------------------------------
 
 # Guard the actual bug: the pbs/slurm branches must not hardcode return 0.
@@ -145,6 +171,8 @@ run_test "active venv -> passes"                        t_venv_active_passes
 run_test "active conda -> passes"                       t_conda_active_passes
 run_test "module-provided python3 -> passes"            t_module_python_passes
 run_test "error message names frameworks + module load" t_error_names_the_cause
+run_test "undefined module -> error says so"            t_flags_undefined_module
+run_test "defined module -> no misleading note"         t_no_module_note_when_defined
 run_test "pbs branch propagates its return code"        t_pbs_branch_propagates
 run_test "slurm branch propagates its return code"      t_slurm_branch_propagates
 run_test "both branches assert the post-condition"      t_both_branches_assert

--- a/tests/test_setup_env_no_silent_noop.sh
+++ b/tests/test_setup_env_no_silent_noop.sh
@@ -37,8 +37,12 @@ UTILS="${UTILS:-src/ezpz/bin/utils.sh}"
 
 FN_FILE="$(mktemp)"
 trap 'rm -f "${FN_FILE}"' EXIT
-awk '/^ezpz_assert_python_env_active\(\) \{/{f=1} f{print} f&&/^\}/{exit}' \
+awk '/^ezpz_get_python_root\(\) \{/{f=1} f{print} f&&/^\}/{exit}' \
     "${UTILS}" > "${FN_FILE}"
+awk '/^ezpz_assert_python_env_active\(\) \{/{f=1} f{print} f&&/^\}/{exit}' \
+    "${UTILS}" >> "${FN_FILE}"
+grep -q "ezpz_get_python_root" "${FN_FILE}" || {
+    printf "%sFATAL%s: helper deps not extracted\n" "${R}" "${N}" >&2; exit 1; }
 grep -q "VIRTUAL_ENV" "${FN_FILE}" || {
     printf "%sFATAL%s: could not extract ezpz_assert_python_env_active\n" "${R}" "${N}" >&2
     exit 1
@@ -141,6 +145,41 @@ t_no_module_note_when_defined() {
     [[ "${out}" != *"not defined in this shell"* ]]
 }
 
+# A PYTHONUSERBASE-only setup (no venv, no conda) is a SUPPORTED config --
+# ezpz_get_python_root honors it. Rejecting it would turn a working
+# environment into a hard failure. (Codex P2 on #217.)
+t_pythonuserbase_only_passes() {
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT
+    PYTHONUSERBASE="/tmp/some/userbase"
+    PATH="/usr/bin:/bin"
+    ezpz_assert_python_env_active
+}
+
+t_python_root_only_passes() {
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHONUSERBASE
+    PYTHON_ROOT="/tmp/some/root"
+    PATH="/usr/bin:/bin"
+    ezpz_assert_python_env_active
+}
+
+# A shim that RESOLVES to the system interpreter must still be rejected;
+# comparing the unresolved path would accept it. (Codex P2 on #217.)
+t_symlink_to_system_python_fails() {
+    source "${FN_FILE}"
+    log_message() { :; }
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
+    local d; d="$(mktemp -d)"
+    ln -s /usr/bin/python3 "${d}/python3" 2>/dev/null || { rm -rf "${d}"; return 0; }
+    PATH="${d}:/usr/bin:/bin"
+    local rc=0; ezpz_assert_python_env_active || rc=1
+    rm -rf "${d}"
+    [[ "${rc}" -eq 1 ]]
+}
+
 # --- the call sites ----------------------------------------------------
 
 # Guard the actual bug: the pbs/slurm branches must not hardcode return 0.
@@ -171,6 +210,9 @@ run_test "active venv -> passes"                        t_venv_active_passes
 run_test "active conda -> passes"                       t_conda_active_passes
 run_test "module-provided python3 -> passes"            t_module_python_passes
 run_test "error message names frameworks + module load" t_error_names_the_cause
+run_test "PYTHONUSERBASE-only -> passes (supported)"     t_pythonuserbase_only_passes
+run_test "PYTHON_ROOT-only -> passes (supported)"       t_python_root_only_passes
+run_test "shim resolving to system python -> FAILS"     t_symlink_to_system_python_fails
 run_test "undefined module -> error says so"            t_flags_undefined_module
 run_test "defined module -> no misleading note"         t_no_module_note_when_defined
 run_test "pbs branch propagates its return code"        t_pbs_branch_propagates

--- a/tests/test_shell_suites.py
+++ b/tests/test_shell_suites.py
@@ -9,6 +9,7 @@ cover:
   * test_ezpz_setup_venv.sh          — ezpz_setup Flow B auto-venv
   * test_failover_lib.sh             — failover.sh bad-node helpers
   * test_xpu_module_python_guard.sh  — XPU module load must not evict
+  * test_setup_env_no_silent_noop.sh — ezpz_setup_env must not fake success
                                        an active python env
 
 Each is parametrized as its own pytest case so a failure names the
@@ -31,6 +32,7 @@ SHELL_SUITES = [
     "test_ezpz_setup_venv.sh",
     "test_failover_lib.sh",
     "test_xpu_module_python_guard.sh",
+    "test_setup_env_no_silent_noop.sh",
 ]
 
 pytestmark = [


### PR DESCRIPTION
Fixes #216 — `ezpz_setup_env` printed `[✓] Finished` and exited 0 while
activating nothing, leaving `python3` as `/usr/bin/python3`. Jobs then
died much later with `ModuleNotFoundError: No module named 'torch'`, far
from the cause. The reporter lost a full PBS job to it.

## Root cause

`ezpz_setup_python` (utils.sh:1846-1851):

```bash
if [[ "${scheduler_type}" == "pbs" ]]; then
    ezpz_setup_python_alcf
    return 0            # <-- discards the return code
elif [[ "${scheduler_type}" == "slurm" ]]; then
    ezpz_setup_python_nersc
    return 0            # <-- same
```

`ezpz_setup_python_alcf` returns 1 on every failure it detects; the
caller threw that away. Worth noting the `unknown`-scheduler branch just
below already propagated correctly — only the two paths nearly everyone
uses were broken.

## What actually triggers it

Not simply "no frameworks module loaded", as the issue reasonably
assumed. `ezpz_setup_conda_sunspot` (:845) calls `module load
frameworks`; under `bash -l` that succeeds and setup works. Under plain
`bash script.sh` the `module` **function is not defined**, so the call is
a silent no-op. Measured on Sunspot, same job, same code:

```
bash -l  : venv built, torch importable   -> rc 0
bash     : nothing activated              -> rc 1   (was 0 before this fix)
```

That is how the reporter hit it, and why it does not reproduce from an
interactive shell.

## The fix

1. Propagate the return code on both branches.
2. `ezpz_assert_python_env_active` — a post-condition that checks the
   **outcome** instead of trusting the steps: if `python3` is still the
   system interpreter and neither `VIRTUAL_ENV` nor `CONDA_PREFIX` is
   set, fail. This catches a silent no-op even if some future path
   returns 0 wrongly.
3. The error names the cause — including that `module` is undefined in
   this shell when that is true, since "load a frameworks module" is
   useless advice to someone who cannot run `module`. Also flags that a
   bare `module load frameworks` loads nothing (both versions on Sunspot
   are unversioned defaults).

Covers suggestions 1 and 3 from the issue. I did not implement 2
(auto-load a default module) — silently loading a specific framework
version on the user's behalf seemed worse than a clear error.

## Verification

Reproduced first, then fixed, then both directions confirmed in real PBS
jobs (12473470, 12473501):

| case | before | after |
|---|---|---|
| plain `bash`, no module | rc 0, `[✓] Finished`, nothing active | **rc 1** + actionable message |
| `bash -l`, module loaded | works | **still works**, rc 0, torch importable |
| plain `bash`, venv pre-activated | works | **still works**, rc 0 |

10 shell tests in `tests/test_setup_env_no_silent_noop.sh`, registered in
the pytest shell suite, and verified to fail against the pre-fix
`utils.sh`.

One note on the tests: the two call-site guards originally used `grep
-P`, which is GNU-only — on BSD grep it errors, and `!` inverted that
into a **vacuous pass**. They were rewritten with awk and re-checked
against the old code to confirm they actually bite.

## Summary by Sourcery

Make Python environment setup fail fast and explain the cause when activation silently does not occur.

Bug Fixes:
- Prevent `ezpz_setup_env` from reporting success when Python environment activation has not taken effect.
- Propagate PBS and Slurm Python setup failures and provide actionable diagnostics for missing or ineffective framework module loading.

Enhancements:
- Add post-condition validation that recognizes supported Python environments while rejecting system-interpreter no-ops and symlinks resolving to system Python.

Tests:
- Add regression coverage for silent setup no-ops, supported environment configurations, diagnostic messages, and return-code propagation.
- Register the silent-no-op shell regression suite with the pytest shell suite.