### PR TITLE
fix(setup): name the empty-MODULEPATH cause (closes #221)

### DIFF
--- a/docs/notes/shell-environment.md
+++ b/docs/notes/shell-environment.md
@@ -152,6 +152,24 @@ The recommended one-liner.  Internally it calls:
 ezpz_setup_env
 ```
 
+!!! warning "In a batch job, run the script under a login shell"
+
+    PBS and Slurm execute job scripts under a **non-login** shell, so
+    your login profile never runs and `module` is either undefined or
+    left with an empty `MODULEPATH`. Every `module load` inside
+    `ezpz_setup_env` is then a silent no-op, setup falls through to the
+    system Python, and the job dies later with `ModuleNotFoundError:
+    torch` or a missing `libmkl_intel_lp64.so`.
+
+    Use `#!/bin/bash -l`, or re-exec once at the top of the script.
+    Sourcing lmod's init is **not** enough — it defines the `module`
+    function but not the site `MODULEPATH`. See
+    [Import Errors](../troubleshooting.md#module-load-does-nothing-in-a-pbs-slurm-job-script)
+    for the full recipe.
+
+    `ezpz_setup_env` detects both states and names them rather than
+    reporting success.
+
 ### Key Functions
 
 | Function                     | Description                                                                               |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,6 +52,60 @@ recommended fix.
 | `ModuleNotFoundError: ezpz` | Not installed | `pip install git+https://github.com/saforem2/ezpz` |
 | `ImportError: ... .so` | Binary incompatibility | Rebuild from source; match Python/PyTorch versions |
 | `ImportError: libsycl.so.9: undefined symbol: urDeviceWaitExp` (XPU) | System oneAPI libs shadow the venv's bundled ones | Prepend the venv libs — use `ezpz_activate_venv` (see below) |
+| `ModuleNotFoundError: torch` or `OSError: libmkl_intel_lp64.so.N` **inside a batch job** | `module load` was a silent no-op: schedulers run job scripts non-login | Run the job script under a login shell (see below) |
+
+#### `module load` does nothing in a PBS / Slurm job script
+
+Schedulers run job scripts under a **non-login** shell, so your login
+profile never executes. Two distinct failures follow, both quiet:
+
+1. **`module` is not defined at all.** `module load frameworks` is not a
+   missing binary — it is a missing shell *function*, so the line does
+   nothing and the script continues.
+2. **`module` is defined but `MODULEPATH` is empty.** Every load then
+   reports `The following module(s) are unknown`.
+
+Either way setup falls through to the system Python, and the job dies
+later somewhere unrelated:
+
+```
+OSError: libmkl_intel_lp64.so.3: cannot open shared object file
+```
+
+naming neither lmod nor the module that failed to load.
+
+!!! warning "Sourcing lmod's init is not sufficient"
+
+    ```bash
+    . /usr/share/lmod/lmod/init/bash   # defines the `module` FUNCTION
+    module load frameworks/2026.1.0    # still fails: MODULEPATH is undefined
+    ```
+
+    The init script supplies the function; the site `MODULEPATH` comes
+    from the login profile. A script can therefore pass a
+    `command -v module` check and still have every `module load` be a
+    no-op.
+
+Use a login shell. Either the shebang:
+
+```bash
+#!/bin/bash -l
+```
+
+or, when the shebang is not under your control, re-exec once at the top
+of the script:
+
+```bash
+if [ -z "${_RELOGIN:-}" ]; then
+    export _RELOGIN=1
+    exec /bin/bash -l "$0" "$@"
+fi
+```
+
+`ezpz_setup_env` detects both states and reports them by name rather
+than letting the failure surface later as a missing module. Note also
+that `module load frameworks` with **no version** loads nothing and
+exits 0 — always pin the version.
 
 #### `libsycl.so` undefined symbol on XPU
 

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -1895,6 +1895,27 @@ ezpz_assert_python_env_active() {
 		log_message ERROR "      'module load' inside ezpz was a silent no-op."
 		log_message ERROR "      Run the script with \`bash -l\` (login shell), or"
 		log_message ERROR "      source your lmod init before calling ezpz_setup_env."
+	elif [[ -z "${MODULEPATH:-}" ]]; then
+		# `module` exists but MODULEPATH does not. Sourcing lmod's init
+		# defines the FUNCTION; the site MODULEPATH comes from the login
+		# profile. So a script can pass a `command -v module` check and
+		# still have every `module load` fail with
+		#
+		#     Lmod Warning: MODULEPATH is undefined.
+		#     Lmod has detected the following error: The following
+		#     module(s) are unknown: "frameworks/2026.1.0"
+		#
+		# Observed under PBS, which runs job scripts non-login: torch then
+		# imported from the wrong prefix and died on a missing
+		# libmkl_intel_lp64.so, naming neither lmod nor the module.
+		log_message ERROR "NOTE: \`module\` is defined but MODULEPATH is EMPTY, so"
+		log_message ERROR "      every 'module load' reported 'unknown module'."
+		log_message ERROR "      Sourcing lmod's init is NOT enough -- it defines the"
+		log_message ERROR "      function but not the site module path. Use a login"
+		log_message ERROR "      shell. In a PBS/Slurm job script:"
+		log_message ERROR "          #!/bin/bash -l"
+		log_message ERROR "      or re-exec once at the top of the script:"
+		log_message ERROR "          [ -z \"\${_RELOGIN:-}\" ] && export _RELOGIN=1 && exec bash -l \"\$0\" \"\$@\""
 	fi
 	log_message ERROR "Then re-run ezpz_setup_env."
 	return 1

--- a/tests/test_setup_env_no_silent_noop.sh
+++ b/tests/test_setup_env_no_silent_noop.sh
@@ -122,6 +122,49 @@ t_error_names_the_cause() {
 # When `module` is undefined (plain `bash script.sh`), any `module load`
 # inside ezpz is a silent no-op -- the actual trigger in #216. The error
 # must say so, because the user's interactive shell would have worked.
+# `module` DEFINED but MODULEPATH empty: the second silent no-op. Sourcing
+# lmod's init supplies the function; the site MODULEPATH comes from the
+# login profile, so every `module load` reports "unknown module". Hit
+# under PBS, which runs job scripts non-login (issue #221).
+t_flags_empty_modulepath() {
+    source "${FN_FILE}"
+    local out=""
+    log_message() { out+="$* "; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    module() { :; }          # defined, as after sourcing lmod's init
+    MODULEPATH=""            # ...but no site path
+    ezpz_assert_python_env_active 2>/dev/null || true
+    [[ "${out}" == *"MODULEPATH is EMPTY"* ]]
+}
+
+# The message must name the FIX, not just the symptom: `bash -l`. Someone
+# hitting this has already tried sourcing lmod's init.
+t_modulepath_suggests_login_shell() {
+    source "${FN_FILE}"
+    local out=""
+    log_message() { out+="$* "; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    module() { :; }
+    MODULEPATH=""
+    ezpz_assert_python_env_active 2>/dev/null || true
+    [[ "${out}" == *"bash -l"* ]]
+}
+
+# The converse: with MODULEPATH set, blaming it would be a false lead.
+t_no_modulepath_note_when_set() {
+    source "${FN_FILE}"
+    local out=""
+    log_message() { out+="$* "; }
+    unset VIRTUAL_ENV CONDA_PREFIX
+    PATH="/usr/bin:/bin"
+    module() { :; }
+    MODULEPATH="/opt/modulefiles"
+    ezpz_assert_python_env_active 2>/dev/null || true
+    [[ "${out}" != *"MODULEPATH is EMPTY"* ]]
+}
+
 t_flags_undefined_module() {
     source "${FN_FILE}"
     local out=""
@@ -215,6 +258,9 @@ run_test "PYTHON_ROOT-only -> passes (supported)"       t_python_root_only_passe
 run_test "shim resolving to system python -> FAILS"     t_symlink_to_system_python_fails
 run_test "undefined module -> error says so"            t_flags_undefined_module
 run_test "defined module -> no misleading note"         t_no_module_note_when_defined
+run_test "empty MODULEPATH -> error says so"            t_flags_empty_modulepath
+run_test "empty MODULEPATH -> suggests a login shell"   t_modulepath_suggests_login_shell
+run_test "MODULEPATH set -> no misleading note"         t_no_modulepath_note_when_set
 run_test "pbs branch propagates its return code"        t_pbs_branch_propagates
 run_test "slurm branch propagates its return code"      t_slurm_branch_propagates
 run_test "both branches assert the post-condition"      t_both_branches_assert


### PR DESCRIPTION
## The gap

#217 made `ezpz_setup_env` fail loudly when the `module` **command** is missing. There's a second, closely related silent no-op it didn't name: **`module` exists, but `MODULEPATH` doesn't.**

Sourcing lmod's init defines the module *function*; the site `MODULEPATH` comes from the login profile. So a script can pass a `command -v module` check and still have every `module load` fail:

```
Lmod Warning: MODULEPATH is undefined.
Lmod has detected the following error: The following module(s) are unknown: "frameworks/2026.1.0"
```

Module-load output is usually discarded, so setup carries on with the system python.

## How I found it

Three PBS submissions while validating #219 on ALCF. The observable symptom was:

```
OSError: libmkl_intel_lp64.so.3: cannot open shared object file
```

torch imported from the wrong prefix, naming neither lmod nor the module — several frames from the cause, exactly like #216.

The non-obvious part is that **the natural fix doesn't work**:

```bash
. /usr/share/lmod/lmod/init/bash     # gives you the `module` FUNCTION
module load frameworks/2026.1.0      # still fails: MODULEPATH is undefined
```

So the message says so explicitly and gives the two forms that do work (`#!/bin/bash -l`, or a one-shot re-exec) rather than leaving someone to rediscover that sourcing the init is a dead end.

## Tests

Three, added to the existing `test_setup_env_no_silent_noop.sh` suite (now 16):

- empty `MODULEPATH` → the error names it
- empty `MODULEPATH` → the message names the *fix*, not just the symptom
- `MODULEPATH` **set** → not blamed (a false lead is what makes this class expensive)

The first two were verified to **fail against the pre-fix helper** by reverting `utils.sh` and re-running:

```
empty MODULEPATH -> error says so             FAIL
empty MODULEPATH -> suggests a login shell    FAIL
MODULEPATH set -> no misleading note          PASS
14 passed, 2 failed
```

then passing once restored. A guard that can't fail isn't a guard.

## Verification

- Shell suite: **16 passed, 0 failed**
- Python suite: **1567 passed, 11 skipped**
- `shellcheck -S error`: 2 SC2068 findings, both pre-existing on `main` and untouched by this diff (verified by stashing)

Message-only change to a diagnostic path — no behavior change for a working setup.

Closes #221. Related: #216, #217.

## Summary by Sourcery

Name empty `MODULEPATH` as a setup failure and guide batch jobs toward a login-shell environment.

Bug Fixes:
- Identify and report when `module` is defined but `MODULEPATH` is empty, preventing silent module-load failures in batch jobs.

Enhancements:
- Clarify that sourcing lmod’s initialization alone is insufficient and recommend running PBS/Slurm scripts with a login shell or re-executing under one.

Documentation:
- Document the two common non-login-shell failure modes for module loading and provide login-shell troubleshooting guidance.

Tests:
- Add coverage for empty `MODULEPATH`, the recommended login-shell fix, and avoiding misleading diagnostics when `MODULEPATH` is set.