### PR TITLE
fix(tests): 2h test suite -> 85s (leaked MASTER_ADDR blocked gloo rendezvous for 30min)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,58 @@ def _suppress_ezpz_loggers():
         logging.getLogger(name).setLevel(logging.CRITICAL)
 
 
+# Rendezvous variables are process-global, and a test that writes them
+# through raw `os.environ` (rather than monkeypatch) leaks them into every
+# test that follows. That is not a cosmetic problem: a later gloo
+# rendezvous inherits the stale value, and if it points somewhere
+# unreachable -- a fabricated `MASTER_ADDR`, a port owned by nothing --
+# the rendezvous does not fail. It blocks until torch's default process
+# group timeout, which is *30 minutes*. A handful of those turned this
+# suite into a 2-hour run in which every individual file still passed in
+# seconds, so nothing looked broken.
+#
+# Two defenses, because the failure is silent and expensive:
+#   * this fixture scrubs the variables between tests, so a leak cannot
+#     reach the next test, and
+#   * `_no_rendezvous_leak` fails the *leaking* test by name, so the
+#     scrub never quietly papers over a real bug.
+_RENDEZVOUS_VARS = ("MASTER_ADDR", "MASTER_PORT")
+
+
+@pytest.fixture(autouse=True)
+def _no_rendezvous_leak():
+    """Fail a test that leaks MASTER_ADDR/MASTER_PORT, and scrub them.
+
+    Use `monkeypatch.setenv`/`delenv` for these in tests. Note that
+    `delenv` alone is not enough when the code under test *writes* the
+    variable: monkeypatch records it as absent, restores nothing, and
+    the write survives teardown.
+    """
+    before = {k: os.environ.get(k) for k in _RENDEZVOUS_VARS}
+    try:
+        yield
+    finally:
+        after = {k: os.environ.get(k) for k in _RENDEZVOUS_VARS}
+        leaked = {
+            k: after[k]
+            for k in _RENDEZVOUS_VARS
+            if after[k] is not None and after[k] != before[k]
+        }
+        # Scrub first: the next test must not inherit this either way.
+        for k, v in before.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        if leaked:
+            raise AssertionError(
+                f"test leaked rendezvous env {leaked} into the process; "
+                "a later gloo rendezvous inherits it and blocks for the "
+                "30-minute default PG timeout. Set these via "
+                "`monkeypatch.setenv` so teardown restores them."
+            )
+
+
 @pytest.fixture
 def mock_dist_env():
     """Mock distributed environment variables."""

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -2784,7 +2784,16 @@ class TestSetupDdpMasterPortBroadcast:
     def _run(self, monkeypatch, rank, bcast):
         import torch
 
+        # `_setup_ddp` writes MASTER_ADDR/MASTER_PORT through raw
+        # `os.environ`, which monkeypatch cannot see and therefore does
+        # not undo. `delenv` only records them as *absent*, so teardown
+        # deletes nothing and the fabricated values below survive into
+        # every later test. A leaked `MASTER_ADDR="host-0.example"` then
+        # sends the next gloo rendezvous to a host that does not resolve,
+        # where it waits out the 30-minute default PG timeout.
+        # `setenv` gives monkeypatch a recorded value to restore.
         for k in ("MASTER_ADDR", "MASTER_PORT"):
+            monkeypatch.setenv(k, os.environ.get(k, ""))
             monkeypatch.delenv(k, raising=False)
         monkeypatch.setenv("RANK", str(rank))
         monkeypatch.setenv("WORLD_SIZE", "2")

--- a/tests/test_tinker_lora.py
+++ b/tests/test_tinker_lora.py
@@ -17,6 +17,7 @@ they skip cleanly where that is unavailable.
 
 from __future__ import annotations
 
+import contextlib
 import os
 
 import pytest
@@ -362,6 +363,29 @@ class TestLoraTpPlan:
 
 
 @pytest.mark.skipif(os.name != "posix", reason="needs a gloo PG")
+# A single-rank gloo PG needs a rendezvous address. Set it EXPLICITLY
+# rather than with `os.environ.setdefault`: setdefault *defers* to
+# whatever is already in the environment, so a value leaked by an
+# earlier test wins. That is how a fabricated `MASTER_ADDR` from a pure
+# unit test reached this rendezvous and blocked it for the 30-minute
+# default PG timeout. Restoring the previous values on the way out
+# keeps this test from becoming the next leaker (tests/conftest.py's
+# `_no_rendezvous_leak` enforces that).
+@contextlib.contextmanager
+def _rendezvous_env(port: str):
+    prev = {k: os.environ.get(k) for k in ("MASTER_ADDR", "MASTER_PORT")}
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = port
+    try:
+        yield
+    finally:
+        for k, v in prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 class TestLoraTpPlanAgainstTorch:
     """The retarget must actually satisfy ``parallelize_module``."""
 
@@ -371,13 +395,14 @@ class TestLoraTpPlanAgainstTorch:
 
         if dist.is_initialized():
             return True
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", "29733")
-        try:
-            dist.init_process_group("gloo", rank=0, world_size=1)
-        except Exception:
-            return False
-        return True
+        with _rendezvous_env("29733"):
+            try:
+                dist.init_process_group(
+                    "gloo", rank=0, world_size=1
+                )
+            except Exception:
+                return False
+            return True
 
     def test_unretargeted_plan_raises_but_retargeted_works(self):
         import torch.distributed as dist
@@ -430,12 +455,13 @@ class TestLoraUnderFSDP2:
 
         if dist.is_initialized():
             pytest.skip("PG already initialized by another test")
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", "29734")
-        try:
-            dist.init_process_group("gloo", rank=0, world_size=1)
-        except Exception:
-            pytest.skip("could not init gloo PG")
+        with _rendezvous_env("29734"):
+            try:
+                dist.init_process_group(
+                    "gloo", rank=0, world_size=1
+                )
+            except Exception:
+                pytest.skip("could not init gloo PG")
         try:
             from torch.distributed.device_mesh import init_device_mesh
             from torch.distributed.fsdp import fully_shard

