### PR TITLE
docs: distinguish checkpoint restart from --auto-retry failover

### DIFF
--- a/docs/guides/checkpoint-restart.md
+++ b/docs/guides/checkpoint-restart.md
@@ -42,7 +42,7 @@ ezpz launch --auto-retry --np <N> -- \
     | | what fails | what recovers | measured where |
     | --- | --- | --- | --- |
     | **Checkpoint restart** (this page) | the training process | a relaunch on the **same** nodes, resuming from the last checkpoint | here — real Sunspot runs |
-    | **`--auto-retry`** ([fault injection](fault-injection.md)) | a **node** — or any retryable failure it cannot attribute to one | a named bad host is retired; otherwise a spare is rotated in blindly. Either way the job relaunches **elsewhere** | locally; on-node validation still outstanding |
+    | **`--auto-retry`** ([fault injection](fault-injection.md)) | a **node** — or any retryable failure it cannot attribute to one | a named bad host is retired; otherwise a spare is rotated in blindly. Either way the job relaunches **elsewhere** | locally, plus a real 4-node Sunspot node-kill |
 
     Both survive a `pkill -9` and keep training, which is exactly why
     they look alike from outside. The difference is whether the *node

--- a/docs/guides/checkpoint-restart.md
+++ b/docs/guides/checkpoint-restart.md
@@ -33,6 +33,22 @@ ezpz launch --auto-retry --np <N> -- \
     --ckpt-dir ./ckpts --save-interval 100 --train-iters 3000
 ```
 
+!!! warning "This page measures restart, not failover"
+
+    The two are easy to conflate, and the command above makes it
+    easier: `--auto-retry` composes with resume, but the numbers below
+    were **not** produced with it.
+
+    | | what fails | what recovers | measured where |
+    | --- | --- | --- | --- |
+    | **Checkpoint restart** (this page) | the training process | a relaunch on the **same** nodes, resuming from the last checkpoint | here — real Sunspot runs |
+    | **`--auto-retry`** ([fault injection](fault-injection.md)) | a **node** | the bad host is retired, a spare takes its slot, and the job relaunches **elsewhere** | locally; on-node validation still outstanding |
+
+    Both survive a `pkill -9` and keep training, which is exactly why
+    they look alike from outside. The difference is whether the *node
+    set changes*. The experiment below uses a plain relaunch loop on a
+    fixed node set, so nothing here exercises node-swapping.
+
 ### Asynchronous checkpointing
 
 By default a save is **synchronous** — the training loop blocks while every
@@ -83,6 +99,14 @@ XPU ranks, `tp=2`)**, checkpointing every 100 steps:
    across all nodes every ~90 s (a real `pkill -9`; PALS then tears down the
    training `mpiexec`, each attempt exiting rc=137). A relaunch loop restarts
    on the same nodes and `fsdp_tp` auto-resumes from the last checkpoint.
+
+The kill is `pbsdsh` with no node index, so it lands on **every** node at
+once, and the relaunch is a plain `while` loop in the job script — not
+`--auto-retry`. That is deliberate: with every node hit there is no
+healthy/bad distinction to fail over between, and with no spare nodes in
+the allocation there is nowhere to fail over *to*. The scripts say so in
+their header comments, and it is worth repeating here because the
+recovery looks identical from the outside.
 
 ![Training progress over time — baseline vs checkpoint restart](checkpoint-restart.png)
 

--- a/docs/guides/checkpoint-restart.md
+++ b/docs/guides/checkpoint-restart.md
@@ -42,12 +42,20 @@ ezpz launch --auto-retry --np <N> -- \
     | | what fails | what recovers | measured where |
     | --- | --- | --- | --- |
     | **Checkpoint restart** (this page) | the training process | a relaunch on the **same** nodes, resuming from the last checkpoint | here — real Sunspot runs |
-    | **`--auto-retry`** ([fault injection](fault-injection.md)) | a **node** | the bad host is retired, a spare takes its slot, and the job relaunches **elsewhere** | locally; on-node validation still outstanding |
+    | **`--auto-retry`** ([fault injection](fault-injection.md)) | a **node** — or any retryable failure it cannot attribute to one | a named bad host is retired; otherwise a spare is rotated in blindly. Either way the job relaunches **elsewhere** | locally; on-node validation still outstanding |
 
     Both survive a `pkill -9` and keep training, which is exactly why
     they look alike from outside. The difference is whether the *node
     set changes*. The experiment below uses a plain relaunch loop on a
     fixed node set, so nothing here exercises node-swapping.
+
+    One asymmetry worth knowing: the plain relaunch loop always
+    retries, but **`--auto-retry` needs a spare to retry at all**.
+    Every retryable verdict is gated on `has_spares`
+    (`launch_autoretry.py:490-502`); with none left the run ends as
+    `EXHAUSTED` rather than relaunching. If `--np` claims the whole
+    allocation there is no spare, so ask the scheduler for more nodes
+    than you train on — that is what `--nhosts` is for.
 
 ### Asynchronous checkpointing
 

--- a/docs/guides/fault-injection.md
+++ b/docs/guides/fault-injection.md
@@ -22,9 +22,14 @@ carry on training, so they look alike from outside:
 | | what fails | what recovers |
 | --- | --- | --- |
 | Checkpoint restart | the training **process** | relaunch on the **same** nodes, resuming from the last checkpoint |
-| `--auto-retry` (here) | a **node** | the bad host is retired, a spare takes its slot, the job runs **elsewhere** |
+| `--auto-retry` (here) | a **node** — or any retryable failure it cannot pin on one | a named host is retired; otherwise a spare is rotated in blindly. Either way the job runs **elsewhere** |
 
-The difference is whether the node set changes. Checkpoint restart is
+The difference is whether the node set changes. Note the hedge in that
+second row: only a scraped, named host yields `BAD_NODE_KNOWN`. A
+watchdog timeout or an unrecognised crash still burns a spare, on the
+guess that a node is at fault — see the classification table below.
+And a retry of any kind requires a spare to exist: with none, the
+verdict is `EXHAUSTED` and the job stops. Checkpoint restart is
 measured on real hardware; node-swapping is exercised here in process,
 and on-node validation is still outstanding (see [Scope](#scope)).
 

--- a/docs/guides/fault-injection.md
+++ b/docs/guides/fault-injection.md
@@ -30,8 +30,8 @@ watchdog timeout or an unrecognised crash still burns a spare, on the
 guess that a node is at fault — see the classification table below.
 And a retry of any kind requires a spare to exist: with none, the
 verdict is `EXHAUSTED` and the job stops. Checkpoint restart is
-measured on real hardware; node-swapping is exercised here in process,
-and on-node validation is still outstanding (see [Scope](#scope)).
+measured on real hardware, and node-swapping is now validated on real
+hardware too — see [On-node validation](#on-node-validation).
 
 ## The experiment
 
@@ -161,6 +161,53 @@ distributed init and reading a sharded checkpoint. What it does exercise
 for real is every decision the loop makes, the subprocess plumbing, the
 idle watchdog, the scraper, and the hostfile rewrite.
 
-The remaining gap is a genuine multi-node failure: killing a real node on
-a live allocation and confirming the relaunch lands on a different one.
-That still needs an allocation, and is tracked separately.
+## On-node validation
+
+The one claim no in-process test can make is that the *next* attempt's
+`mpiexec` actually lands somewhere else. That needed real hardware, and
+`experiments/fault-injection/autoretry_nodekill.pbs` now does it: 4
+Sunspot nodes split 2 active + 2 spare, `pbsdsh -n 0` killing the ranks
+on exactly one active node mid-training, with `--auto-retry` driving the
+retry loop.
+
+Sunspot job 12473704, killing `x1921c1s0b0n0` after checkpoint 40:
+
+| attempt | ran on | outcome |
+|---|---|---|
+| 1 | `s0b0n0` (victim), `s1b0n0` | 13 ranks killed on the victim |
+| 2 | `s1b0n0`, **`s4b0n0`** (spare) | victim retired, spare swapped in |
+| 3 | `s1b0n0`, **`s5b0n0`** (spare) | see the caveat below |
+
+Attempt 2 is the result: the killed host was recorded in
+`bad_nodes.txt`, removed from the active hostfile, and the relaunch ran
+on a different node set. Node-swapping works on real hardware.
+
+!!! warning "The same run exposed a classifier bug"
+
+    Attempt 2 died of `OSError: [Errno 28] No space left on device`
+    during a checkpoint save — the experiment kept every 22 GB
+    checkpoint and filled a shared filesystem. `--auto-retry` scraped a
+    host out of the resulting PALS teardown cascade and retired
+    `s4b0n0`, a healthy node, then relaunched into the same full disk.
+
+    A whole-job failure whose cascade happens to name a host is read as
+    that host being bad. Tracked in
+    [#231](https://github.com/saforem2/ezpz/issues/231). The experiment
+    now bounds its own footprint and refuses to start without room.
+
+Two harness bugs are worth recording, because both produced confident
+wrong verdicts before any of the above was true:
+
+- `pbsdsh -- bash -c '<multi-line>'` does not survive the trip
+  (`syntax error: unexpected end of file`). The kill never landed, the
+  job trained to completion, and a trailing `|| true` reported success
+  anyway. The killer is now a file, and reports non-zero if it kills
+  nothing.
+- Two assertions passed *vacuously* when there was no relaunch: an
+  untouched hostfile still has N hosts, and attempt 1 — which ran before
+  the kill — naturally never names the victim. They are now gated behind
+  the relaunch check, which is evaluated first.
+
+The general lesson: a chaos harness that cannot distinguish "the fault
+was injected and handled" from "the fault was never injected" reports
+the second as the first.

--- a/docs/guides/fault-injection.md
+++ b/docs/guides/fault-injection.md
@@ -16,6 +16,18 @@ For what recovery *costs* at real scale, see
 checkpoint, 10.4–11.1 s per restart. This page is about the loop's
 decisions; that one is about the I/O.
 
+The two are worth keeping apart, because both survive a `pkill -9` and
+carry on training, so they look alike from outside:
+
+| | what fails | what recovers |
+| --- | --- | --- |
+| Checkpoint restart | the training **process** | relaunch on the **same** nodes, resuming from the last checkpoint |
+| `--auto-retry` (here) | a **node** | the bad host is retired, a spare takes its slot, the job runs **elsewhere** |
+
+The difference is whether the node set changes. Checkpoint restart is
+measured on real hardware; node-swapping is exercised here in process,
+and on-node validation is still outstanding (see [Scope](#scope)).
+
 ## The experiment
 
 Four attempts against a 300-step job checkpointing every 25 steps, with

--- a/experiments/fault-injection/autoretry_nodekill.pbs
+++ b/experiments/fault-injection/autoretry_nodekill.pbs
@@ -6,6 +6,9 @@
 #PBS -q workq
 #PBS -l filesystems=tegu:home
 #PBS -j oe
+# Absolute, because the script cd's and PBS resolves a relative path
+# against the CWD at exit -- job 12473702's log landed in the repo dir.
+#PBS -o /home/foremans/
 #
 # Does `ezpz launch --auto-retry` actually swap a bad node out, on real
 # hardware, mid-training?
@@ -107,7 +110,18 @@ chaos() {
         [ -f "${DONE}" ] && { echo "[CHAOS] training ended before the kill"; return 0; }
     done
     echo "[CHAOS] killing ranks on ${victim} at $(date +%s) (ckpt=$(latest_ckpt_step "${CKPT}"))"
-    pbsdsh -n 0 -- bash -c 'pkill -9 -f "ezpz.examples.fsdp_tp" 2>/dev/null; true' || true
+    # Kill the RANKS, not the supervisor. `pkill -f ezpz.examples.fsdp_tp`
+    # also matches the `python3 -m ezpz.launch --auto-retry -- python3 -m
+    # ezpz.examples.fsdp_tp ...` parent, whose command line contains that
+    # string -- so the first run took out the retry loop itself and there
+    # was nothing left to fail over (job 12473702: 1 attempt, empty
+    # bad_nodes.txt). Excluding `ezpz.launch` leaves the supervisor alive
+    # to observe the failure and swap.
+    pbsdsh -n 0 -- bash -c \
+        'for pid in $(pgrep -f "ezpz[.]examples[.]fsdp_tp"); do
+             grep -qa "ezpz.launch" "/proc/$pid/cmdline" 2>/dev/null && continue
+             kill -9 "$pid" 2>/dev/null
+         done; true' || true
     echo "[CHAOS] kill delivered"
 }
 
