### PR TITLE
fix(deps): pin plotext<6 (6.0.0 drops the legacy API and breaks main)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
   "hydra-core",
   "numpy",
   "omegaconf",
-  "plotext",
+  # plotext 6.0.0 (2026-08-23) is a rewrite that drops the entire
+  # legacy top-level API — clear_figure, clf, main, theme, plot_size.
+  # ezpz.tplot is written against v5; pin until it is ported.
+  "plotext<6",
   "rich",
   "seaborn",
   "transformers>=4.50",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,12 @@ dependencies = [
   "hydra-core",
   "numpy",
   "omegaconf",
-  # plotext 6.0.0 (2026-08-23) is a rewrite that drops the entire
-  # legacy top-level API — clear_figure, clf, main, theme, plot_size.
-  # ezpz.tplot is written against v5; pin until it is ported.
-  "plotext<6",
+  # ezpz.tplot needs plotext's v5 API: clear_figure, main, theme,
+  # plot_size. 6.0.0 (2026-08-23) is a rewrite that drops all of them,
+  # and 4.x predates `theme`. Verified by unpacking the wheels: 5.0.2
+  # is the earliest release with the full set. Lift once tplot is
+  # ported to the v6 module layout.
+  "plotext>=5,<6",
   "rich",
   "seaborn",
   "transformers>=4.50",


### PR DESCRIPTION
## main is broken right now

Not by a commit. `plotext 6.0.0` was published **today at 15:45 UTC** and is a rewrite that removes the entire top-level API `ezpz.tplot` is written against:

```
clear_figure   clf   main   theme   plot_size     # all gone in 6.0.0
```

The dependency was unpinned (`"plotext"`), so CI resolved the new major within the hour:

```
AttributeError: module 'plotext' has no attribute 'clear_figure'
FAILED tests/test_tplot.py  (6 tests)
```

Timeline, which is the proof this isn't a code change:

| | |
|---|---|
| `main` pytest, 14:23 | ✅ success |
| plotext 6.0.0 on PyPI | 15:45 |
| next run, 16:36 | ❌ 6 failures |

No commits in between. Any fresh install of ezpz hits this today.

## Why pin rather than patch

`tplot.py`'s `_require_plotext` already has a `hasattr` fallback chain — but `tplot` (`:347`) and `tplot_dict` (`:282`) call `plotext.clear_figure()` directly and bypass it. Adding two more guards would make the tests pass while leaving `tplot` unable to actually plot: 6.0.0 removes the whole surface, not one function. I verified that by unpacking the 6.0.0 wheel and grepping its `__init__` — none of the five names appear.

So: pin now, port deliberately. The port is a real piece of work against a new module layout (`plotext._primitives.*`, `plotext._settings.*`) and shouldn't be rushed to unbreak CI.

## Verification

- `plotext<6` resolves 5.3.2 ✅, excludes 6.0.0 ✅
- `tests/test_tplot.py`: 14 passed
- Full suite: **1583 passed, 11 skipped**

## Follow-up

Port `ezpz.tplot` to the plotext 6 API, then lift the pin. Worth filing once this lands.