### PR TITLE
fix(autoretry): --auto-retry gave up on real jobs (#224) and crashed on scraper errors (#223)

### DIFF
--- a/src/ezpz/failover/patterns/__init__.py
+++ b/src/ezpz/failover/patterns/__init__.py
@@ -147,7 +147,13 @@ def reverse_resolve_ip(ip: str, timeout_s: float = 5.0) -> "str | None":
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
-        FileNotFoundError,
+        # OSError, not just FileNotFoundError: it also covers
+        # PermissionError (a `getent` that exists but is not
+        # executable, which is what macOS has) and NotADirectoryError.
+        # The narrower catch let those escape all the way out of
+        # `run_with_auto_retry`, so a recoverable node failure crashed
+        # the machinery meant to recover from it -- see #223.
+        OSError,
     ):
         return None
     if not out:

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -437,6 +437,16 @@ def classify_attempt(
     KeyboardInterrupt is re-raised before we reach it.
     """
     log_text = log_path.read_text(errors="replace") if log_path.exists() else ""
+    # Strip ANSI ONCE, here, so every matcher below sees plain text.
+    #
+    # ezpz's logger colorizes when attached to a tty, and the escapes
+    # land INSIDE the tokens being matched: `\x1b[36miter\x1b[0m=12`
+    # defeats `\biter=\d+`, and a colorized `rank 3 died from signal 15`
+    # stops matching the innocent-cascade strip and is misread as a real
+    # crash. `_extract_inner_rc` already stripped for exactly this
+    # reason; doing it for the other two as well is the fix, rather
+    # than teaching each pattern to tolerate escapes.
+    log_text = _strip_ansi(log_text)
 
     inner_rc = _extract_inner_rc(log_text)
     crash = _has_crash_patterns(log_text)
@@ -706,11 +716,16 @@ def run_with_auto_retry(
                 # retry loop entirely (#223). Logged rather than
                 # swallowed silently: losing the bad node's NAME is
                 # worth a line in the log.
+                # Include the path and the traceback: this is the only
+                # trace of WHY attribution was lost, and "scraper
+                # failed" alone is not enough to debug from.
                 logger.warning(
-                    "[auto-retry] scraper failed (%s: %s); falling back "
-                    "to blind rotation",
+                    "[auto-retry] scraper failed on %s (%s: %s); falling "
+                    "back to blind rotation",
+                    p,
                     type(exc).__name__,
                     exc,
+                    exc_info=True,
                 )
                 return []
 
@@ -801,7 +816,9 @@ def run_with_auto_retry(
         if reason is TerminationReason.STUCK_PRE_TRAINING:
             logger.error(
                 "[auto-retry] FAILOVER STOP: stuck_pre_training "
-                "(two consecutive attempts with zero step= markers, "
+                "(two consecutive attempts with no progress markers "
+                "-- no iter=/step=/epoch=/batch=/idx= line in either "
+                "log, "
                 "rc=%d)",
                 last_rc,
             )

--- a/src/ezpz/launch_autoretry.py
+++ b/src/ezpz/launch_autoretry.py
@@ -113,12 +113,30 @@ _WALLTIME_RC = 143
 # launch.py:_WATCHDOG_EXIT_CODE).
 _WATCHDOG_RC = 124
 
-# Progress marker: History.update prints `step=N` (or step=<N>) on
-# its summary line. If two consecutive attempts both contain zero
-# `step=` markers, the run is broken before training even started
-# (bad config, missing dataset, etc.) and no amount of node swapping
-# will help — bail out.
-_PROGRESS_MARKER_RX = re.compile(r"\bstep=\d+", re.MULTILINE)
+# Progress marker: evidence that training actually began. If two
+# consecutive attempts show none, the run is broken before training
+# starts (bad config, missing dataset, ...) and no amount of node
+# swapping will help — bail out.
+#
+# This matches any of `History.update`'s counter names, not just
+# `step`. That distinction is the whole bug: the counter bases are
+# ("iter", "step", "epoch", "batch", "idx") -- see
+# `ezpz.utils.format_compact_summary` -- and every ezpz example emits
+# `iter=` (minimal.py:92, test.py:401), not `step=`. Matching `step=`
+# alone meant a real ezpz job that hit a bad node twice was filed as
+# "never started" and ABANDONED with spares still free, which is
+# precisely the failure --auto-retry exists to survive.
+#
+# `torchtitan`-style `step: 1` (colon, spaces) is deliberately
+# accepted too: the separator carries no information here, and being
+# strict about it costs a real recovery.
+#
+# Erring toward accepting evidence of life is the right asymmetry. A
+# false positive costs one extra swap attempt; a false negative
+# abandons a recoverable job.
+_PROGRESS_MARKER_RX = re.compile(
+    r"\b(?:iter|step|epoch|batch|idx)\s*[=:]\s*\d+", re.MULTILINE
+)
 
 
 class TerminationReason(Enum):
@@ -676,7 +694,24 @@ def run_with_auto_retry(
         def _default_scrape(p: Path) -> list[str]:
             try:
                 return scrape_bad_nodes(p, machine=machine)
-            except FileNotFoundError:
+            except Exception as exc:
+                # Scraping is best-effort ATTRIBUTION: it upgrades a
+                # blind rotation to a named one. Nothing it can fail at
+                # is worth aborting a recoverable job for, so no
+                # scraper failure is fatal here -- a blind rotation is
+                # strictly better than a crash.
+                #
+                # This used to catch FileNotFoundError alone, so a
+                # PermissionError from `getent` propagated out of the
+                # retry loop entirely (#223). Logged rather than
+                # swallowed silently: losing the bad node's NAME is
+                # worth a line in the log.
+                logger.warning(
+                    "[auto-retry] scraper failed (%s: %s); falling back "
+                    "to blind rotation",
+                    type(exc).__name__,
+                    exc,
+                )
                 return []
 
         scrape_fn = _default_scrape

--- a/tests/test_autoretry_faultinject.py
+++ b/tests/test_autoretry_faultinject.py
@@ -356,19 +356,17 @@ class TestGlooPeerScrape:
         assert h.attempts == 2
         assert len(h.bad) == 1
 
-    def test_resolver_error_currently_escapes_the_loop(self, tmp_path):
-        """Pins the bug above so the fix is a deliberate edit.
+    def test_resolver_error_is_swallowed(self, tmp_path):
+        """A broken `getent` must not break resolution's caller.
 
-        Change this to `== []` once `reverse_resolve_ip` swallows
-        `OSError`.
+        Previously this caught `FileNotFoundError` only, so a
+        `PermissionError` -- a `getent` that exists but is not
+        executable, which is what macOS has -- escaped. This test
+        asserted `pytest.raises(PermissionError)` when it was written;
+        the assertion flipped when #223 was fixed.
         """
         from ezpz.failover.patterns import reverse_resolve_ip
 
-        log = tmp_path / "a.log"
-        log.write_text(
-            "RuntimeError: [enforce fail at gloo/transport/tcp/pair.cc:598] "
-            "Connection closed by peer [10.0.0.42]:53121\n"
-        )
         import subprocess as _sp
 
         def _boom(*_a, **_k):
@@ -377,10 +375,32 @@ class TestGlooPeerScrape:
         orig = _sp.check_output
         _sp.check_output = _boom
         try:
-            with pytest.raises(PermissionError):
-                reverse_resolve_ip("10.0.0.42")
+            assert reverse_resolve_ip("10.0.0.42") is None
         finally:
             _sp.check_output = orig
+
+    def test_a_failing_scraper_does_not_abort_the_run(
+        self, tmp_path, monkeypatch
+    ):
+        """The real consequence of #223, at the loop level.
+
+        Attribution is best-effort: it upgrades a blind rotation to a
+        named one. If the scraper explodes the job should still
+        recover, blindly. Before the fix this raised out of
+        `run_with_auto_retry` and killed a recoverable run.
+        """
+        monkeypatch.setattr(
+            "ezpz.failover.scrape_bad_nodes",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                PermissionError(13, "Permission denied", "getent")
+            ),
+        )
+        h = Harness(tmp_path, FI_MODE="shepherd", FI_FAIL_ON="1")
+        rc = h.run(monkeypatch)
+
+        assert rc == 0, "a scraper failure aborted an otherwise fine run"
+        assert h.attempts == 2
+        assert len(h.bad) == 1, "it should still have rotated blindly"
 
 
 class TestProcessLevelFailures:
@@ -523,20 +543,17 @@ class TestProgressMarkerContract:
             f"spares run out; got {h.attempts} attempts"
         )
 
-    def test_real_iter_output_is_not_seen_as_progress(
+    def test_real_iter_output_counts_as_progress(
         self, tmp_path, monkeypatch
     ):
-        """The actual bug: `iter=N` is real output and does not count.
+        """`iter=N` is what every ezpz example prints, and it counts.
 
-        `FI_MARKER=iter` emits exactly what `minimal.py` and `test.py`
-        print. The log is FULL of progress; the loop still gives up at
-        two attempts with spares to spare.
-
-        An earlier version of this test used `FI_STEPS=0` -- an empty
-        log -- which proved only that the guard fires on silence, and
-        would have kept passing after a fix that made `iter=` count.
-        Raised in review; this is the version that would actually go red
-        once #224 is fixed.
+        This test was written to FAIL, back when the marker was
+        `\bstep=\d+` and `minimal.py`/`test.py` both emitted `iter=`:
+        a job visibly mid-training was filed as "never started" and
+        abandoned with spares free. Fixing #224 flipped it, which is
+        the strongest evidence available that the fix does what it
+        claims -- the assertion changed direction, not the harness.
         """
         h = Harness(
             tmp_path, FI_MODE="shepherd", FI_MARKER="iter", FI_STEPS="3"
@@ -550,13 +567,13 @@ class TestProgressMarkerContract:
 
         log = h.log_text()
         assert "iter=" in log, "the child did not emit the real marker"
-        assert "step=" not in log
+        assert "step=" not in log, "this must exercise the iter= path only"
         assert h.rc != 0
-        assert h.attempts == 2, (
-            "the loop abandoned a job that was visibly training -- see "
-            f"issue #224; got {h.attempts} attempts with 2 spares free"
+        assert h.attempts == 3, (
+            "a job that is visibly training should keep failing over "
+            f"until spares run out; got {h.attempts} attempts"
         )
-        assert len(h.bad) == 1
+        assert len(h.bad) == 2, "both spares should have been consumed"
 
     def test_no_output_at_all_aborts_after_two_attempts(
         self, tmp_path, monkeypatch

--- a/tests/test_autoretry_faultinject.py
+++ b/tests/test_autoretry_faultinject.py
@@ -546,7 +546,7 @@ class TestProgressMarkerContract:
     def test_real_iter_output_counts_as_progress(
         self, tmp_path, monkeypatch
     ):
-        """`iter=N` is what every ezpz example prints, and it counts.
+        r"""`iter=N` is what every ezpz example prints, and it counts.
 
         This test was written to FAIL, back when the marker was
         `\bstep=\d+` and `minimal.py`/`test.py` both emitted `iter=`:

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -199,6 +199,44 @@ class TestPureHelpers:
         """
         assert _has_progress_markers(line), f"{line!r} should count"
 
+    def test_progress_markers_survive_ansi_color(self, tmp_path):
+        """Color must not hide progress. Raised as a P1 in review.
+
+        ezpz's logger colorizes when attached to a tty, and the escapes
+        land INSIDE the token: `\x1b[36miter\x1b[0m=12` does not match
+        `\biter=\d+`. Unfixed, the whole point of #224 would have been
+        undone on any normal terminal.
+
+        Asserted through `classify_attempt`, not `_has_progress_markers`
+        -- the strip happens in the caller, so testing the helper alone
+        would pass while the real path stayed broken.
+        """
+        log = tmp_path / "a.log"
+        log.write_text("\x1b[1;36miter\x1b[0m=\x1b[36m12\x1b[0m loss=0.5\n")
+        res = classify_attempt(
+            1, log, [], prior_attempt_had_progress=False, has_spares=True
+        )
+        assert res.has_progress, "ANSI-colored progress was not seen"
+        assert res.reason is not TerminationReason.STUCK_PRE_TRAINING
+
+    def test_colored_innocent_cascade_is_still_innocent(self, tmp_path):
+        """The same bug, on the crash side.
+
+        A colorized `rank 3 died from signal 15` stopped matching the
+        innocent-cascade strip, so a clean walltime kill was read as a
+        real crash and burned a spare.
+        """
+        log = tmp_path / "b.log"
+        log.write_text(
+            "iter=5\nrank 3 \x1b[31mdied from signal\x1b[0m 15\n"
+        )
+        res = classify_attempt(
+            143, log, [], prior_attempt_had_progress=True, has_spares=True
+        )
+        assert res.reason is TerminationReason.WALLTIME, (
+            f"colored cascade misread as {res.reason.value}"
+        )
+
     @pytest.mark.parametrize(
         "line",
         [

--- a/tests/test_launch_autoretry.py
+++ b/tests/test_launch_autoretry.py
@@ -177,9 +177,39 @@ class TestPureHelpers:
     def test_progress_markers_step_equals(self):
         assert _has_progress_markers("iter=10 step=5 loss=0.1")
 
-    def test_progress_markers_absent(self):
-        # No step=N anywhere.
-        assert not _has_progress_markers("loading dataset...\nERROR: cuda")
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "iter=12   loss=0.500000 dt=0.010000",  # what ezpz prints
+            "step=5 loss=0.1",
+            "epoch=3 loss=0.9",
+            "batch=17",
+            "idx=0",
+            "step: 1  loss: 8.2",  # torchtitan style
+            "train/iter=40",  # prefixed form
+        ],
+    )
+    def test_progress_markers_accept_every_counter_name(self, line):
+        """Any of History.update's counters is evidence of life.
+
+        Matching `step=` alone was #224: `minimal.py` and `test.py`
+        both print `iter=`, so a real ezpz job that hit a bad node
+        twice was classified as never having started and abandoned
+        with spare nodes still free.
+        """
+        assert _has_progress_markers(line), f"{line!r} should count"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "loading dataset...\nERROR: cuda",
+            "footstep=3",  # \b must not match mid-word
+            "step=",  # no number
+            "steps are slow",
+        ],
+    )
+    def test_progress_markers_absent(self, line):
+        assert not _has_progress_markers(line), f"{line!r} should NOT count"
 
     def test_derive_spare_count_unused(self):
         assert derive_spare_count(10, 8) == 2