@@ -157,9 +171,18 @@ else
     grep -q "${VICTIM}" <<< "${BAD}"; check "killed host is recorded bad" $?
     ! grep -q "${VICTIM}" <<< "${ACT}"
     check "killed host is OUT of the active hostfile" $?
+    # Ordered so the prerequisite is checked FIRST: without a relaunch
+    # the two checks below are vacuous -- on job 12473702 they both
+    # reported PASS while the test as a whole failed, because an
+    # untouched hostfile still has N hosts and attempt-1 (which ran
+    # BEFORE the kill) naturally never mentions the victim.
+    [ "${N_ATTEMPTS}" -ge 2 ]; check "the job was relaunched (>=2 attempts)" $?
+
+    if [ "${N_ATTEMPTS}" -lt 2 ]; then
+        echo "  SKIP  remaining checks: no relaunch, so nothing to verify"
+    else
     [ "$(wc -l < "${FO_DIR}/active.hostfile")" -eq "${ACTIVE_HOSTS}" ]
     check "active set still has ${ACTIVE_HOSTS} hosts (a spare filled in)" $?
-    [ "${N_ATTEMPTS}" -ge 2 ]; check "the job was relaunched (>=2 attempts)" $?
 
     # The claim no in-process test can make: the post-kill attempt ran
     # on the NEW host set. PALS prints the hosts it launched on, so the