--- a/tests/test_tinker_lora.py
+++ b/tests/test_tinker_lora.py
@@ -362,7 +362,6 @@ class TestLoraTpPlan:
         assert all(k.endswith((".base", ".A", ".B")) for k in plan)
 
 
-@pytest.mark.skipif(os.name != "posix", reason="needs a gloo PG")
 # A single-rank gloo PG needs a rendezvous address. Set it EXPLICITLY
 # rather than with `os.environ.setdefault`: setdefault *defers* to
 # whatever is already in the environment, so a value leaked by an
@@ -386,6 +385,7 @@ def _rendezvous_env(port: str):
                 os.environ[k] = v
 
 
+@pytest.mark.skipif(os.name != "posix", reason="needs a gloo PG")
 class TestLoraTpPlanAgainstTorch:
     """The retarget must actually satisfy ``parallelize_module``."""
 


### PR DESCRIPTION
## What

The pytest suite took **~2 hours** (2h03m in CI). This brings it to **~85 seconds**, with all 1566 tests still passing.

Not a speed optimization — no test was made to do less work. A real bug was making tests wait on a rendezvous that could never succeed.

## Root cause

`TestSetupDdpMasterPortBroadcast` is a pure unit test for the `MASTER_PORT` broadcast guard. It feeds in a **fabricated** hostname, `host-0.example`, and that value was escaping into the process environment for the rest of the session.

The escape hatch is a monkeypatch subtlety:

```python
monkeypatch.delenv("MASTER_ADDR", raising=False)   # records it as ABSENT
...
dist._setup_ddp(...)          # writes MASTER_ADDR via raw os.environ
```

`delenv` records the variable as absent, so teardown *deletes* it and restores nothing. The code under test then **writes** the variable through raw `os.environ` — a mutation monkeypatch never saw and therefore never undoes. The fabricated value survived teardown.

Downstream, `test_tinker_lora.py` set its rendezvous with `os.environ.setdefault("MASTER_ADDR", "127.0.0.1")`. `setdefault` *defers* to what is already there, so it inherited `host-0.example` — a host that does not resolve.

A rendezvous to an unresolvable host **does not fail**. It blocks until torch's default process-group timeout:

```
default_pg_timeout = 0:30:00
```

A few of those is two hours.

## Why it stayed hidden

Every symptom pointed away from the cause:

- **Every test file passes in seconds individually** — the slowest is 27s, and all "slow" files together total ~94s. Nothing looks broken.
- **It only appears in combination.** `test_tinker_lora.py` takes 5s alone; after the preceding 63 files it was still hung at 4+ minutes.
- **It is non-deterministic.** Different tests hang on different runs, since `pytest-randomly` shuffles order by default. Reproducing it required `-p no:randomly`.
- **CI was green.** The suite passed — it just took 2h03m.

## Evidence

Instrumenting the environment immediately before the hanging test:

```
[PROBE] test_unretargeted_plan_raises_but_retargeted_works:
        MASTER_PORT='29500' MASTER_ADDR='host-0.example' is_initialized=False
```

Counterfactual — scrubbing only these two variables between tests, changing nothing else:

| | before | after |
|---|---|---|
| the 64-file combination that hung | hung indefinitely | **64s** |
| full suite | ~7200s | **88s** |

## The fix

Three commits, each independently verifiable:

1. **`e05547b`** — `monkeypatch.setenv` before `delenv` in `_run`, giving monkeypatch a recorded value to restore. Fixes the leak at its source.
2. **`7a55fbe`** — replaces `setdefault` with an explicit, self-restoring rendezvous context manager in both single-rank PG helpers. `setdefault` is exactly the wrong call here: it defers to leaked state.
3. **`4eed155`** — an autouse fixture that scrubs the variables between tests **and fails the leaking test by name**.

Commit 3 is deliberately not just a scrub. Scrubbing alone would fix the runtime while making the next leak invisible — and this bug class is expensive precisely because it is silent. The guard was verified to work by reverting commit 1 and confirming it fails the leaking test:

```
ERROR tests/test_distributed.py::TestSetupDdpMasterPortBroadcast::test_working_broadcast_is_unaffected
E  AssertionError: test leaked rendezvous env {'MASTER_ADDR': 'host-0.example', ...}
```

## Verification

- Full suite, sequential order: **1566 passed, 11 skipped — 84s**
- Full suite, randomized order (as CI runs it): **1566 passed, 11 skipped — 80s**
- `ruff check`: clean

Note the diffs are minimal on purpose. `ruff format` wants to reformat unrelated code in these files (164 lines of churn in `test_distributed.py` for a 4-line fix); that drift **already exists on `main`** and CI does not run `ruff format --check`, so it is left alone rather than burying the fix.

## Scope

Test-infrastructure only — no `src/` changes, so no runtime behavior changes.

Found while investigating #216 (PR #217); kept separate since it is unrelated to that shell fix.

## Summary by Sourcery

Prevent test-wide rendezvous environment leaks from turning the pytest suite into multi-hour runs.

Bug Fixes:
- Prevent leaked distributed rendezvous environment variables from causing later tests to block on unreachable gloo hosts.
- Ensure single-rank gloo tests explicitly configure and restore their rendezvous environment instead of inheriting stale process state.

Enhancements:
- Add an autouse test guard that restores rendezvous variables between tests and identifies the test responsible for any leak.

Tests:
- Harden distributed test isolation so rendezvous environment leaks fail immediately while still being scrubbed for subsequent tests.