### PR TITLE
feat(lora): HuggingFace model support (--lora-rank was silently ignored for HF)

### DIFF
--- a/docs/guides/finetuning.md
+++ b/docs/guides/finetuning.md
@@ -73,6 +73,46 @@ ezpz launch --nhosts 4 -- python3 -m ezpz.examples.fsdp_tp \
     runs a real 2-rank gloo mesh and gates on tp=2 matching tp=1
     numerically — a layout bug can run cleanly and still be wrong.
 
+## HuggingFace models
+
+The same flags work on HF Llama-family models — Llama, Mistral, Qwen2, Gemma:
+
+```bash
+python3 -m ezpz.launch --np 12 -- \
+  python3 -m ezpz.examples.fsdp_tp \
+    --model Qwen/Qwen3-0.6B --lora-rank 16 --dataset random
+```
+
+`LoraConfig` gates by *role* (`train_attn` / `train_mlp` / `train_unembed`)
+rather than by name, because the roles are stable across model families even
+when the spellings are not. `target_names()` emits both vocabularies at once:
+
+| role | native | HuggingFace |
+| --- | --- | --- |
+| `attn` | `wq` `wk` `wv` `wo` | `q_proj` `k_proj` `v_proj` `o_proj` |
+| `mlp` | `w1` `w2` `w3` | `gate_proj` `up_proj` `down_proj` |
+| `unembed` | `output` | `lm_head` |
+
+Emitting both is safe rather than sloppy: `apply_lora` wraps a child only
+when its attribute name is in the target set **and** it is an `nn.Linear`, so
+a spelling the model does not use never fires. No architecture sniffing, and
+nothing to mis-detect.
+
+Two things to know:
+
+- **HF runs are FSDP-only.** The HF path forces `--tp 1` (the TP plan is
+  written against the native module names), so LoRA composes with FSDP2 and
+  HSDP there, not with tensor parallelism.
+- **Tied embeddings are fine.** When `tie_word_embeddings=True`,
+  `lm_head.weight` *is* `embed_tokens.weight`; the adapter is additive and
+  the shared tensor stays frozen, so `--lora-target unembed` does not
+  accidentally thaw the input embedding.
+
+If a requested role adapts nothing, the run **fails at setup** rather than
+training. That matters more than it sounds: a LoRA request that silently
+falls back to full fine-tuning produces a plausible loss curve, a normal-looking
+log, and a checkpoint that is quietly 100× larger than intended.
+
 ## Why LoRA starts as a no-op
 
 `B` is zero-initialized, so `y = Wx + (alpha/r)·B(A(x))` equals `Wx` exactly
@@ -191,5 +231,9 @@ optimizer holds state for.
   `ezpz.examples.generate` against a saved checkpoint; the in-process path
   lands with the RL loop, which is the first thing that needs a real
   train→sample handoff.
-- **HF models.** `apply_lora` targets the native `Transformer`; the HF branch
-  already forces `tp=1` and takes a separate sharding path.
+- **Fused-QKV architectures** (GPT-2, Falcon, GPT-NeoX, MPT). GPT-2's
+  projections are `transformers.pytorch_utils.Conv1D`, which is not an
+  `nn.Linear` subclass, so `apply_lora` cannot wrap them; Falcon and GPT-NeoX
+  pack q/k/v into a single `query_key_value` that would have to be split
+  before an adapter could target one projection. These fail with a named
+  error rather than adapting nothing.

--- a/docs/guides/finetuning.md
+++ b/docs/guides/finetuning.md
@@ -2,8 +2,9 @@
 
 `ezpz.tinker` gives you two things:
 