@@ -168,6 +191,7 @@ else
     if [ -n "${LAST}" ]; then
         ! grep -q "${VICTIM}" "${LAST}"
         check "final attempt did NOT run on the dead host ($(basename "${LAST}"))" $?
+    fi
     fi
 fi
 

--- a/experiments/fault-injection/autoretry_nodekill.pbs
+++ b/experiments/fault-injection/autoretry_nodekill.pbs
@@ -8,7 +8,7 @@
 #PBS -j oe
 # Absolute, because the script cd's and PBS resolves a relative path
 # against the CWD at exit -- job 12473702's log landed in the repo dir.
-#PBS -o /home/foremans/
+#PBS -o /home/foremans/autoretry-nodekill.log
 #
 # Does `ezpz launch --auto-retry` actually swap a bad node out, on real
 # hardware, mid-training?
@@ -96,6 +96,33 @@ latest_ckpt_step() {
     echo "${best}"
 }
 
+# ---- the killer, as a file ----------------------------------------------
+# Written to the shared FS so `pbsdsh` can exec it directly. See the note
+# in chaos() for why this is not an inline `bash -c`.
+KILLER="${EXPT}/kill_ranks.sh"
+cat > "${KILLER}" <<'KILLEOF'
+#!/bin/bash
+# Kill the training RANKS on this node, leaving the retry supervisor.
+#
+# `pkill -f ezpz.examples.fsdp_tp` also matches the parent
+# `python3 -m ezpz.launch --auto-retry -- python3 -m ezpz.examples.fsdp_tp`,
+# whose own command line contains that string. Job 12473702 killed the
+# supervisor that way: 1 attempt, empty bad_nodes.txt, nothing left to
+# fail over. So skip any pid whose cmdline mentions ezpz.launch.
+n=0
+for pid in $(pgrep -f "ezpz[.]examples[.]fsdp_tp" 2>/dev/null); do
+    if grep -qa "ezpz.launch" "/proc/${pid}/cmdline" 2>/dev/null; then
+        continue
+    fi
+    kill -9 "${pid}" 2>/dev/null && n=$((n + 1))
+done
+echo "[killer] $(hostname): killed ${n} rank pid(s)"
+# Report nothing-killed as a failure: a silent no-op here makes every
+# downstream failover assertion vacuous.
+[ "${n}" -gt 0 ]
+KILLEOF
+chmod +x "${KILLER}"
+
 # ---- kill ONE node, once ------------------------------------------------
 # `pbsdsh -n 0` targets the first node in the allocation, which is
 # active[0] -- the host auto-retry should retire. Killing a single node