### PR DESCRIPTION
Two bugs the [fault-injection harness](https://github.com/saforem2/ezpz/pull/225) found. Both make `--auto-retry` fail at the thing it exists for.

## #224 — the loop never saw progress from ezpz's own examples

`_PROGRESS_MARKER_RX` was `\bstep=\d+`, and the comment above it claimed *"History.update prints `step=N`"*. **It doesn't.** The counter bases are `("iter", "step", "epoch", "batch", "idx")` and every ezpz example emits `iter=`:

- `minimal.py:92` → `metrics = {"iter": step, ...}`
- `test.py:401` → `history.update({"iter": self.train_iter, ...})`

rendered as `iter=12   loss=0.500000`.

So the guard meant to detect *"this job never started"* fired on jobs that were visibly training. Two consecutive bad-node failures of any real ezpz workload → `STUCK_PRE_TRAINING` → **run abandoned with spare nodes still free.** That is precisely the scenario the flag exists to survive.

The pattern now accepts any of `History.update`'s counter names, plus `step: 1` as well as `step=1` — the separator carries no information here, and torchtitan-style logs use the colon.

The asymmetry is deliberate: **a false positive costs one extra swap attempt; a false negative abandons a recoverable job.**

## #223 — a scraper failure took down the whole run

Two narrow `except` clauses, one consequence. `reverse_resolve_ip` caught `FileNotFoundError` but not `PermissionError` (a `getent` that exists but isn't executable — what macOS has), and the loop's default `scrape_fn` caught only `FileNotFoundError` too. The exception propagated out of `run_with_auto_retry` entirely: **a recoverable node failure crashed the machinery meant to recover from it.**

- `reverse_resolve_ip` now catches `OSError`, which covers the family and matches what its docstring already promised.
- The loop is deliberately broader still. Scraping is best-effort *attribution* — it upgrades a blind rotation to a named one — so nothing it can fail at is worth aborting a job for. It logs a warning rather than swallowing silently, because losing the bad node's name is worth a line.

## The evidence

The harness already contained a test **written to fail** against the old marker, emitting real `iter=` output. Fixing #224 flipped it — the assertion changed direction, not the harness. Same for #223's resolver test, which asserted `pytest.raises(PermissionError)`.

Each fix is independently mutation-checked:

| revert | result |
|---|---|
| marker back to `\bstep=\d+` | **7 tests fail** |
| `OSError` → `FileNotFoundError` in the resolver | `test_resolver_error_is_swallowed` fails |
| loop's `except Exception` → `FileNotFoundError` | `test_a_failing_scraper_does_not_abort_the_run` fails |

Two new tests cover the loop-level consequence of #223 and the full counter vocabulary for #224, including the near-misses `\b` must still reject (`footstep=3`, `step=` with no digits).

## Verification

- `tests/test_launch_autoretry.py` (122) + `tests/test_autoretry_faultinject.py` (22): **154 passed**
- Full suite: **1615 passed, 11 skipped**
- `ruff` clean

Closes #223. Closes #224.

## Summary by Sourcery

Make auto-retry resilient to real training logs and non-fatal node attribution failures so recoverable jobs continue failing over instead of being abandoned or crashed.

Bug Fixes:
- Make auto-retry recognize progress from all supported training counter formats, including ezpz's `iter=` output and colon-separated step markers.
- Prevent resolver and node-scraper failures from aborting recoverable auto-retry runs by falling back to blind node rotation.
- Ensure ANSI-colored logs are classified correctly for progress and innocent failure detection.

Enhancements:
- Improve diagnostics when best-effort node attribution fails by logging the scraper error and traceback.

Tests:
- Expand auto-retry coverage for counter vocabularies, malformed near-matches, ANSI-colored logs, resolver errors, and scraper failures.