-- **LoRA adapters** for the native `Transformer`, composable with FSDP2 and
-  the async DCP checkpoint layer.
+- **LoRA adapters** for the native `Transformer` *and* HuggingFace
+  Llama-family models, composable with FSDP2 and the async DCP checkpoint
+  layer.
 - **A decoupled training step** — `forward_backward` and `optim_step` as
   separate calls — shaped after
   [Tinker](https://tinker-docs.thinkingmachines.ai/), but running in your own
@@ -26,7 +27,7 @@ factor.
 | `--lora-rank` | `0` (off) | inner dimension `r`; `0` means full fine-tuning |
 | `--lora-alpha` | `= rank` | update is scaled by `alpha/rank` |
 | `--lora-dropout` | `0.0` | dropout on the adapter branch input |
-| `--lora-target` | `attn,mlp` | `attn` (wq/wk/wv/wo), `mlp` (w1/w2/w3), `unembed` |
+| `--lora-target` | `attn,mlp` | roles to adapt: `attn`, `mlp`, `unembed` — see the [spelling table](#huggingface-models) for what each covers on native vs HF models |
 
 LoRA composes with FSDP2, HSDP and tensor parallelism. At `tp > 1` the
 adapters are sharded alongside the weights they wrap:
@@ -75,13 +76,48 @@ ezpz launch --nhosts 4 -- python3 -m ezpz.examples.fsdp_tp \
 
 ## HuggingFace models
 
-The same flags work on HF Llama-family models — Llama, Mistral, Qwen2, Gemma:
+The same flags work on HF Llama-family models — Llama, Mistral, Qwen2, Gemma.
+Any `--model` containing a `/` is treated as a hub repo id:
 
 ```bash
 python3 -m ezpz.launch --np 12 -- \
   python3 -m ezpz.examples.fsdp_tp \
-    --model Qwen/Qwen3-0.6B --lora-rank 16 --dataset random
+    --model Qwen/Qwen3-0.6B --lora-rank 16 --dataset random \
+    --train-iters 5 --batch-size 1 --seq-len 512
 ```
+
+The run tells you what it adapted, which is the number to check first:
+
+```text
+LoRA: 196 adapters (rank=16, targets=attn,mlp); 10,092,544 trainable of 606,142,464
+```
+
+1.7% trainable — that line is the difference between a LoRA run and a full
+fine-tune wearing its clothes. (Measured on Sunspot, 12 ranks; Aurora gives
+the identical count.)
+
+To drive it from Python instead — any HF causal-LM, no ezpz model code:
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from ezpz.tinker import LoraConfig, apply_lora, adapter_state_dict
+from ezpz.tinker.lora import iter_lora_modules
+
+model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B")
+model = apply_lora(model, LoraConfig(rank=16))       # attn + mlp by default
+
+n = len(list(iter_lora_modules(model)))              # 196
+trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+# Save just the adapters: 60x smaller than the full model
+# (~40 MB vs ~2.4 GB in fp32; ~20 MB vs ~1.2 GB in bf16).
+torch.save(adapter_state_dict(model), "adapters.pt")
+```
+
+`apply_lora` **raises** if the target names match nothing, so an
+unsupported architecture fails immediately rather than training a
+full fine-tune that looks like LoRA.
 
 `LoraConfig` gates by *role* (`train_attn` / `train_mlp` / `train_unembed`)
 rather than by name, because the roles are stable across model families even
@@ -111,7 +147,8 @@ Two things to know:
 If a requested role adapts nothing, the run **fails at setup** rather than
 training. That matters more than it sounds: a LoRA request that silently
 falls back to full fine-tuning produces a plausible loss curve, a normal-looking
-log, and a checkpoint that is quietly 100× larger than intended.
+log, and a checkpoint tens of times larger than intended (60× for the
+Qwen3-0.6B run above).
 
 ## Why LoRA starts as a no-op
 

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -2827,15 +2827,30 @@ def train(
         # the shared weight stays frozen. Verified in
         # tests/test_tinker_lora_hf.py.)
         _applied = [n for n, _ in _lora.iter_lora_modules(model)]
-        if "unembed" in _targets and not any(
-            n.rsplit(".", 1)[-1] in _lora.UNEMBED_TARGETS for n in _applied
-        ):
+        _leaves = {n.rsplit(".", 1)[-1] for n in _applied}
+        _role_names = {
+            "attn": set(_lora.ATTN_TARGETS) | set(_lora.HF_ATTN_TARGETS),
+            "mlp": set(_lora.MLP_TARGETS) | set(_lora.HF_MLP_TARGETS),
+            "unembed": set(_lora.UNEMBED_TARGETS),
+        }
+        _empty = sorted(
+            role
+            for role in _targets
+            if not (_leaves & _role_names.get(role, set()))
+        )
+        if _empty:
             raise SystemExit(
-                "--lora-target includes 'unembed' but no unembedding "
-                f"projection was adapted on {type(model).__name__}: "
-                f"expected one of {list(_lora.UNEMBED_TARGETS)} as a "
-                "top-level nn.Linear. Drop 'unembed' from --lora-target, "
-                "or use a model that exposes a separate output head."
+                f"--lora-target requested {_empty} but no matching "
+                f"projection was adapted on {type(model).__name__}. "
+                f"Adapted instead: {sorted(_leaves) or 'nothing'}. "
+                "Expected attribute names: "
+                + "; ".join(
+                    f"{r}={sorted(_role_names[r])}"
+                    for r in _empty
+                    if r in _role_names
+                )
+                + ". Fused-QKV architectures (GPT-2, Falcon, GPT-NeoX) pack "
+                "q/k/v into one tensor or use Conv1D and are not supported."
             )
         logger.info(
             "LoRA: %d adapters (rank=%d, targets=%s); %s trainable of %s",

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -1483,8 +1483,12 @@ def parse_args(argv: Optional[list[str]] = None):
             "fine-tuning). Freezes the base weights and trains a low-rank "
             "update per targeted projection, so only ~rank/dim of the "
             "parameters are trainable and checkpoints shrink by roughly the "
-            "same factor. Composes with FSDP2, TP and meta-init. Native "
-            "models only -- the HF path is unaffected."
+            "same factor. Composes with FSDP2, TP and meta-init. Works on "
+            "native models and on HF Llama-family models (Llama, Mistral, "
+            "Qwen2, Gemma), which are FSDP-only since the HF path forces "
+            "--tp 1. Fused-QKV architectures (GPT-2, Falcon, GPT-NeoX) are "
+            "not supported and fail with a named error rather than "
+            "silently training nothing."
         ),
     )
     parser.add_argument(
@@ -2782,32 +2786,65 @@ def train(
                 model = Transformer.from_model_args(config)
         else:
             model = Transformer.from_model_args(config)
-        # LoRA must be applied BEFORE parallelize(): the TP plan and
-        # fully_shard both need to see the final module tree. Under
-        # meta-init the adapters are built on `meta` too and materialized
-        # by the same to_empty()/init_weights() pass.
-        if getattr(args, "lora_rank", 0) > 0:
-            _targets = {
-                t.strip() for t in str(args.lora_target).split(",") if t.strip()
-            }
-            _unknown = _targets - {"attn", "mlp", "unembed"}
-            if _unknown:
-                raise SystemExit(
-                    f"--lora-target: unknown {sorted(_unknown)}; "
-                    "expected any of attn, mlp, unembed"
-                )
-            model = _lora.apply_lora(
-                model,
-                _lora.LoraConfig(
-                    rank=args.lora_rank,
-                    alpha=args.lora_alpha,
-                    dropout=args.lora_dropout,
-                    train_attn="attn" in _targets,
-                    train_mlp="mlp" in _targets,
-                    train_unembed="unembed" in _targets,
-                    seed=args.seed,
-                ),
+    # LoRA must be applied BEFORE parallelize()/fully_shard(): both need to
+    # see the final module tree. Under meta-init the adapters are built on
+    # `meta` too and materialized by the same to_empty()/init_weights()
+    # pass (native path only -- HF never meta-inits).
+    #
+    # This runs for BOTH paths. It used to live inside the native `else:`
+    # above, which meant `--lora-rank 16` on an HF model was accepted,
+    # logged, and then silently ignored: a full fine-tune wearing a LoRA
+    # run's clothes.
+    if getattr(args, "lora_rank", 0) > 0:
+        _targets = {
+            t.strip() for t in str(args.lora_target).split(",") if t.strip()
+        }
+        _unknown = _targets - {"attn", "mlp", "unembed"}
+        if _unknown:
+            raise SystemExit(
+                f"--lora-target: unknown {sorted(_unknown)}; "
+                "expected any of attn, mlp, unembed"
             )
+        model = _lora.apply_lora(
+            model,
+            _lora.LoraConfig(
+                rank=args.lora_rank,
+                alpha=args.lora_alpha,
+                dropout=args.lora_dropout,
+                train_attn="attn" in _targets,
+                train_mlp="mlp" in _targets,
+                train_unembed="unembed" in _targets,
+                seed=args.seed,
+            ),
+        )
+        # `apply_lora` raises when it matches NOTHING, but a PARTIAL match
+        # is the more dangerous case: it returns happily having adapted
+        # less than was asked for. Assert on the finished tree so a
+        # requested role cannot quietly become a no-op.
+        #
+        # (Tied embeddings are fine and deliberately not special-cased:
+        # `lm_head` is still an nn.Linear, the adapter is additive, and
+        # the shared weight stays frozen. Verified in
+        # tests/test_tinker_lora_hf.py.)
+        _applied = [n for n, _ in _lora.iter_lora_modules(model)]
+        if "unembed" in _targets and not any(
+            n.rsplit(".", 1)[-1] in _lora.UNEMBED_TARGETS for n in _applied
+        ):
+            raise SystemExit(
+                "--lora-target includes 'unembed' but no unembedding "
+                f"projection was adapted on {type(model).__name__}: "
+                f"expected one of {list(_lora.UNEMBED_TARGETS)} as a "
+                "top-level nn.Linear. Drop 'unembed' from --lora-target, "
+                "or use a model that exposes a separate output head."
+            )
+        logger.info(
+            "LoRA: %d adapters (rank=%d, targets=%s); %s trainable of %s",
+            len(_applied),
+            args.lora_rank,
+            ",".join(sorted(_targets)),
+            f"{sum(p.numel() for p in model.parameters() if p.requires_grad):,}",
+            f"{sum(p.numel() for p in model.parameters()):,}",
+        )
     mstr = summarize_model(
         model,
         verbose=False,

--- a/src/ezpz/tinker/lora.py
+++ b/src/ezpz/tinker/lora.py
@@ -56,6 +56,27 @@ logger = ezpz.get_logger(__name__)
 ATTN_TARGETS: tuple[str, ...] = ("wq", "wk", "wv", "wo")
 MLP_TARGETS: tuple[str, ...] = ("w1", "w2", "w3")
 
+# The same roles as spelled by HuggingFace's Llama family (Llama, Mistral,
+# Qwen2, Gemma, ...). `target_names()` emits both sets rather than sniffing
+# the architecture: `apply_lora` wraps a child only when its *attribute
+# name* is in the target set AND it is an `nn.Linear`, so a spelling that
+# does not exist on the model simply never fires. A union therefore needs
+# no detection heuristic and cannot mis-detect.
+#
+# Fused-QKV families are deliberately absent. GPT-2 projections are
+# `transformers.pytorch_utils.Conv1D`, which is NOT an `nn.Linear`
+# subclass, so `apply_lora` skips them whatever they are called; Falcon
+# and GPT-NeoX pack qkv into one `query_key_value` that would have to be
+# split before an adapter could target a single projection. Naming them
+# here would produce silent no-ops, so the guard in `fsdp_tp` reports them
+# as unsupported instead.
+HF_ATTN_TARGETS: tuple[str, ...] = ("q_proj", "k_proj", "v_proj", "o_proj")
+HF_MLP_TARGETS: tuple[str, ...] = ("gate_proj", "up_proj", "down_proj")
+
+# Root-level unembedding projection: `output` on ezpz.models.llama,
+# `lm_head` on HF `*ForCausalLM`. Same role, same shape, same depth.
+UNEMBED_TARGETS: tuple[str, ...] = ("output", "lm_head")
+
 
 @dataclass
 class LoraConfig:
@@ -97,11 +118,19 @@ class LoraConfig:
             )
 
     def target_names(self) -> tuple[str, ...]:
+        """Attribute names to adapt, in both native and HF spellings.
+
+        Emitting both is safe because `apply_lora` matches on the
+        attribute name AND requires an `nn.Linear`, so the spellings a
+        given model does not use never fire.
+        """
         names: list[str] = []
         if self.train_attn:
             names.extend(ATTN_TARGETS)
+            names.extend(HF_ATTN_TARGETS)
         if self.train_mlp:
             names.extend(MLP_TARGETS)
+            names.extend(HF_MLP_TARGETS)
         names.extend(self.extra_targets)
         return tuple(dict.fromkeys(names))  # dedupe, keep order
 
@@ -255,17 +284,29 @@ def apply_lora(
             wrapped.append(f"{mod_name}.{attr}" if mod_name else attr)
 
     if cfg.train_unembed:
-        out = getattr(model, "output", None)
-        if isinstance(out, nn.Linear):
-            model.output = LoRALinear(  # type: ignore[assignment]
-                out, cfg.rank, cfg.alpha, cfg.dropout
-            )
-            wrapped.append("output")
+        # Write back to the attribute we actually matched. Hardcoding
+        # `model.output = ...` on an HF model creates a NEW attribute and
+        # leaves `lm_head` a plain Linear, so the forward path never sees
+        # the adapter -- a silent no-op that still reports success.
+        for attr in UNEMBED_TARGETS:
+            out = getattr(model, attr, None)
+            if isinstance(out, nn.Linear):
+                setattr(
+                    model,
+                    attr,
+                    LoRALinear(out, cfg.rank, cfg.alpha, cfg.dropout),
+                )
+                wrapped.append(attr)
+                break
 
     if not wrapped:
         raise RuntimeError(
-            f"apply_lora matched no modules (targets={sorted(targets)}). "
-            "Is this an ezpz.models.llama Transformer?"
+            f"apply_lora matched no modules (targets={sorted(targets)}) "
+            f"on {type(model).__name__}. Supported: ezpz.models.llama "
+            "Transformer, and HF Llama-family models (Llama, Mistral, "
+            "Qwen2, Gemma). Fused-QKV architectures (GPT-2, Falcon, "
+            "GPT-NeoX) are not supported: their projections are either "
+            "not nn.Linear or pack q/k/v into one tensor."
         )
 
     n_train = sum(p.numel() for p in model.parameters() if p.requires_grad)
@@ -323,7 +364,16 @@ def lora_tp_plan(
     Keys naming something other than a wrapped target -- ``norm``,
     ``PrepareModuleInput`` -- pass through untouched either way.
     """
-    adapted = set(ATTN_TARGETS) | set(MLP_TARGETS) | {"output"}
+    # Both spellings, so this table cannot drift from `target_names()`.
+    # Inert for HF today (the HF path forces tp=1 and never builds a TP
+    # plan), but wrong-by-omission the moment that changes.
+    adapted = (
+        set(ATTN_TARGETS)
+        | set(MLP_TARGETS)
+        | set(HF_ATTN_TARGETS)
+        | set(HF_MLP_TARGETS)
+        | set(UNEMBED_TARGETS)
+    )
     out: dict[str, Any] = {}
     for key, style in base_plan.items():
         leaf = key.rsplit(".", 1)[-1]

--- a/src/ezpz/tinker/lora.py
+++ b/src/ezpz/tinker/lora.py
@@ -1,4 +1,5 @@
-"""LoRA adapters for :mod:`ezpz.models.llama`, composable with FSDP2 + TP.
+"""LoRA adapters for :mod:`ezpz.models.llama` and HuggingFace Llama-family
+models (Llama, Mistral, Qwen2, Gemma), composable with FSDP2 + TP.
 
 Low-Rank Adaptation freezes the pretrained weight ``W`` and learns a
 low-rank update, so ``y = Wx + (alpha/r)·B(A(x))`` with
@@ -118,11 +119,17 @@ class LoraConfig:
             )
 
     def target_names(self) -> tuple[str, ...]:
-        """Attribute names to adapt, in both native and HF spellings.
+        """Submodule attribute names to adapt, native and HF spellings.
 
         Emitting both is safe because `apply_lora` matches on the
         attribute name AND requires an `nn.Linear`, so the spellings a
         given model does not use never fire.
+
+        Covers `train_attn` and `train_mlp` only. `train_unembed` is
+        deliberately absent: `apply_lora` resolves it against the ROOT
+        module (`UNEMBED_TARGETS`) rather than every submodule, so
+        including `output`/`lm_head` here would wrap any nested child
+        that happened to share the name.
         """
         names: list[str] = []
         if self.train_attn:

--- a/tests/test_fsdp_tp_lora_flags.py
+++ b/tests/test_fsdp_tp_lora_flags.py
@@ -174,7 +174,58 @@ class TestHfPathReachesLora:
             "nothing inspects the finished tree, so a partially-applied "
             "LoRA request would pass silently"
         )
-        assert "UNEMBED_TARGETS" in src
+
+    def test_every_role_is_validated_not_just_unembed(self):
+        """The guard must cover attn and mlp too, not only unembed.
+
+        An earlier version checked `unembed` alone, so a model that
+        matched `attn` but had no recognizable MLP passed with fewer
+        adapters than requested -- the exact silent-partial-application
+        this guard exists to prevent.
+        """
+        src = self._train_src()
+        for role in ("ATTN_TARGETS", "MLP_TARGETS", "UNEMBED_TARGETS"):
+            assert role in src, f"the guard ignores {role}"
+        assert "HF_ATTN_TARGETS" in src and "HF_MLP_TARGETS" in src, (
+            "the guard checks only native spellings, so every HF model "
+            "would look like an empty role"
+        )
+
+    def test_partial_role_match_is_detected(self):
+        """Behavioural check of the guard's predicate, not its text.
+
+        Builds a model with attention projections but no MLP, asks for
+        both roles, and confirms the empty role is identified.
+        """
+        torch = pytest.importorskip("torch")
+        nn = torch.nn
+        from ezpz.tinker import lora as _lora
+
+        class Attn(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q_proj = nn.Linear(8, 8)
+                self.k_proj = nn.Linear(8, 8)
+
+        model = nn.Module()
+        model.layers = nn.ModuleList([Attn()])
+        model = _lora.apply_lora(
+            model,
+            _lora.LoraConfig(rank=2, train_attn=True, train_mlp=True),
+            verbose=False,
+        )
+        leaves = {
+            n.rsplit(".", 1)[-1] for n, _ in _lora.iter_lora_modules(model)
+        }
+        roles = {
+            "attn": set(_lora.ATTN_TARGETS) | set(_lora.HF_ATTN_TARGETS),
+            "mlp": set(_lora.MLP_TARGETS) | set(_lora.HF_MLP_TARGETS),
+        }
+        empty = sorted(r for r in roles if not (leaves & roles[r]))
+        assert empty == ["mlp"], (
+            f"expected 'mlp' to be flagged as unmatched, got {empty}; "
+            "apply_lora does NOT raise here because attn matched"
+        )
 
     def test_help_text_no_longer_claims_native_only(self):
         m = _fsdp_tp()

--- a/tests/test_fsdp_tp_lora_flags.py
+++ b/tests/test_fsdp_tp_lora_flags.py
@@ -137,6 +137,54 @@ class TestTpSupported:
             )
 
 
+class TestHfPathReachesLora:
+    """`--lora-rank` must not be silently ignored for HF models.
+
+    The LoRA block used to live inside the native model's ``else:``
+    branch, so an HF run accepted the flag, logged nothing unusual, and
+    full fine-tuned. Source-level checks because instantiating an HF
+    model here would need weights.
+    """
+
+    @staticmethod
+    def _train_src():
+        return __import__("inspect").getsource(_fsdp_tp().train)
+
+    def test_lora_block_is_not_nested_in_the_native_branch(self):
+        """`if args.lora_rank` must sit at function level.
+
+        Its indentation is the whole bug: one level deeper and only
+        native models reach it.
+        """
+        import re
+
+        src = self._train_src()
+        m = re.search(r'^(\s*)if getattr\(args, "lora_rank"', src, re.M)
+        assert m, "the --lora-rank block moved or was renamed"
+        assert len(m.group(1)) == 4, (
+            f"the LoRA block is indented {len(m.group(1))} spaces, so it "
+            "is nested inside a branch; at function level it must be 4, "
+            "or HF models silently skip LoRA again"
+        )
+
+    def test_partial_application_is_refused(self):
+        """A requested role that adapts nothing must fail loudly."""
+        src = self._train_src()
+        assert "iter_lora_modules(model)" in src, (
+            "nothing inspects the finished tree, so a partially-applied "
+            "LoRA request would pass silently"
+        )
+        assert "UNEMBED_TARGETS" in src
+
+    def test_help_text_no_longer_claims_native_only(self):
+        m = _fsdp_tp()
+        p = m.build_parser() if hasattr(m, "build_parser") else None
+        help_txt = p.format_help() if p else __import__("inspect").getsource(m)
+        assert "Native models only" not in help_txt, (
+            "--lora-rank still advertises itself as native-only"
+        )
+
+
 class TestTargetValidation:
     """An unknown --lora-target must fail loudly at setup, not silently
     adapt nothing (which would look like LoRA 'not working')."""

--- a/tests/test_tinker_lora.py
+++ b/tests/test_tinker_lora.py
@@ -27,7 +27,10 @@ nn = pytest.importorskip("torch.nn")
 
 from ezpz.tinker.lora import (  # noqa: E402
     ATTN_TARGETS,
+    HF_ATTN_TARGETS,
+    HF_MLP_TARGETS,
     MLP_TARGETS,
+    UNEMBED_TARGETS,
     LoraConfig,
     LoRALinear,
     adapter_state_dict,
@@ -131,12 +134,30 @@ class TestLoRALinear:
 
 class TestLoraConfig:
     def test_target_names_by_role(self):
-        assert set(LoraConfig(train_mlp=False).target_names()) == set(
-            ATTN_TARGETS
-        )
-        assert set(LoraConfig(train_attn=False).target_names()) == set(
-            MLP_TARGETS
-        )
+        """Each role emits BOTH spellings, and only that role's names.
+
+        The exact-equality assertions matter in both directions: a role
+        must not leak the other role's names (which would adapt more
+        than asked), and must not drop the HF spellings (which would
+        silently adapt nothing on an HF model).
+        """
+        attn = set(LoraConfig(train_mlp=False).target_names())
+        assert attn == set(ATTN_TARGETS) | set(HF_ATTN_TARGETS)
+
+        mlp = set(LoraConfig(train_attn=False).target_names())
+        assert mlp == set(MLP_TARGETS) | set(HF_MLP_TARGETS)
+
+        assert not attn & mlp, "roles must not overlap"
+
+    def test_unembed_is_not_in_target_names(self):
+        """`train_unembed` is handled separately, in `apply_lora`.
+
+        It walks `UNEMBED_TARGETS` against the ROOT module rather than
+        every submodule, so leaking `output`/`lm_head` into the generic
+        name set would wrap unintended children.
+        """
+        names = set(LoraConfig(train_unembed=True).target_names())
+        assert not names & set(UNEMBED_TARGETS)
 
     def test_rejects_bad_rank(self):
         with pytest.raises(ValueError, match="rank must be > 0"):

--- a/tests/test_tinker_lora_hf.py
+++ b/tests/test_tinker_lora_hf.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import pytest
 
 torch = pytest.importorskip("torch")
-transformers = pytest.importorskip("transformers")
+pytest.importorskip("transformers")
 
 import torch.nn as nn  # noqa: E402
 

--- a/tests/test_tinker_lora_hf.py
+++ b/tests/test_tinker_lora_hf.py
@@ -1,0 +1,214 @@
+"""LoRA on HuggingFace models.
+
+Why this file exists: `--lora-rank 16 --model meta-llama/Llama-3.2-1B`
+used to be accepted, logged, and then silently ignored -- a full
+fine-tune that looked exactly like a LoRA run. Two separate causes:
+
+1. The `apply_lora` call in ``fsdp_tp.train`` sat inside the native
+   model's ``else:`` branch, so the HF path never reached it.
+2. The target names were hardcoded to ``ezpz.models.llama``
+   (``wq/wk/wv/wo``, ``w1/w2/w3``). HF Llama spells the same roles
+   ``q_proj/k_proj/v_proj/o_proj`` and ``gate_proj/up_proj/down_proj``,
+   with ``lm_head`` for the unembedding. Zero overlap, so even a
+   reachable call would have matched nothing.
+
+The models here are built from an in-memory ``LlamaConfig`` rather than
+loaded from disk. A ``tiny-random-llama-2/`` directory exists in the
+working tree but is **not tracked by git**, so a test depending on it
+would pass locally and fail on a clean clone.
+
+The gate throughout is that every trainable parameter receives a
+gradient after a real forward/backward. "It ran without raising" is not
+the bar: a LoRA branch that is detached from the graph runs perfectly
+well and trains nothing, which is the exact failure being fixed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+transformers = pytest.importorskip("transformers")
+
+import torch.nn as nn  # noqa: E402
+
+from ezpz.tinker.lora import (  # noqa: E402
+    LoraConfig,
+    UNEMBED_TARGETS,
+    apply_lora,
+    iter_lora_modules,
+)
+
+RANK = 4
+
+
+def _hf_llama(*, tie: bool = False, vocab: int = 64):
+    """A 2-layer HF Llama small enough to train in a unit test."""
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    cfg = LlamaConfig(
+        vocab_size=vocab,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+        tie_word_embeddings=tie,
+    )
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(cfg)
+    if tie:
+        model.tie_weights()
+    return model
+
+
+def _fwd_bwd(model, vocab: int = 64):
+    """Run one real step; return (n_trainable, n_with_grad)."""
+    out = model(input_ids=torch.randint(0, vocab, (1, 8))).logits
+    out.float().pow(2).mean().backward()
+    trainable = [p for p in model.parameters() if p.requires_grad]
+    return len(trainable), sum(p.grad is not None for p in trainable)
+
+
+class TestHfAttnMlp:
+    def test_wraps_hf_projections(self):
+        model = apply_lora(_hf_llama(), LoraConfig(rank=RANK), verbose=False)
+        leaves = {n.rsplit(".", 1)[-1] for n, _ in iter_lora_modules(model)}
+        assert leaves == {
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        }
+
+    def test_every_adapter_receives_a_gradient(self):
+        """The real gate: a detached adapter runs fine and learns nothing."""
+        model = apply_lora(_hf_llama(), LoraConfig(rank=RANK), verbose=False)
+        n_train, n_grad = _fwd_bwd(model)
+        assert n_train > 0, "nothing trainable -- the test proves nothing"
+        assert n_grad == n_train, (
+            f"{n_train - n_grad} adapter params got no gradient; some "
+            "adapter is detached from the graph"
+        )
+
+    def test_base_weights_are_frozen(self):
+        model = apply_lora(_hf_llama(), LoraConfig(rank=RANK), verbose=False)
+        for name, mod in iter_lora_modules(model):
+            assert not mod.base.weight.requires_grad, (
+                f"{name}: base weight is still trainable, so this is a "
+                "full fine-tune wearing LoRA's clothes"
+            )
+
+    def test_is_actually_low_rank(self):
+        """Trainable params must be a small fraction of the total."""
+        model = apply_lora(_hf_llama(), LoraConfig(rank=RANK), verbose=False)
+        train = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        total = sum(p.numel() for p in model.parameters())
+        assert 0 < train < total / 2, f"{train}/{total} trainable"
+
+    @pytest.mark.parametrize(
+        "attn,mlp,expect",
+        [
+            (True, False, {"q_proj", "k_proj", "v_proj", "o_proj"}),
+            (False, True, {"gate_proj", "up_proj", "down_proj"}),
+        ],
+        ids=["attn-only", "mlp-only"],
+    )
+    def test_target_selection_is_honored(self, attn, mlp, expect):
+        model = apply_lora(
+            _hf_llama(),
+            LoraConfig(rank=RANK, train_attn=attn, train_mlp=mlp),
+            verbose=False,
+        )
+        leaves = {n.rsplit(".", 1)[-1] for n, _ in iter_lora_modules(model)}
+        assert leaves == expect
+
+
+class TestHfUnembed:
+    def test_wraps_lm_head_by_its_own_name(self):
+        """The adapter must replace `lm_head`, not create `model.output`.
+
+        Writing to a hardcoded `output` attribute leaves `lm_head` a
+        plain Linear: the forward path never sees the adapter, so the
+        run silently trains fewer parameters than requested.
+        """
+        model = apply_lora(
+            _hf_llama(),
+            LoraConfig(rank=RANK, train_unembed=True),
+            verbose=False,
+        )
+        assert type(model.lm_head).__name__ == "LoRALinear"
+        leaves = {n.rsplit(".", 1)[-1] for n, _ in iter_lora_modules(model)}
+        assert "lm_head" in leaves
+        # The native spelling must NOT have been invented on the side.
+        assert not isinstance(getattr(model, "output", None), nn.Module)
+
+    def test_unembed_adapter_trains(self):
+        model = apply_lora(
+            _hf_llama(),
+            LoraConfig(rank=RANK, train_unembed=True),
+            verbose=False,
+        )
+        n_train, n_grad = _fwd_bwd(model)
+        assert n_grad == n_train
+
+    def test_tied_embeddings_are_adapted_without_unfreezing_the_embedding(
+        self,
+    ):
+        """Tied `lm_head` works, and must not thaw the shared weight.
+
+        When `tie_word_embeddings=True`, `lm_head.weight` IS
+        `embed_tokens.weight`. Wrapping is still correct -- the adapter
+        is additive and leaves the shared tensor alone -- but only as
+        long as the base stays frozen. If wrapping ever made the base
+        trainable it would silently unfreeze the input embedding too,
+        turning a "LoRA" run into a partial full fine-tune.
+        """
+        model = apply_lora(
+            _hf_llama(tie=True),
+            LoraConfig(rank=RANK, train_unembed=True),
+            verbose=False,
+        )
+        leaves = {n.rsplit(".", 1)[-1] for n, _ in iter_lora_modules(model)}
+        assert leaves & set(UNEMBED_TARGETS), "lm_head was not adapted"
+
+        assert model.lm_head.base.weight is model.model.embed_tokens.weight, (
+            "wrapping broke weight tying"
+        )
+        assert not model.model.embed_tokens.weight.requires_grad, (
+            "the tied embedding is trainable, so this is no longer LoRA"
+        )
+        n_train, n_grad = _fwd_bwd(model)
+        assert n_grad == n_train
+
+
+class TestUnsupportedArchitectures:
+    def test_fused_qkv_conv1d_raises_with_a_named_error(self):
+        """GPT-2 style `Conv1D` is not an nn.Linear, so nothing matches.
+
+        A name table cannot fix this, so the error must say so rather
+        than leaving the user to wonder why LoRA "did nothing".
+        """
+        conv1d = pytest.importorskip("transformers.pytorch_utils").Conv1D
+        assert not issubclass(conv1d, nn.Linear), (
+            "Conv1D became an nn.Linear subclass upstream; this test's "
+            "premise (and the docs' scope note) need revisiting"
+        )
+
+        class FusedAttn(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.c_attn = conv1d(3 * 8, 8)
+
+        model = nn.Module()
+        model.h = nn.ModuleList([FusedAttn()])
+        with pytest.raises(RuntimeError, match="matched no modules") as ei:
+            apply_lora(model, LoraConfig(rank=RANK), verbose=False)
+        assert "Fused-QKV" in str(ei.value), (
+            "the error should name the actual limitation, not just "
+            "report a miss"
+        )


### PR DESCRIPTION
## The bug

`--lora-rank 16 --model meta-llama/Llama-3.2-1B` **silently did nothing.**

Not an error — the flag was accepted, the run logged normally, and you got a full fine-tune wearing a LoRA run's clothes: plausible loss curve, and a checkpoint ~100× larger than intended.

Two independent causes:

1. **The LoRA block was unreachable for HF models.** It sat inside the native model's `else:` branch in `fsdp_tp.train`, so the HF path never called `apply_lora` at all.
2. **The names wouldn't have matched anyway.** `lora.py` hardcoded `wq/wk/wv/wo` + `w1/w2/w3`; HF Llama spells the same roles `q_proj/k_proj/v_proj/o_proj` + `gate_proj/up_proj/down_proj` + `lm_head`. Zero overlap.

Same silent-failure class as the rendezvous leak fixed in #218 — everything *looks* fine, so nothing prompts you to check.

## The fix

`LoraConfig` already gates by **role** (`train_attn`/`train_mlp`/`train_unembed`), and the module docstring already argued why: *"the roles are stable across model families even when the attribute spellings are not."* The abstraction just stopped at its own front door. This carries it through.

| role | native | HuggingFace |
|---|---|---|
| `attn` | `wq` `wk` `wv` `wo` | `q_proj` `k_proj` `v_proj` `o_proj` |
| `mlp` | `w1` `w2` `w3` | `gate_proj` `up_proj` `down_proj` |
| `unembed` | `output` | `lm_head` |

`target_names()` emits **both** vocabularies rather than sniffing the architecture. That's safe rather than sloppy: `apply_lora` wraps a child only when its attribute name is in the target set **and** it is an `nn.Linear`, so a spelling the model doesn't use never fires. No detection heuristic, nothing to mis-detect.

Three things found by experiment, each of which would otherwise have shipped as a bug:

- **The unembed lookup must write back to the attribute it matched.** The old code did `model.output = LoRALinear(...)`; on an HF model that creates a *new* attribute and leaves `lm_head` a plain `Linear`, so the forward path never sees the adapter — it reports success while training nothing.
- **Tied embeddings are fine, and I'd initially assumed otherwise.** With `tie_word_embeddings=True`, `lm_head.weight` *is* `embed_tokens.weight`; the adapter is additive and the shared tensor stays frozen. A test pins that wrapping doesn't thaw the input embedding.
- **Fused-QKV families genuinely can't work this way.** `transformers.pytorch_utils.Conv1D` is **not** an `nn.Linear` subclass (verified), so GPT-2 is unwrappable whatever it's called; Falcon/GPT-NeoX pack q/k/v into one tensor. The error now names that limitation instead of asking whether the model is an ezpz `Transformer`.

## The guard

`apply_lora` already raised on a *total* miss. The dangerous case is a **partial** match — it returns happily having adapted less than asked. So after application, the finished module tree is inspected and a requested role that produced no adapters is refused at setup. The run also logs adapter count and trainable/total params, so a run that isn't actually low-rank is visible in the log rather than only in the checkpoint size.

## Tests

`tests/test_tinker_lora_hf.py` builds `LlamaForCausalLM` from an in-memory `LlamaConfig` — deliberately **not** from the `tiny-random-llama-2/` directory in the working tree, which is untracked and absent on a clean clone.

The gate throughout is that **every trainable parameter receives a gradient** after a real forward/backward. "It ran without raising" is not the bar: a LoRA branch detached from the graph runs perfectly well and trains nothing.

One test asserts the LoRA block's **indentation is 4 spaces**, which reads odd until you realize that's precisely the bug — one level deeper and it's back inside the native branch. Verified by re-nesting the block and confirming the test fails, then restoring and confirming it passes. A guard that can't fail isn't a guard.

## Verification

Local: **1581 passed, 11 skipped in 77s**, `ruff` clean.

On an HF Llama: 15 adapters including `lm_head`, **30/30** trainable params receive gradients, 61,760 of 229,520 params trainable.

ALCF hardware validation on Sunspot, Aurora and Polaris is running now; results will be posted to this PR before merge.

## Summary by Sourcery

Enable reliable LoRA fine-tuning for HuggingFace Llama-family models while failing clearly when requested adapters cannot be applied.

New Features:
- Support LoRA adapters for HuggingFace Llama-family causal language models using role-based targets across native and HF projection names.

Bug Fixes:
- Ensure --lora-rank is applied on the HuggingFace training path instead of being silently ignored.
- Wrap the matched HuggingFace lm_head correctly when adapting the unembedding layer.
- Reject partial LoRA applications and unsupported fused-QKV architectures instead of allowing silent no-ops.

Enhancements:
- Log the number of adapters and trainable versus total parameters for LoRA runs.
- Preserve correct behavior for tied embeddings while keeping shared base weights frozen.

Documentation:
- Document HuggingFace LoRA usage, role-to-module mappings, parameter reporting, supported model families, and architecture limitations.

Tests:
- Add coverage for HuggingFace projection wrapping, gradient flow, freezing, target selection, unembedding, tied embeddings, unsupported architectures, and validation of partial applications.