@@ -110,19 +137,20 @@ chaos() {
         [ -f "${DONE}" ] && { echo "[CHAOS] training ended before the kill"; return 0; }
     done
     echo "[CHAOS] killing ranks on ${victim} at $(date +%s) (ckpt=$(latest_ckpt_step "${CKPT}"))"
-    # Kill the RANKS, not the supervisor. `pkill -f ezpz.examples.fsdp_tp`
-    # also matches the `python3 -m ezpz.launch --auto-retry -- python3 -m
-    # ezpz.examples.fsdp_tp ...` parent, whose command line contains that
-    # string -- so the first run took out the retry loop itself and there
-    # was nothing left to fail over (job 12473702: 1 attempt, empty
-    # bad_nodes.txt). Excluding `ezpz.launch` leaves the supervisor alive
-    # to observe the failure and swap.
-    pbsdsh -n 0 -- bash -c \
-        'for pid in $(pgrep -f "ezpz[.]examples[.]fsdp_tp"); do
-             grep -qa "ezpz.launch" "/proc/$pid/cmdline" 2>/dev/null && continue
-             kill -9 "$pid" 2>/dev/null
-         done; true' || true
-    echo "[CHAOS] kill delivered"
+    # Run a FILE, not an inline script. `pbsdsh -- bash -c '<multi-line>'`
+    # does not survive the trip: job 12473703 got "bash: -c: line 1:
+    # syntax error: unexpected end of file" and, because of a trailing
+    # `|| true`, still printed "kill delivered" while training ran on to
+    # completion. A file has no quoting or newline exposure at all.
+    # Capture to a file as well as stdout: the verdict runs while the
+    # job's own stdout is still spooled by PBS and cannot be read back.
+    pbsdsh -n 0 -- /bin/bash "${KILLER}" 2>&1 | tee "${EXPT}/kill.out"
+    local krc=${PIPESTATUS[0]}
+    echo "[CHAOS] kill rc=${krc}"
+    # Do NOT swallow this. A kill that never lands makes every downstream
+    # assertion vacuous, and that is exactly how 12473703 read as a
+    # failover bug when it was a quoting bug.
+    [ "${krc}" -eq 0 ] || echo "[CHAOS] WARNING: killer script failed"
 }
 
 chaos & CPID=$!
@@ -143,6 +171,9 @@ kill "${CPID}" 2>/dev/null || true
 # ---- verdict ------------------------------------------------------------
 FO_DIR="$(ls -dt "${D}"/logs/failover-* 2>/dev/null | head -1)"
 VICTIM="$(cat "${EXPT}/victim.txt" 2>/dev/null || echo '<none>')"
+# The killer runs under pbsdsh; chaos() tees its output here because the
+# job's own stdout is still spooled by PBS at this point.
+KILLOUT="$(cat "${EXPT}/kill.out" 2>/dev/null)"
 
 echo
 echo "======================= RESULT ======================="
@@ -168,14 +199,23 @@ else
     ACT="$(cat "${FO_DIR}/active.hostfile" 2>/dev/null)"
     N_ATTEMPTS="$(ls -1 "${FO_DIR}"/attempt-*.log 2>/dev/null | wc -l)"
 
+    # Checked FIRST because everything else presumes it. Job 12473703
+    # reported three FAILs that all traced back to a kill that never
+    # landed (`pbsdsh -- bash -c` mangled the inline script) -- the
+    # failover logic was never reached, let alone wrong. If the ranks
+    # are still alive there is no bad node and nothing to conclude.
+    grep -q "killed [1-9][0-9]* rank pid" <<< "${KILLOUT}"
+    check "the kill actually landed on ${VICTIM}" $?
+
     grep -q "${VICTIM}" <<< "${BAD}"; check "killed host is recorded bad" $?
     ! grep -q "${VICTIM}" <<< "${ACT}"
     check "killed host is OUT of the active hostfile" $?
-    # Ordered so the prerequisite is checked FIRST: without a relaunch
-    # the two checks below are vacuous -- on job 12473702 they both
-    # reported PASS while the test as a whole failed, because an
-    # untouched hostfile still has N hosts and attempt-1 (which ran
-    # BEFORE the kill) naturally never mentions the victim.
+    # Ordered so the prerequisite is checked before its dependents:
+    # without a relaunch the two checks below are vacuous -- on job
+    # 12473702 they both reported PASS while the test as a whole
+    # failed, because an untouched hostfile still has N hosts and
+    # attempt-1 (which ran BEFORE the kill) naturally never mentions
+    # the victim.
     [ "${N_ATTEMPTS}" -ge 2 ]; check "the job was relaunched (>=2 attempts)" $?
 
     if [ "${N_ATTEMPTS}" -lt 2 ]; then

--- a/experiments/fault-injection/autoretry_nodekill.pbs
+++ b/experiments/fault-injection/autoretry_nodekill.pbs
@@ -73,13 +73,42 @@ export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
 EXPT="${D}/out/autoretry-nodekill-${PBS_JOBID%%.*}"
 mkdir -p "${EXPT}"
 CKPT="${EXPT}/ckpt"
+# Checkpoints are the bulk of this experiment's footprint and are
+# worthless once the verdict is computed -- the assertions read
+# bad_nodes.txt and the attempt logs, never the weights. Reclaim them
+# however the job ends, including a walltime kill.
+trap 'rm -rf "${CKPT}" 2>/dev/null' EXIT
 LOG="${EXPT}/train.log"
 DONE="${EXPT}/.done"
 
 ACTIVE_HOSTS=2          # --nhosts; the rest of select= becomes spare
 KILL_AFTER_STEP=40      # kill once a complete checkpoint passes this
-TRAIN_ITERS=400
-SAVE_INTERVAL=20
+# Sized so the run cannot fill the shared filesystem. agpt-2b writes
+# ~22 GB per checkpoint and NOTHING prunes them, so job 12473704's
+# 400 iters / save-interval 20 produced 15 saves = 331 GB and then
+# died with `OSError: [Errno 28] No space left on device` mid-save --
+# on /lus/tegu, which other people are using.
+#
+# This test does not need long training: it needs ONE durable
+# checkpoint before the kill and enough runway after it to observe a
+# relaunch. 100 iters saving every 25 is 4 saves (~88 GB peak), and
+# the trap below reclaims them on exit.
+TRAIN_ITERS=100
+SAVE_INTERVAL=25
+
+# Preflight: refuse to start without room for the checkpoints. Job
+# 12473704 ran 56 minutes and then died mid-save on ENOSPC, which the
+# classifier read as a bad node and "fixed" by burning a spare -- an
+# expensive way to discover a full disk. ~22 GB/save * 4 saves, with
+# headroom for the async fanout holding two copies briefly.
+NEED_GB=120
+AVAIL_GB="$(df -BG --output=avail "${EXPT}" 2>/dev/null | tail -1 | tr -dc '0-9')"
+if [ -n "${AVAIL_GB}" ] && [ "${AVAIL_GB}" -lt "${NEED_GB}" ]; then
+    echo "FATAL: only ${AVAIL_GB}GB free at ${EXPT}, need ~${NEED_GB}GB."
+    echo "       Refusing to start rather than dying mid-checkpoint."
+    exit 1
+fi
+echo "=== disk: ${AVAIL_GB:-?}GB free, need ~${NEED_GB}GB ==="
 
 mapfile -t ALL_HOSTS < "${PBS_NODEFILE}"
 echo "=== allocation (${#ALL_HOSTS[@]} hosts) ==="
@@ -100,6 +129,7 @@ latest_ckpt_step() {
 # Written to the shared FS so `pbsdsh` can exec it directly. See the note
 # in chaos() for why this is not an inline `bash -c`.
 KILLER="${EXPT}/kill_ranks.sh"
+RECEIPT="${EXPT}/kill_receipt.txt"
 cat > "${KILLER}" <<'KILLEOF'
 #!/bin/bash
 # Kill the training RANKS on this node, leaving the retry supervisor.
@@ -117,6 +147,15 @@ for pid in $(pgrep -f "ezpz[.]examples[.]fsdp_tp" 2>/dev/null); do
     kill -9 "${pid}" 2>/dev/null && n=$((n + 1))
 done
 echo "[killer] $(hostname): killed ${n} rank pid(s)"
+# Write the receipt directly rather than relying on output plumbing.
+# On job 12473704 `pbsdsh ... | tee kill.out` left kill.out EMPTY --
+# pbsdsh's output reaches the job's stdout without passing through the
+# local pipe -- so the verdict could not see a kill that had plainly
+# worked (the job log shows "killed 13 rank pid(s)"). A file the
+# killer writes itself has no such dependency.
+if [ -n "${KILL_RECEIPT:-}" ]; then
+    echo "$(hostname) killed ${n}" >> "${KILL_RECEIPT}"
+fi
 # Report nothing-killed as a failure: a silent no-op here makes every
 # downstream failover assertion vacuous.
 [ "${n}" -gt 0 ]
@@ -142,10 +181,12 @@ chaos() {
     # syntax error: unexpected end of file" and, because of a trailing
     # `|| true`, still printed "kill delivered" while training ran on to
     # completion. A file has no quoting or newline exposure at all.
-    # Capture to a file as well as stdout: the verdict runs while the
-    # job's own stdout is still spooled by PBS and cannot be read back.
-    pbsdsh -n 0 -- /bin/bash "${KILLER}" 2>&1 | tee "${EXPT}/kill.out"
-    local krc=${PIPESTATUS[0]}
+    # `pbsdsh -- env VAR=... bash <script>`: pbsdsh does not forward the
+    # caller's environment, and the receipt path must reach the remote
+    # side for the killer to write it.
+    pbsdsh -n 0 -- /usr/bin/env "KILL_RECEIPT=${RECEIPT}" \
+        /bin/bash "${KILLER}"
+    local krc=$?
     echo "[CHAOS] kill rc=${krc}"
     # Do NOT swallow this. A kill that never lands makes every downstream
     # assertion vacuous, and that is exactly how 12473703 read as a
@@ -176,9 +217,10 @@ kill "${CPID}" 2>/dev/null || true
 FO_DIR="${D}/logs/failover-${PBS_JOBID%%.*}"
 [ -d "${FO_DIR}" ] || FO_DIR=""
 VICTIM="$(cat "${EXPT}/victim.txt" 2>/dev/null || echo '<none>')"
-# The killer runs under pbsdsh; chaos() tees its output here because the
-# job's own stdout is still spooled by PBS at this point.
-KILLOUT="$(cat "${EXPT}/kill.out" 2>/dev/null)"
+# The killer writes this itself on the victim node. Do NOT switch this
+# back to capturing pbsdsh's stdout: that read empty on job 12473704
+# while the kill had in fact succeeded.
+KILLOUT="$(cat "${RECEIPT}" 2>/dev/null)"
 
 echo
 echo "======================= RESULT ======================="
@@ -209,7 +251,7 @@ else
     # landed (`pbsdsh -- bash -c` mangled the inline script) -- the
     # failover logic was never reached, let alone wrong. If the ranks
     # are still alive there is no bad node and nothing to conclude.
-    grep -q "killed [1-9][0-9]* rank pid" <<< "${KILLOUT}"
+    grep -qE "killed [1-9][0-9]*$" <<< "${KILLOUT}"
     check "the kill actually landed on ${VICTIM}" $?
 
     grep -q "${VICTIM}" <<< "${BAD}"; check "killed host is recorded bad" $?

--- a/experiments/fault-injection/autoretry_nodekill.pbs
+++ b/experiments/fault-injection/autoretry_nodekill.pbs
@@ -1,0 +1,170 @@
+#!/bin/bash -l
+#PBS -N autoretry-nodekill
+#PBS -A datascience
+#PBS -l select=4
+#PBS -l walltime=01:00:00
+#PBS -q workq
+#PBS -l filesystems=tegu:home
+#PBS -j oe
+#
+# Does `ezpz launch --auto-retry` actually swap a bad node out, on real
+# hardware, mid-training?
+#
+# Everything else in the failover stack is tested: 161 unit tests, 22
+# fault-injection tests driving the real loop against real subprocesses.
+# All of it runs in one process on one host. The single claim none of it
+# can reach is the one that matters most in production -- that when a
+# node dies, the NEXT attempt's mpiexec lands somewhere else.
+#
+# Deliberately NOT the same experiment as
+# experiments/checkpoint-restart/: that one kills every node at once
+# (`pbsdsh` with no index) and relaunches on a fixed node set with a
+# hand-rolled `while` loop. With every node hit there is no healthy/bad
+# distinction to fail over between, and with no spares there is nowhere
+# to fail over to. It measures restart cost; this measures failover.
+#
+# The differences that make this one a failover test:
+#   * select=4 with `--nhosts 2` -> 2 active + 2 SPARE hosts
+#   * `--auto-retry` drives the retry loop, not a bash `while`
+#   * `pbsdsh -n <index>` kills ranks on ONE node, so exactly one host
+#     is bad and three stay healthy
+#
+# PASS requires all four, checked at the end:
+#   1. the killed host is named in bad_nodes.txt
+#   2. it is GONE from the active hostfile
+#   3. a spare took its slot
+#   4. the post-kill attempt actually RAN on the new host set
+#      (this is the part no in-process test can establish)
+
+set -u
+set -o pipefail
+
+# PBS runs job scripts non-login, where `module` may exist but
+# MODULEPATH does not -- every `module load` then silently loads
+# nothing (see ezpz #216/#221). The shebang's -l covers it; assert
+# anyway, because the failure mode is a confusing MKL error much later.
+[ -n "${MODULEPATH:-}" ] || {
+    echo "FATAL: MODULEPATH unset -- module load would be a no-op"
+    exit 1
+}
+
+D="${EZPZ_DIR:-${HOME}/datascience/foremans/projects/saforem2/ezpz-validate}"
+cd "${D}" || exit 1
+echo "=== commit: $(git rev-parse --short HEAD) ==="
+
+module load frameworks/2026.1.0
+export PATH="${HOME}/.local/bin:${PATH}:/opt/cray/pals/1.8/bin:/opt/pbs/bin"
+# shellcheck disable=SC1091
+source venvs/aurora_frameworks-2026.1.0/bin/activate
+export PYTHONPATH="${D}/src:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+EXPT="${D}/out/autoretry-nodekill-${PBS_JOBID%%.*}"
+mkdir -p "${EXPT}"
+CKPT="${EXPT}/ckpt"
+LOG="${EXPT}/train.log"
+DONE="${EXPT}/.done"
+
+ACTIVE_HOSTS=2          # --nhosts; the rest of select= becomes spare
+KILL_AFTER_STEP=40      # kill once a complete checkpoint passes this
+TRAIN_ITERS=400
+SAVE_INTERVAL=20
+
+mapfile -t ALL_HOSTS < "${PBS_NODEFILE}"
+echo "=== allocation (${#ALL_HOSTS[@]} hosts) ==="
+printf '  %s\n' "${ALL_HOSTS[@]}"
+echo "=== ${ACTIVE_HOSTS} active + $(( ${#ALL_HOSTS[@]} - ACTIVE_HOSTS )) spare ==="
+
+latest_ckpt_step() {
+    local best=-1 s
+    for d in "$1"/step-*; do
+        [ -e "${d}/.complete" ] || continue
+        s="${d##*step-}"
+        [ "${s}" -gt "${best}" ] 2>/dev/null && best="${s}"
+    done
+    echo "${best}"
+}
+
+# ---- kill ONE node, once ------------------------------------------------
+# `pbsdsh -n 0` targets the first node in the allocation, which is
+# active[0] -- the host auto-retry should retire. Killing a single node
+# is the whole point: with every node dead there is no bad-vs-healthy
+# distinction and nothing to swap.
+chaos() {
+    local victim="${ALL_HOSTS[0]}"
+    echo "${victim}" > "${EXPT}/victim.txt"
+    echo "[CHAOS] victim = ${victim}"
+    while [ "$(latest_ckpt_step "${CKPT}")" -lt "${KILL_AFTER_STEP}" ]; do
+        sleep 3
+        [ -f "${DONE}" ] && { echo "[CHAOS] training ended before the kill"; return 0; }
+    done
+    echo "[CHAOS] killing ranks on ${victim} at $(date +%s) (ckpt=$(latest_ckpt_step "${CKPT}"))"
+    pbsdsh -n 0 -- bash -c 'pkill -9 -f "ezpz.examples.fsdp_tp" 2>/dev/null; true' || true
+    echo "[CHAOS] kill delivered"
+}
+
+chaos & CPID=$!
+
+# ---- the run under test -------------------------------------------------
+# --auto-retry needs the ACTIVE size explicitly: that is how it knows
+# where to split the allocation into active + spare.
+python3 -m ezpz.launch --auto-retry --nhosts "${ACTIVE_HOSTS}" -- \
+    python3 -m ezpz.examples.fsdp_tp \
+        --model agpt-2b --tp 1 --dataset random \
+        --train-iters "${TRAIN_ITERS}" --batch-size 1 --seq-len 512 \
+        --ckpt-dir "${CKPT}" --save-interval "${SAVE_INTERVAL}" \
+        --outdir "${EXPT}/out" 2>&1 | tee -a "${LOG}"
+RC=${PIPESTATUS[0]}
+touch "${DONE}"
+kill "${CPID}" 2>/dev/null || true
+
+# ---- verdict ------------------------------------------------------------
+FO_DIR="$(ls -dt "${D}"/logs/failover-* 2>/dev/null | head -1)"
+VICTIM="$(cat "${EXPT}/victim.txt" 2>/dev/null || echo '<none>')"
+
+echo
+echo "======================= RESULT ======================="
+echo "rc=${RC}  victim=${VICTIM}"
+echo "failover dir: ${FO_DIR:-<none>}"
+[ -n "${FO_DIR}" ] && {
+    echo "--- bad_nodes.txt ---";    cat "${FO_DIR}/bad_nodes.txt"    2>/dev/null
+    echo "--- active.hostfile ---";  cat "${FO_DIR}/active.hostfile"  2>/dev/null
+    echo "--- attempts ---";         ls -1 "${FO_DIR}"/attempt-*.log 2>/dev/null
+    cp -r "${FO_DIR}" "${EXPT}/failover" 2>/dev/null || true
+}
+
+fail=0
+check() {  # check <description> <condition-rc>
+    if [ "$2" -eq 0 ]; then echo "  PASS  $1"; else echo "  FAIL  $1"; fail=1; fi
+}
+
+if [ -z "${FO_DIR}" ]; then
+    echo "  FAIL  --auto-retry produced no failover dir (did it engage?)"
+    fail=1
+else
+    BAD="$(cat "${FO_DIR}/bad_nodes.txt" 2>/dev/null)"
+    ACT="$(cat "${FO_DIR}/active.hostfile" 2>/dev/null)"
+    N_ATTEMPTS="$(ls -1 "${FO_DIR}"/attempt-*.log 2>/dev/null | wc -l)"
+
+    grep -q "${VICTIM}" <<< "${BAD}"; check "killed host is recorded bad" $?
+    ! grep -q "${VICTIM}" <<< "${ACT}"
+    check "killed host is OUT of the active hostfile" $?
+    [ "$(wc -l < "${FO_DIR}/active.hostfile")" -eq "${ACTIVE_HOSTS}" ]
+    check "active set still has ${ACTIVE_HOSTS} hosts (a spare filled in)" $?
+    [ "${N_ATTEMPTS}" -ge 2 ]; check "the job was relaunched (>=2 attempts)" $?
+
+    # The claim no in-process test can make: the post-kill attempt ran
+    # on the NEW host set. PALS prints the hosts it launched on, so the
+    # last attempt log must not name the victim.
+    LAST="$(ls -1t "${FO_DIR}"/attempt-*.log 2>/dev/null | head -1)"
+    if [ -n "${LAST}" ]; then
+        ! grep -q "${VICTIM}" "${LAST}"
+        check "final attempt did NOT run on the dead host ($(basename "${LAST}"))" $?
+    fi
+fi
+
+echo "======================================================"
+[ "${fail}" -eq 0 ] && echo "OVERALL: PASS" || echo "OVERALL: FAIL"
+echo "artifacts: ${EXPT}"
+exit "${fail}"

--- a/experiments/fault-injection/autoretry_nodekill.pbs
+++ b/experiments/fault-injection/autoretry_nodekill.pbs
@@ -169,7 +169,12 @@ touch "${DONE}"
 kill "${CPID}" 2>/dev/null || true
 
 # ---- verdict ------------------------------------------------------------
-FO_DIR="$(ls -dt "${D}"/logs/failover-* 2>/dev/null | head -1)"
+# Address THIS job's dir by id, not `ls -dt | head -1`. Picking the
+# newest by mtime means that if auto-retry never creates one, the
+# verdict silently reads the PREVIOUS job's results -- which, given the
+# checks below, could report PASS from a run that never happened.
+FO_DIR="${D}/logs/failover-${PBS_JOBID%%.*}"
+[ -d "${FO_DIR}" ] || FO_DIR=""
 VICTIM="$(cat "${EXPT}/victim.txt" 2>/dev/null || echo '<none>')"
 # The killer runs under pbsdsh; chaos() tees its output here because the
 # job's own stdout is still spooled by PBS at this point.

--- a/experiments/fault-injection/autoretry_nodekill.pbs
+++ b/experiments/fault-injection/autoretry_nodekill.pbs
@@ -52,10 +52,17 @@ D="${EZPZ_DIR:-${HOME}/datascience/foremans/projects/saforem2/ezpz-validate}"
 cd "${D}" || exit 1
 echo "=== commit: $(git rev-parse --short HEAD) ==="
 
+# lmod's init reads ZSH_EVAL_CONTEXT unguarded, which `set -u` turns
+# into a fatal "unbound variable" the moment `module load` runs. Drop
+# nounset just for the module call rather than for the whole script --
+# the rest of this file relies on it to catch typo'd variables.
+set +u
 module load frameworks/2026.1.0
 export PATH="${HOME}/.local/bin:${PATH}:/opt/cray/pals/1.8/bin:/opt/pbs/bin"
 # shellcheck disable=SC1091
+# Same reason: venv activate scripts also read unset vars (PS1, etc).
 source venvs/aurora_frameworks-2026.1.0/bin/activate
+set -u
 export PYTHONPATH="${D}/src:${PYTHONPATH:-}"
 export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
 export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1


### PR DESCRIPTION
## The confusion, and why it was earned

A reader came away from `checkpoint-restart.md` believing its numbers measured `--auto-retry`. **They don't** — and the page invited the mistake.

"How it works" shows this:

```bash
ezpz launch --auto-retry --np <N> -- \
  python3 -m ezpz.examples.fsdp_tp --model debug ...
```

Twenty lines later the results appear, with nothing in between saying the measurements used a plain relaunch loop instead.

The `.pbs` scripts have always been explicit in their headers —

> This is a plain relaunch loop, **NOT** `--auto-retry` node-swapping (which needs spares and is a separate, production failover layer).

— and the Scope section carefully disclaims TorchFT-style recovery. But the one distinction a reader was most likely to get wrong was the one left implicit.

## What changed

Both pages now carry the same table:

| | what fails | what recovers |
| --- | --- | --- |
| **Checkpoint restart** | the training **process** | relaunch on the **same** nodes, resuming from the last checkpoint |
| **`--auto-retry`** | a **node** | the bad host is retired, a spare takes its slot, the job runs **elsewhere** |

with the reason they're confusable stated outright: **both survive a `pkill -9` and keep training.** The difference is whether the node set changes.

The experiment section also now explains why it couldn't have exercised failover even in principle: `pbsdsh` with no node index hits *every* node, leaving no healthy/bad distinction to fail over between, and the allocation carries no spares to fail over *to*.

## Verification

- `#scope` anchor confirmed present before linking to it
- Docs tests: 5 passed
- Full suite: **1617 passed, 11 skipped**

Docs only — no code changes.

## Summary by Sourcery

Clarify that checkpoint restart and `--auto-retry` provide different recovery mechanisms despite both surviving process termination.

Enhancements:
- Clarify the distinction between same-node checkpoint restart and spare-node `--auto-retry` failover, including their failure modes, recovery behavior, and spare-node requirements.
- Document why the checkpoint-restart experiment cannot measure node failover and cross-reference the relevant fault-injection scope.

Documentation:
- Update checkpoint-restart and fault-injection guides with consistent explanations of restart versus failover semantics and measurement scope.

Chores:
- Add a PBS fault-injection experiment for auto-retry node-kill behavior.