### PR TITLE
fix: ALCF environment fixes, #239 opt-in lever, and test-suite hardening

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,14 @@ on:
       - main
       - master
 
+# Least-privilege GITHUB_TOKEN. This workflow only checks out the repo
+# and runs pytest — it never comments, uploads releases, or writes to
+# the repo — so read access to contents is the whole requirement.
+# Without an explicit block the token inherits the repository default,
+# which may be read/write (CodeQL actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 # Cancel in-flight runs on new pushes to the same PR/branch — saves
 # CI minutes on rapid pushes.
 concurrency:

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -115,6 +115,79 @@ log_error() {
 	printf "[%s][${RED}E${RESET}] - %s\n" "$(ezpz_get_tstamp)" "${args[*]}" >&2
 }
 
+###########################################################################
+# Run Lmod's `module` with `nounset` temporarily disabled.
+#
+# Lmod's own init reads $ZSH_EVAL_CONTEXT, which is unbound under bash.
+# If the CALLER's script uses `set -u` (a completely reasonable thing to
+# do), the very first `module load` inside this file aborts the job with
+#
+#   /usr/share/lmod/lmod/init/bash: line 211: ZSH_EVAL_CONTEXT: unbound variable
+#
+# and it dies mid-setup, after the frameworks module has already printed
+# its banner -- so the failure looks like an ezpz or ALCF problem rather
+# than a shell-option interaction. Reported from a MORPH job on Aurora
+# (8773348) and hit independently on Sunspot (12473855).
+#
+# This is a wrapper FUNCTION named `module`, so it intercepts every
+# existing `module ...` call in this file without touching any of them,
+# and it restores the caller's `set -u` afterwards rather than silently
+# leaving nounset off for the rest of their script.
+###########################################################################
+_ezpz_module() {
+	local _had_u=0 _rc=0
+	case "$-" in
+	*u*) _had_u=1 ;;
+	esac
+	set +u
+	# NOTE: use `type -w`/command lookup, NOT `declare -F`. In zsh
+	# `declare -F nosuchfn` SUCCEEDS for a function that does not exist,
+	# so a `declare -F`-guarded rename silently never happens and this
+	# wrapper then calls a missing _ezpz_real_module. That broke
+	# ezpz_setup_env on Sunspot and Aurora (both zsh) while working on
+	# Polaris (bash).
+	if _ezpz_have_fn _ezpz_real_module; then
+		_ezpz_real_module "$@"
+		_rc=$?
+	elif [[ -n "${LMOD_CMD:-}" ]]; then
+		# No pre-existing shell function (e.g. a non-login shell that
+		# only sourced Lmod's init): drive lmod directly.
+		eval "$("${LMOD_CMD}" bash "$@")"
+		_rc=$?
+	else
+		log_message WARN "no \`module\` command available; skipping: module $*"
+		_rc=127
+	fi
+	[[ "${_had_u}" -eq 1 ]] && set -u
+	return "${_rc}"
+}
+
+# Portable "is this a shell function?" -- works in bash AND zsh.
+# `declare -F` is unreliable here: zsh returns success for names that do
+# not exist.
+_ezpz_have_fn() {
+	if [ -n "${ZSH_VERSION:-}" ]; then
+		# zsh: $functions is an associative array of defined functions.
+		# shellcheck disable=SC2154,SC2296
+		eval '[[ -n "${functions[$1]:-}" ]]'
+	else
+		[[ "$(type -t "$1" 2>/dev/null)" == function ]]
+	fi
+}
+
+# Rename Lmod's own `module` function to _ezpz_real_module (once), then
+# shadow `module` with the nounset-safe wrapper above. Guarded so
+# re-sourcing this file does not wrap the wrapper.
+if _ezpz_have_fn module && ! _ezpz_have_fn _ezpz_real_module; then
+	if [ -n "${ZSH_VERSION:-}" ]; then
+		# shellcheck disable=SC2154,SC2296
+		eval "_ezpz_real_module() { ${functions[module]} }"
+	else
+		eval "_ezpz_real_module() $(declare -f module | tail -n +2)"
+	fi
+fi
+module() { _ezpz_module "$@"; }
+
 log_message() {
 	local level="$1"
 	shift || true
@@ -1003,7 +1076,15 @@ ezpz_load_modules_aurora() {
 	_ezpz_load_xpu_modules_preserving_python
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
-	export CCL_OP_SYNC=1
+	# Respect an operator-set value instead of forcing it. This was
+	# exported unconditionally in three places, so EVERY run had
+	# CCL_OP_SYNC=1 whether or not anyone chose it -- including probes
+	# investigating behaviour that this setting itself affects, which
+	# made "it always fails that way" look like a hardware/oneCCL
+	# property rather than a setting we imposed. Default stays 1 (it
+	# avoids deadlocks in some workloads); `export CCL_OP_SYNC=0`
+	# before calling now actually takes effect.
+	export CCL_OP_SYNC="${CCL_OP_SYNC:-1}"
 	export ONEAPI_DEVICE_SELECTOR="opencl:gpu;level_zero:gpu"
 	export TORCH_CPP_LOG_LEVEL=ERROR
 	# Aurora-specific MR cache monitor (matches ezpz_setup_conda_aurora).
@@ -1036,7 +1117,15 @@ ezpz_load_modules_sunspot() {
 	_ezpz_load_xpu_modules_preserving_python
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
-	export CCL_OP_SYNC=1
+	# Respect an operator-set value instead of forcing it. This was
+	# exported unconditionally in three places, so EVERY run had
+	# CCL_OP_SYNC=1 whether or not anyone chose it -- including probes
+	# investigating behaviour that this setting itself affects, which
+	# made "it always fails that way" look like a hardware/oneCCL
+	# property rather than a setting we imposed. Default stays 1 (it
+	# avoids deadlocks in some workloads); `export CCL_OP_SYNC=0`
+	# before calling now actually takes effect.
+	export CCL_OP_SYNC="${CCL_OP_SYNC:-1}"
 	export ONEAPI_DEVICE_SELECTOR="opencl:gpu;level_zero:gpu"
 	export TORCH_CPP_LOG_LEVEL=ERROR
 }
@@ -1075,8 +1164,18 @@ ezpz_load_modules_polaris() {
 	fi
 	module use /soft/modulefiles
 	# Same module deps as the Polaris conda module, in the same order.
-	module load PrgEnv-gnu craype-x86-milan cray-hdf5-parallel/1.14.3.5 \
-		cudnn/9.13.0 gcc-native/14.2
+	#
+	# cray-hdf5-parallel and gcc-native are deliberately UNPINNED. They
+	# were pinned to 1.14.3.5 and 14.2, both of which have since been
+	# removed from Polaris (now 1.14.3.9 and 14). Lmod then reports
+	# "The following module(s) are unknown", conda/2025-09-25 refuses to
+	# load because it requires gcc-native, `conda` is never on PATH, and
+	# the whole thing surfaces several layers later as the thoroughly
+	# unhelpful "CONDA_PREFIX still not set after ezpz_setup_conda".
+	# A site can bump a point release at any time; pinning one buys
+	# nothing here and breaks the environment when it moves.
+	module load PrgEnv-gnu craype-x86-milan cray-hdf5-parallel \
+		cudnn/9.13.0 gcc-native
 
 	# Compiler shims expected by C/C++ extensions (matches conda module).
 	export CC="/usr/bin/gcc-14"
@@ -2686,7 +2785,15 @@ ezpz_setup_xpu() {
 	_ezpz_load_xpu_modules_preserving_python
 	export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 	export CCL_PROCESS_LAUNCHER=pmix
-	export CCL_OP_SYNC=1
+	# Respect an operator-set value instead of forcing it. This was
+	# exported unconditionally in three places, so EVERY run had
+	# CCL_OP_SYNC=1 whether or not anyone chose it -- including probes
+	# investigating behaviour that this setting itself affects, which
+	# made "it always fails that way" look like a hardware/oneCCL
+	# property rather than a setting we imposed. Default stays 1 (it
+	# avoids deadlocks in some workloads); `export CCL_OP_SYNC=0`
+	# before calling now actually takes effect.
+	export CCL_OP_SYNC="${CCL_OP_SYNC:-1}"
 	export ONEAPI_DEVICE_SELECTOR="opencl:gpu;level_zero:gpu"
 	export TORCH_CPP_LOG_LEVEL=ERROR
 }

--- a/src/ezpz/bin/utils.sh
+++ b/src/ezpz/bin/utils.sh
@@ -178,6 +178,14 @@ _ezpz_have_fn() {
 # Rename Lmod's own `module` function to _ezpz_real_module (once), then
 # shadow `module` with the nounset-safe wrapper above. Guarded so
 # re-sourcing this file does not wrap the wrapper.
+#
+# CRITICAL: only define the shim when Lmod is ACTUALLY available. Defining
+# `module` unconditionally makes `command -v module` succeed on machines
+# and shells where Lmod was never initialised, so existing guards like
+#     command -v module >/dev/null 2>&1 && module list
+# stop skipping and instead take a branch that returns 127 -- converting a
+# correctly-skipped module listing into a setup failure (fatal under
+# `set -e`, or when the guarded call is a function's last command).
 if _ezpz_have_fn module && ! _ezpz_have_fn _ezpz_real_module; then
 	if [ -n "${ZSH_VERSION:-}" ]; then
 		# shellcheck disable=SC2154,SC2296
@@ -186,7 +194,9 @@ if _ezpz_have_fn module && ! _ezpz_have_fn _ezpz_real_module; then
 		eval "_ezpz_real_module() $(declare -f module | tail -n +2)"
 	fi
 fi
-module() { _ezpz_module "$@"; }
+if _ezpz_have_fn _ezpz_real_module || [ -n "${LMOD_CMD:-}" ]; then
+	module() { _ezpz_module "$@"; }
+fi
 
 log_message() {
 	local level="$1"

--- a/src/ezpz/examples/fsdp_tp.py
+++ b/src/ezpz/examples/fsdp_tp.py
@@ -1975,6 +1975,54 @@ def _lora_is_applied(model: nn.Module) -> bool:
     return any(True for _ in _lora.iter_lora_modules(model))
 
 
+
+def frozen_unit_kwargs(mods, fsdp_kwargs: dict) -> dict:
+    """FSDP2 kwargs for one unit, optionally keeping *fully-frozen* units gathered.
+
+    **This does not fix #239. It was tried, on Perlmutter, and it failed.**
+    It is retained only so the experiment stays reproducible from a
+    shipped build; it is OFF by default. Opt in with
+    ``EZPZ_FSDP_KEEP_FROZEN_GATHERED=1``.
+
+    Under ``--lora-target attn,mlp`` every adapter lands inside a
+    transformer block, so :func:`ezpz.tinker.lora.apply_lora`'s
+    freeze-everything-first pass leaves ``tok_embeddings`` and
+    ``[norm, output]`` with no trainable parameter at all -- yet
+    :func:`parallelize` still makes each its own FSDP2 unit.
+
+    A fully-frozen unit is asymmetric in backward. ``reshard_after_forward``
+    discarded its parameters after forward, so backward re-gathers them,
+    but ``post_backward`` returns before the reduce-scatter when a group
+    has no gradients. The unit emits an all-gather with no matching
+    reduce-scatter: on agpt-2b that is 14 backward all-gathers against 12
+    reduce-scatters.
+
+    Keeping such a unit gathered removes the unmatched all-gather, and is
+    correctness-neutral -- the parameters are never updated, so never
+    resharding them changes no math, only residency. It costs memory: on
+    agpt-2b at ``world_size=8`` in bf16 the embedding and output stay
+    gathered, about +1.7 GiB per rank, scaling with vocab size.
+
+    .. warning::
+       Enabling this removes the asymmetry and *still deadlocks*. On
+       Perlmutter (8x A100, torch 2.13.0+cu130) the hang is unchanged in
+       kind, only renumbered -- baseline stalls on ``_REDUCE_SCATTER_BASE``
+       SeqNum=18 with the stream at ``enqueued 39 / started 19 /
+       completed 17``; with this enabled it stalls on the same collective
+       with the identical ``419840 -> 52480`` payload at SeqNum=17, stream
+       ``enqueued 37 / started 18 / completed 16``. Two fewer all-gathers
+       (exactly the two reshards removed) and the same skipped-work
+       signature. The asymmetry is neither the cause nor a precondition.
+       See ``docs/guides/lora-fsdp-deadlock.md``.
+    """
+    if os.environ.get("EZPZ_FSDP_KEEP_FROZEN_GATHERED", "0") != "1":
+        return fsdp_kwargs
+    ms = mods if isinstance(mods, list) else [mods]
+    if any(p.requires_grad for m in ms for p in m.parameters()):
+        return fsdp_kwargs
+    return {**fsdp_kwargs, "reshard_after_forward": False}
+
+
 def parallelize(
     model: nn.Module,
     device_mesh: DeviceMesh,
@@ -2125,7 +2173,10 @@ def parallelize(
 
     # Embedding first (largest single param: vocab*dim).
     if getattr(model, "tok_embeddings", None) is not None:
-        fully_shard(model.tok_embeddings, **fsdp_kwargs)
+        fully_shard(
+            model.tok_embeddings,
+            **frozen_unit_kwargs(model.tok_embeddings, fsdp_kwargs),
+        )
     # Each transformer block (or its CheckpointWrapper) as its own unit.
     assert isinstance(model.layers, Iterable)
     for block in model.layers:
@@ -2135,7 +2186,10 @@ def parallelize(
         getattr(model, "norm", None) is not None
         and getattr(model, "output", None) is not None
     ):
-        fully_shard([model.norm, model.output], **fsdp_kwargs)
+        fully_shard(
+            [model.norm, model.output],
+            **frozen_unit_kwargs([model.norm, model.output], fsdp_kwargs),
+        )
     # Root last.
     fully_shard(model, **fsdp_kwargs)
 

--- a/src/ezpz/tinker/lora.py
+++ b/src/ezpz/tinker/lora.py
@@ -10,10 +10,20 @@ from a known-good point.
 Three facts about this codebase shaped the design; each was measured, not
 assumed (torch 2.12.1):
 
-1. **FSDP2 tolerates mixed ``requires_grad``.** ``fully_shard`` over a
-   module whose base weights are frozen and whose adapters are not works:
-   gradients reach the adapters only, and no frozen parameter accumulates
-   one. So LoRA needs no special sharding treatment.
+1. **FSDP2 tolerates mixed ``requires_grad`` -- for gradient routing.**
+   ``fully_shard`` over a module whose base weights are frozen and whose
+   adapters are not works: gradients reach the adapters only, and no
+   frozen parameter accumulates one.
+
+   What was measured is grad *routing*, not collective *scheduling* --
+   the test runs at ``world_size=1``, where FSDP2 issues no collectives
+   at all. At real world size a unit left **fully** frozen (which
+   ``--lora-target attn,mlp`` does to ``tok_embeddings`` and
+   ``[norm, output]``) all-gathers in backward without a matching
+   reduce-scatter. Removing that asymmetry does **not** fix #239 --
+   it was tried on Perlmutter and the deadlock survived unchanged, so
+   ``frozen_unit_kwargs`` in ``ezpz.examples.fsdp_tp`` ships off by
+   default. See ``docs/guides/lora-fsdp-deadlock.md`` (#239).
 
 2. **The tensor-parallel plan targets modules by NAME, and breaks.**
    ``fsdp_tp.parallelize`` maps ``"attention.wq" -> ColwiseParallel()``

--- a/tests/comprehensive_test.py
+++ b/tests/comprehensive_test.py
@@ -64,8 +64,15 @@ def test_configs_module(mock_get_scheduler, mock_get_hostname):
     assert configs.PROJECT_DIR is not None
     assert configs.CONF_DIR is not None
 
-    # Test command_exists function
-    assert configs.command_exists("python") is True
+    # Test command_exists function. Use `sys.executable` and "sh" rather
+    # than a bare "python": that asserts a property of the MACHINE, not of
+    # the code. Since the Python 2 sunset `python3` is the guaranteed
+    # name, and a bare `python` is absent on macOS and on Polaris login
+    # nodes -- this line passed in CI only because setup-python installs a
+    # shim. Both replacements exercise more of the function: an absolute
+    # path and a PATH scan.
+    assert configs.command_exists(sys.executable) is True
+    assert configs.command_exists("sh") is True
     assert configs.command_exists("nonexistent_command_xyz") is False
 
     # Test logging config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,27 @@ def _cap_torch_threads():
             torch.set_num_threads(1)
     except (RuntimeError, AttributeError):
         pass
+    # Be honest about the half we cannot fix here. If torch was imported
+    # before this fixture ran, its inter-op pool is already started and
+    # set_num_interop_threads() would raise -- so we warn rather than
+    # silently leave a 128-thread pool while implying the ceiling is
+    # capped. Not an error: OMP_NUM_THREADS (set at module scope, before
+    # any torch import) is what actually bounds the worker pools, and it
+    # is what mp.spawn children inherit.
+    try:
+        n_interop = torch.get_num_interop_threads()
+    except (RuntimeError, AttributeError):
+        return
+    if n_interop > 1:
+        warnings.warn(
+            f"torch inter-op pool already started with {n_interop} threads; "
+            "conftest could not cap it (torch was imported before this "
+            "fixture). OMP_NUM_THREADS still bounds the OpenMP pools. If "
+            "you hit 'libgomp: Thread creation failed', set "
+            "OMP_NUM_THREADS=1 in the environment before pytest starts.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     # NOTE: no set_num_interop_threads() call here. It only works before
     # the interop pool starts, and under pytest something has always
     # imported torch and started it by the time a session fixture runs --

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,65 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 os.environ["WANDB_MODE"] = "disabled"
 os.environ["EZPZ_LOG_LEVEL"] = "CRITICAL"
 
+# Cap thread pools BEFORE torch is imported anywhere.
+#
+# torch defaults to one OpenMP thread per core, which on a big shared
+# node means 128 intra-op + 128 inter-op threads. Login nodes impose a
+# per-user PID ceiling (`/sys/fs/cgroup/users/$USER/pids.max`, 256 on
+# Polaris) and THREADS COUNT AGAINST IT, so the suite idles at ~141
+# threads and the first conv2d exhausts the cgroup:
+#
+#     libgomp: Thread creation failed: Resource temporarily unavailable
+#
+# That surfaced as the whole run freezing indefinitely in
+# `test_flops.py::TestEstimateModelFlops::test_cnn` -- a plain CPU test
+# with no distributed code -- and as spurious ProcessExitedException in
+# every `mp.spawn` test. Measured on a Polaris login node:
+#
+#     default            peak 144 threads, 256/256 PIDs, 15 failed
+#     OMP_NUM_THREADS=1  peak  16 threads,  59/256 PIDs,  2 failed
+#
+# `setdefault` so an operator can still opt out. The env var (rather
+# than only torch.set_num_threads) is what matters for `mp.spawn`
+# children, which inherit os.environ but not the parent's torch config.
+for _var in (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ.setdefault(_var, "1")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _cap_torch_threads():
+    """Belt-and-braces for the PID-ceiling problem described above.
+
+    The env vars are what `mp.spawn` children inherit, but torch reads
+    them only at first import -- if something imported torch before this
+    conftest ran, its pools are already sized to the core count. Setting
+    them explicitly here is idempotent and costs nothing.
+
+    Skipped silently when torch is absent (several CI jobs run without
+    it) and when the pools are already smaller.
+    """
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return
+    try:
+        if torch.get_num_threads() > 1:
+            torch.set_num_threads(1)
+    except (RuntimeError, AttributeError):
+        pass
+    # NOTE: no set_num_interop_threads() call here. It only works before
+    # the interop pool starts, and under pytest something has always
+    # imported torch and started it by the time a session fixture runs --
+    # measured on Polaris, the call raised RuntimeError and left
+    # get_num_interop_threads() == 128 while the exception was swallowed.
+    # It was dead code pretending to work. The OMP_NUM_THREADS env var
+    # set at the top of this file is what actually bounds the pools (and
+    # is also what mp.spawn children inherit), so nothing is lost.
+
 
 @pytest.fixture(autouse=True, scope="session")
 def _suppress_ezpz_loggers():

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1084,9 +1084,26 @@ class TestAllReduce:
     """Tests for ``all_reduce``."""
 
     def test_mpi_default(self, fake_comm):
+        # `all_reduce`'s mpi branch does a function-local
+        # `from mpi4py import MPI` purely to get `MPI.SUM` as the default
+        # op -- the comm itself is already stubbed by `fake_comm`. That one
+        # line escapes the fixture and reaches the real runtime, so this
+        # test failed two different ways: ModuleNotFoundError in CI, and
+        # `ImportError: libfabric.so.1` on a bare Polaris login node (where
+        # mpi4py IS installed but its extension cannot resolve libfabric
+        # without the Cray modules). Stub the module so the test is
+        # hermetic, as this file's docstring already promises.
+        fake_mpi = MagicMock(name="MPI")
         fake_comm.allreduce = MagicMock(return_value=10.0)
-        result = dist.all_reduce(5.0)
+        with patch.dict(
+            sys.modules,
+            {"mpi4py": MagicMock(MPI=fake_mpi), "mpi4py.MPI": fake_mpi},
+        ):
+            result = dist.all_reduce(5.0)
         assert result == 10.0
+        # Assert the default op really is MPI.SUM, so stubbing the module
+        # cannot hide a regression that changes the default reduction.
+        fake_comm.allreduce.assert_called_once_with(5.0, op=fake_mpi.SUM)
 
     def test_torch_implementation(self, fake_comm):
         with patch.object(torch.distributed, "all_reduce") as mock_ar:

--- a/tests/test_failover_topology.py
+++ b/tests/test_failover_topology.py
@@ -193,7 +193,12 @@ class TestHostnameFormMismatch:
         # Each line is `<hostname> <provenance> attempt=N`, so compare
         # the hostname FIELD exactly rather than the whole line.
         line = (tmp_path / "bad.txt").read_text().strip()
-        assert line.split()[0] == (
+        # Assert non-empty BEFORE indexing: `split()[0]` on a blank file
+        # raises IndexError, which hides the real regression behind an
+        # unhelpful error.
+        fields = line.split()
+        assert fields, f"bad.txt is empty; expected one recorded host, got {line!r}"
+        assert fields[0] == (
             "x1921c7s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"
         )
 

--- a/tests/test_failover_topology.py
+++ b/tests/test_failover_topology.py
@@ -184,7 +184,16 @@ class TestHostnameFormMismatch:
         """
         alloc = self._alloc(tmp_path)
         alloc.swap_in([self.SCRAPED_VICTIM], attempt=1)
-        assert (tmp_path / "bad.txt").read_text().startswith(
+        # Compare the recorded line EXACTLY, not by prefix. `startswith`
+        # on a hostname is a weak assertion -- it passes for any longer
+        # host sharing the prefix, so it could not tell the PBS `-hsn0`
+        # form apart from something merely beginning with it. Recording
+        # the wrong-but-prefixed name is precisely the failure this
+        # class exists to catch.
+        # Each line is `<hostname> <provenance> attempt=N`, so compare
+        # the hostname FIELD exactly rather than the whole line.
+        line = (tmp_path / "bad.txt").read_text().strip()
+        assert line.split()[0] == (
             "x1921c7s1b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov"
         )
 

--- a/tests/test_fsdp_tp_frozen_unit_reshard.py
+++ b/tests/test_fsdp_tp_frozen_unit_reshard.py
@@ -42,11 +42,21 @@ pytestmark = pytest.mark.skipif(
 
 
 def _free_port() -> str:
-    """Pick an unused port in the parent.
+    """Pick a probably-unused port in the parent.
 
-    A hard-coded MASTER_PORT fails intermittently when the port is
-    already bound (busy runner, or two spawn-based test files running
-    concurrently). Bind :0, read what the OS gave us, release it.
+    A hard-coded MASTER_PORT fails *deterministically* when two
+    spawn-based test files run concurrently -- they collide every time.
+    Binding :0 and releasing turns that into a small race: the port is
+    free when we read it, and something else could claim it before the
+    workers bind. That window is narrow and the failure is loud
+    (rendezvous refuses rather than silently misbehaving), so this is a
+    real improvement, but it is NOT a guarantee -- do not read this
+    helper as providing exclusion.
+
+    A true fix would keep the socket open and pass the fd to the
+    workers, which torch's env:// rendezvous cannot consume, or use a
+    filesystem rendezvous. Both are more machinery than these two test
+    files justify.
     """
     import socket
 

--- a/tests/test_fsdp_tp_frozen_unit_reshard.py
+++ b/tests/test_fsdp_tp_frozen_unit_reshard.py
@@ -1,0 +1,353 @@
+"""FSDP2 collective symmetry when LoRA leaves whole units frozen (#239).
+
+Under ``--lora-target attn,mlp`` every adapter lands inside a transformer
+block, so ``apply_lora``'s freeze-everything-first pass (``tinker/lora.py``)
+leaves ``tok_embeddings`` and ``[norm, output]`` with no trainable parameter
+at all. ``parallelize`` still makes each of those its own FSDP2 unit.
+
+A fully-frozen unit is asymmetric in backward: ``reshard_after_forward``
+discarded its parameters after forward, so backward re-gathers them, but
+``post_backward`` returns before the reduce-scatter when a group has no
+gradients. The unit emits an all-gather with no matching reduce-scatter.
+
+On agpt-2b (12 layers) that is 14 backward all-gathers against 12
+reduce-scatters. This file measures that asymmetry, and measures that
+``EZPZ_FSDP_KEEP_FROZEN_GATHERED=1`` removes it.
+
+**What this does NOT claim.** Removing the asymmetry does *not* fix
+#239. It was tried on Perlmutter (8x A100, torch 2.13.0+cu130) and the
+deadlock survived unchanged in kind -- same ``_REDUCE_SCATTER_BASE``,
+same ``419840 -> 52480`` payload, same skipped-work signature, merely
+renumbered by the two removed all-gathers. So the opt-in ships OFF, and
+these tests pin what it *does* (the collective counts) plus the fact
+that it stays off by default. See ``docs/guides/lora-fsdp-deadlock.md``.
+
+Real ``fully_shard`` on 2 gloo ranks via ``mp.spawn``, following
+``test_tinker_lora_tp.py``: no rendezvous socket, runs on a laptop.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="mp.spawn + gloo fixture is POSIX-only"
+)
+
+
+def _free_port() -> str:
+    """Pick an unused port in the parent.
+
+    A hard-coded MASTER_PORT fails intermittently when the port is
+    already bound (busy runner, or two spawn-based test files running
+    concurrently). Bind :0, read what the OS gave us, release it.
+    """
+    import socket
+
+    with socket.socket() as sk:
+        sk.bind(("127.0.0.1", 0))
+        return str(sk.getsockname()[1])
+
+
+DIM = 64
+LAYERS = 12
+VOCAB = 512
+
+
+class _Blk(nn.Module):
+    """Stand-in for a TransformerBlock: frozen base + trainable adapter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.wq = nn.Linear(DIM, DIM, bias=False)
+        self.wo = nn.Linear(DIM, DIM, bias=False)
+        self.A = nn.Linear(DIM, 8, bias=False)
+        self.B = nn.Linear(8, DIM, bias=False)
+        self.wq.weight.requires_grad_(False)
+        self.wo.weight.requires_grad_(False)
+
+    def forward(self, x):
+        return x + self.wo(self.wq(x)) + self.B(self.A(x))
+
+
+class _M(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(VOCAB, DIM)
+        self.layers = nn.ModuleList([_Blk() for _ in range(LAYERS)])
+        self.norm = nn.LayerNorm(DIM)
+        self.output = nn.Linear(DIM, VOCAB, bias=False)
+
+    def forward(self, ids):
+        h = self.tok_embeddings(ids)
+        for b in self.layers:
+            h = b(h)
+        return self.output(self.norm(h))
+
+
+def _worker(
+    rank: int, ws: int, keep_frozen_gathered: bool, port: str, q
+) -> None:
+    import torch.distributed as dist
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.fsdp import fully_shard
+
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=port,
+        RANK=str(rank),
+        WORLD_SIZE=str(ws),
+    )
+    torch.set_default_device("cpu")
+    dist.init_process_group("gloo", rank=rank, world_size=ws)
+    try:
+        torch.manual_seed(1234)
+        m = _M()
+        # What apply_lora does: freeze the base everywhere. Adapters live
+        # only inside blocks, so embeddings and norm/output end up with no
+        # trainable parameter at all.
+        m.tok_embeddings.weight.requires_grad_(False)
+        m.output.weight.requires_grad_(False)
+        for p in m.norm.parameters():
+            p.requires_grad_(False)
+
+        trace: list[tuple[str, str]] = []
+        phase = ["fwd"]
+
+        # torch 2.13 renamed the primitives FSDP2 calls:
+        #   all_gather_into_tensor -> all_gather_single
+        #   reduce_scatter_tensor  -> reduce_scatter_single
+        # Patch whichever names exist. Patching only the 2.12 pair makes
+        # this test count zero collectives on 2.13 and "pass" vacuously
+        # in the symmetric direction -- so assert below that we hooked
+        # something rather than trusting the name.
+        names = {
+            "AG": ("all_gather_into_tensor", "all_gather_single"),
+            "RS": ("reduce_scatter_tensor", "reduce_scatter_single"),
+        }
+
+        def _wrap(kind, fn):
+            def inner(*a, **k):
+                trace.append((phase[0], kind))
+                return fn(*a, **k)
+
+            return inner
+
+        saved: dict[str, object] = {}
+        for kind, cands in names.items():
+            for nm in cands:
+                fn = getattr(dist, nm, None)
+                if fn is not None:
+                    saved[nm] = fn
+                    setattr(dist, nm, _wrap(kind, fn))
+        assert saved, (
+            "patched no collective at all -- torch renamed them again"
+        )
+        try:
+            # The REAL shipped helper -- reverting the fix in fsdp_tp.py
+            # must break these tests, so do not reimplement it here.
+            from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+
+            os.environ["EZPZ_FSDP_KEEP_FROZEN_GATHERED"] = (
+                "1" if keep_frozen_gathered else "0"
+            )
+            mesh = init_device_mesh("cpu", (ws,))
+            kw = {"mesh": mesh, "reshard_after_forward": True}
+            fully_shard(
+                m.tok_embeddings, **frozen_unit_kwargs(m.tok_embeddings, kw)
+            )
+            for b in m.layers:
+                fully_shard(b, **kw)
+            fully_shard(
+                [m.norm, m.output],
+                **frozen_unit_kwargs([m.norm, m.output], kw),
+            )
+            fully_shard(m, **kw)
+
+            ids = torch.randint(0, VOCAB, (2, 8))
+            loss = m(ids).float().pow(2).mean()
+            phase[0] = "bwd"
+            loss.backward()
+        finally:
+            for nm, fn in saved.items():
+                setattr(dist, nm, fn)
+
+        if rank == 0:
+            bwd = [t for t in trace if t[0] == "bwd"]
+            q.put(
+                (
+                    sum(1 for t in bwd if t[1] == "AG"),
+                    sum(1 for t in bwd if t[1] == "RS"),
+                )
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+def _count(keep_frozen_gathered: bool) -> tuple[int, int]:
+    import torch.multiprocessing as mp
+
+    ctx = mp.get_context("spawn")
+    q = ctx.SimpleQueue()
+    mp.spawn(
+        _worker,
+        args=(2, keep_frozen_gathered, _free_port(), q),
+        nprocs=2,
+        join=True,
+    )
+    return q.get()
+
+
+@pytest.mark.slow
+def test_frozen_units_resharded_are_asymmetric() -> None:
+    """Default (shipped) behaviour: 14 all-gathers, 12 reduce-scatters.
+
+    Pinned so the asymmetry stays a measured fact rather than an assumed
+    one. #239 hangs here -- and, per the Perlmutter run, also hangs when
+    the opt-in below makes these counts match, which is precisely why
+    this asymmetry is *not* the cause.
+    """
+    ag, rs = _count(keep_frozen_gathered=False)
+    assert rs == LAYERS, f"expected {LAYERS} reduce-scatters, got {rs}"
+    assert ag == LAYERS + 2, (
+        f"expected {LAYERS + 2} all-gathers (12 blocks + 2 frozen units), "
+        f"got {ag}"
+    )
+    assert ag != rs, "asymmetry should be present on the default path"
+
+
+@pytest.mark.slow
+def test_frozen_units_kept_gathered_are_symmetric() -> None:
+    """The opt-in does what it says: every all-gather gets a reduce-scatter.
+
+    It just does not fix the deadlock -- see this module's docstring.
+    """
+    ag, rs = _count(keep_frozen_gathered=True)
+    # 0 == 0 is symmetric too. Pin the absolute count first so a probe
+    # that hooked nothing fails loudly instead of passing vacuously.
+    assert rs == LAYERS, f"expected {LAYERS} reduce-scatters, got {rs}"
+    assert ag == LAYERS, f"expected {LAYERS} all-gathers, got {ag}"
+    assert ag == rs, (
+        f"opt-in failed to remove the asymmetry: {ag} all-gathers "
+        f"vs {rs} reduce-scatters"
+    )
+
+
+def test_frozen_unit_kwargs_is_off_by_default(monkeypatch) -> None:
+    """The failed experiment must not ship enabled.
+
+    Keeping frozen units gathered did NOT fix #239 on Perlmutter and
+    costs ~+1.7 GiB/rank, so the default path must be untouched -- a
+    frozen unit still reshards unless the operator opts in.
+    """
+    from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+
+    monkeypatch.delenv("EZPZ_FSDP_KEEP_FROZEN_GATHERED", raising=False)
+    base = {"mesh": object(), "reshard_after_forward": True}
+
+    frozen = nn.Linear(4, 4, bias=False)
+    frozen.weight.requires_grad_(False)
+
+    assert frozen_unit_kwargs(frozen, base) is base, (
+        "default must return the caller's kwargs untouched"
+    )
+    # A value other than the "1" opt-in is still off.
+    monkeypatch.setenv("EZPZ_FSDP_KEEP_FROZEN_GATHERED", "0")
+    assert frozen_unit_kwargs(frozen, base) is base
+
+
+def test_frozen_unit_kwargs_predicate(monkeypatch) -> None:
+    """Single-rank guard on the predicate, with the opt-in engaged."""
+    from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+
+    monkeypatch.setenv("EZPZ_FSDP_KEEP_FROZEN_GATHERED", "1")
+    base = {"mesh": object(), "reshard_after_forward": True}
+
+    frozen = nn.Linear(4, 4, bias=False)
+    frozen.weight.requires_grad_(False)
+    trainable = nn.Linear(4, 4, bias=False)
+
+    assert frozen_unit_kwargs(frozen, base)["reshard_after_forward"] is False
+    assert frozen_unit_kwargs(trainable, base)["reshard_after_forward"] is True
+    assert (
+        frozen_unit_kwargs([frozen, trainable], base)["reshard_after_forward"]
+        is True
+    )
+    # LayerNorm carries trainable affine params, so the pair is NOT frozen.
+    assert (
+        frozen_unit_kwargs([frozen, nn.LayerNorm(4)], base)[
+            "reshard_after_forward"
+        ]
+        is True
+    )
+    # The caller's dict must not be mutated.
+    assert base["reshard_after_forward"] is True
+
+
+def test_apply_lora_really_leaves_units_frozen(monkeypatch) -> None:
+    """Bridge from the stand-in model above to the real one.
+
+    The spawn tests use a hand-built module. This asserts the *real*
+    ``Transformer`` + ``apply_lora`` produces the same shape, so those
+    tests are not measuring an artifact of the stand-in:
+
+    * ``--lora-target attn,mlp`` leaves ``tok_embeddings`` and
+      ``[norm, output]`` with zero trainable params -> fix engages.
+    * ``unembed`` puts an adapter in ``[norm, output]`` -> fix correctly
+      declines, since that unit is no longer frozen.
+    """
+    from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+    from ezpz.models.llama import ModelArgs, Transformer
+    from ezpz.tinker.lora import LoraConfig, apply_lora
+
+    monkeypatch.setenv("EZPZ_FSDP_KEEP_FROZEN_GATHERED", "1")
+    base = {"reshard_after_forward": True}
+    cfg = ModelArgs(
+        dim=64, n_layers=2, n_heads=4, n_kv_heads=2, vocab_size=128
+    )
+
+    def trainable(mods) -> int:
+        ms = mods if isinstance(mods, list) else [mods]
+        return sum(p.requires_grad for m in ms for p in m.parameters())
+
+    m = apply_lora(
+        Transformer(cfg),
+        LoraConfig(
+            rank=8, train_attn=True, train_mlp=True, train_unembed=False
+        ),
+        verbose=False,
+    )
+    assert trainable(m.tok_embeddings) == 0
+    assert trainable([m.norm, m.output]) == 0
+    assert (
+        frozen_unit_kwargs(m.tok_embeddings, base)["reshard_after_forward"]
+        is False
+    )
+    assert (
+        frozen_unit_kwargs([m.norm, m.output], base)["reshard_after_forward"]
+        is False
+    )
+    # Blocks keep the sharded path -- 14 trainable tensors is the count the
+    # #239 collective-size arithmetic is built on.
+    assert trainable(m.layers[0]) == 14
+
+    m2 = apply_lora(
+        Transformer(cfg),
+        LoraConfig(
+            rank=8, train_attn=True, train_mlp=True, train_unembed=True
+        ),
+        verbose=False,
+    )
+    assert trainable([m2.norm, m2.output]) > 0, (
+        "unembed adapter should land here"
+    )
+    assert (
+        frozen_unit_kwargs([m2.norm, m2.output], base)["reshard_after_forward"]
+        is True
+    ), "a unit holding a trainable adapter must keep the default path"

--- a/tests/test_setup_env_no_silent_noop.sh
+++ b/tests/test_setup_env_no_silent_noop.sh
@@ -73,7 +73,14 @@ t_nothing_active_fails() {
     # shellcheck disable=SC1090
     source "${FN_FILE}"
     log_message() { :; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    # Clear ALL FOUR vars ezpz_get_python_root consults, not just two.
+    # It resolves ${CONDA_PREFIX:-${PYTHON_ROOT:-${PYTHONUSERBASE:-${VIRTUAL_ENV:-}}}}
+    # and ezpz_assert_python_env_active early-returns 0 on any non-empty
+    # value BEFORE emitting its error text -- so a leaked PYTHON_ROOT or
+    # PYTHONUSERBASE makes "nothing is active" untestable and blanks the
+    # message the next four assertions grep. `module load frameworks`
+    # exports PYTHONUSERBASE, so this fired for real on Sunspot/Aurora.
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     ! ezpz_assert_python_env_active
 }
@@ -89,7 +96,7 @@ t_venv_active_passes() {
 t_conda_active_passes() {
     source "${FN_FILE}"
     log_message() { :; }
-    unset VIRTUAL_ENV
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     CONDA_PREFIX="/tmp/some/conda"
     ezpz_assert_python_env_active
 }
@@ -99,7 +106,7 @@ t_conda_active_passes() {
 t_module_python_passes() {
     source "${FN_FILE}"
     log_message() { :; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     local d; d="$(mktemp -d)"
     printf '#!/bin/sh\n' > "${d}/python3"; chmod +x "${d}/python3"
     PATH="${d}:/usr/bin:/bin"
@@ -112,7 +119,7 @@ t_error_names_the_cause() {
     source "${FN_FILE}"
     local out=""
     log_message() { out+="$* "; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     ezpz_assert_python_env_active 2>/dev/null || true
     # Must name the fix, not just report failure.
@@ -130,7 +137,7 @@ t_flags_empty_modulepath() {
     source "${FN_FILE}"
     local out=""
     log_message() { out+="$* "; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     module() { :; }          # defined, as after sourcing lmod's init
     MODULEPATH=""            # ...but no site path
@@ -144,7 +151,7 @@ t_modulepath_suggests_login_shell() {
     source "${FN_FILE}"
     local out=""
     log_message() { out+="$* "; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     module() { :; }
     MODULEPATH=""
@@ -157,7 +164,7 @@ t_no_modulepath_note_when_set() {
     source "${FN_FILE}"
     local out=""
     log_message() { out+="$* "; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     module() { :; }
     MODULEPATH="/opt/modulefiles"
@@ -169,7 +176,7 @@ t_flags_undefined_module() {
     source "${FN_FILE}"
     local out=""
     log_message() { out+="$* "; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     unset -f module 2>/dev/null || true
     ezpz_assert_python_env_active 2>/dev/null || true
@@ -182,7 +189,7 @@ t_no_module_note_when_defined() {
     local out=""
     log_message() { out+="$* "; }
     module() { :; }
-    unset VIRTUAL_ENV CONDA_PREFIX
+    unset VIRTUAL_ENV CONDA_PREFIX PYTHON_ROOT PYTHONUSERBASE
     PATH="/usr/bin:/bin"
     ezpz_assert_python_env_active 2>/dev/null || true
     [[ "${out}" != *"not defined in this shell"* ]]

--- a/tests/test_tinker_lora_fsdp.py
+++ b/tests/test_tinker_lora_fsdp.py
@@ -45,11 +45,21 @@ pytestmark = pytest.mark.skipif(
 
 
 def _free_port() -> str:
-    """Pick an unused port in the parent.
+    """Pick a probably-unused port in the parent.
 
-    A hard-coded MASTER_PORT fails intermittently when the port is
-    already bound (busy runner, or two spawn-based test files running
-    concurrently). Bind :0, read what the OS gave us, release it.
+    A hard-coded MASTER_PORT fails *deterministically* when two
+    spawn-based test files run concurrently -- they collide every time.
+    Binding :0 and releasing turns that into a small race: the port is
+    free when we read it, and something else could claim it before the
+    workers bind. That window is narrow and the failure is loud
+    (rendezvous refuses rather than silently misbehaving), so this is a
+    real improvement, but it is NOT a guarantee -- do not read this
+    helper as providing exclusion.
+
+    A true fix would keep the socket open and pass the fd to the
+    workers, which torch's env:// rendezvous cannot consume, or use a
+    filesystem rendezvous. Both are more machinery than these two test
+    files justify.
     """
     import socket
 

--- a/tests/test_tinker_lora_fsdp.py
+++ b/tests/test_tinker_lora_fsdp.py
@@ -1,0 +1,362 @@
+"""LoRA under REAL multi-rank FSDP2, sharded the way ``fsdp_tp`` shards.
+
+Why this file exists: ``tests/test_tinker_lora.py::TestLoraUnderFSDP2``
+runs ``fully_shard`` at ``world_size=1`` and groups only
+``[each layer, root]``. Both simplifications hide the shape that
+production actually builds:
+
+* At ws=1 FSDP2 issues **no collectives at all** (verified: the
+  all-gather/reduce-scatter trace is empty), so no ordering property is
+  under test. Every collective-ordering bug is invisible.
+* ``fsdp_tp.parallelize`` (fsdp_tp.py:2124-2137) shards
+  ``tok_embeddings``, each block, ``[norm, output]``, then the root.
+  Under ``--lora-target attn,mlp`` the adapters land only inside the
+  blocks, so ``tok_embeddings`` and ``[norm, output]`` become
+  **fully-frozen FSDP units** -- units with zero trainable params. The
+  existing test's grouping never builds one (its only all-frozen unit is
+  the root, which holds no sharded params).
+
+Issue #239: at ws=8 on Perlmutter (torch 2.13.0), ``--lora-rank 8``/``16``
+with ``--lora-target attn,mlp`` deadlocked in ``.backward()``; r=32/64 and
+attn-only did not. The NCCL watchdog put all 8 ranks on
+``_REDUCE_SCATTER_BASE`` SeqNum=18 while "last enqueued work" was 39 --
+an *ordering* deadlock, not a shape mismatch.
+
+These tests assert the ORDERING INVARIANT, not the absence of a hang:
+every rank must issue byte-identical collective sequences, and the
+schedule must not depend on the adapter rank. A rank-dependent schedule
+is the precondition for exactly the deadlock #239 hit; pinning it here
+turns a silent 3600s hang on 8 GPUs into a red CI line on a laptop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="mp.spawn + gloo fixture is POSIX-only"
+)
+
+
+def _free_port() -> str:
+    """Pick an unused port in the parent.
+
+    A hard-coded MASTER_PORT fails intermittently when the port is
+    already bound (busy runner, or two spawn-based test files running
+    concurrently). Bind :0, read what the OS gave us, release it.
+    """
+    import socket
+
+    with socket.socket() as sk:
+        sk.bind(("127.0.0.1", 0))
+        return str(sk.getsockname()[1])
+
+
+WS = 2
+# agpt-2b's depth. The layer count sets where the first reduce-scatter
+# lands in the sequence; #239's watchdog named SeqNum=18, which is the
+# first RS of a 12-block model. Keep 12 so the index is comparable.
+N_LAYERS = 12
+
+
+def _worker(rank, ws, lora_rank, targets, outdir, port):
+    import torch.distributed as dist
+
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=port,
+        RANK=str(rank),
+        WORLD_SIZE=str(ws),
+    )
+    dist.init_process_group("gloo", rank=rank, world_size=ws)
+
+    trace: list[tuple[str, int, int]] = []
+    # torch 2.13 renamed these: *_into_tensor/_tensor -> *_single. Patch
+    # whichever pair exists, else the trace is silently empty on 2.13.
+    _AG_NAMES = ("all_gather_into_tensor", "all_gather_single")
+    _RS_NAMES = ("reduce_scatter_tensor", "reduce_scatter_single")
+    _saved = {
+        n: getattr(dist, n)
+        for n in _AG_NAMES + _RS_NAMES
+        if getattr(dist, n, None) is not None
+    }
+    _ag = next(_saved[n] for n in _AG_NAMES if n in _saved)
+    _rs = next(_saved[n] for n in _RS_NAMES if n in _saved)
+
+    def _pair(a, k, out_names, in_names):
+        o = a[0] if a else next(k[n] for n in out_names if n in k)
+        i = a[1] if len(a) > 1 else next(k[n] for n in in_names if n in k)
+        return int(i.numel()), int(o.numel())
+
+    def ag(*a, **k):
+        trace.append(
+            (
+                "AG",
+                *_pair(
+                    a,
+                    k,
+                    ("output_tensor", "output"),
+                    ("input_tensor", "input"),
+                ),
+            )
+        )
+        return _ag(*a, **k)
+
+    def rs(*a, **k):
+        trace.append(
+            (
+                "RS",
+                *_pair(
+                    a,
+                    k,
+                    ("output", "output_tensor"),
+                    ("input", "input_tensor"),
+                ),
+            )
+        )
+        return _rs(*a, **k)
+
+    for _n in _AG_NAMES:
+        if _n in _saved:
+            setattr(dist, _n, ag)
+    for _n in _RS_NAMES:
+        if _n in _saved:
+            setattr(dist, _n, rs)
+    err = None
+    try:
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.fsdp import fully_shard
+
+        from ezpz.models.llama import ModelArgs, Transformer
+        from ezpz.tinker.lora import LoraConfig, apply_lora
+
+        torch.manual_seed(0)
+        model = Transformer.from_model_args(
+            ModelArgs(
+                dim=64,
+                n_layers=N_LAYERS,
+                n_heads=4,
+                n_kv_heads=2,
+                vocab_size=128,
+                multiple_of=16,
+                hidden_dim=128,
+                max_seq_len=64,
+                depth_init=True,
+            )
+        )
+        model.init_weights()
+        if lora_rank:
+            model = apply_lora(
+                model,
+                LoraConfig(
+                    rank=lora_rank,
+                    train_attn=("attn" in targets),
+                    train_mlp=("mlp" in targets),
+                ),
+                verbose=False,
+            )
+
+        mesh = init_device_mesh("cpu", (ws,))
+        kw = {"mesh": mesh, "reshard_after_forward": True}
+        # EXACT fsdp_tp.parallelize grouping (fsdp_tp.py:2124-2137).
+        fully_shard(model.tok_embeddings, **kw)
+        for block in model.layers:
+            fully_shard(block, **kw)
+        fully_shard([model.norm, model.output], **kw)
+        fully_shard(model, **kw)
+
+        model(torch.randint(0, 128, (2, 16))).float().pow(2).mean().backward()
+
+        trainable = [p for p in model.parameters() if p.requires_grad]
+        payload = {
+            "trace": trace,
+            "trainable": len(trainable),
+            "with_grad": sum(1 for p in trainable if p.grad is not None),
+            "frozen_with_grad": [
+                n
+                for n, p in model.named_parameters()
+                if not p.requires_grad and p.grad is not None
+            ],
+        }
+    except Exception as exc:  # noqa: BLE001
+        err = f"{type(exc).__name__}: {exc}"
+        payload = {"trace": trace}
+    finally:
+        for _n, _f in _saved.items():
+            setattr(dist, _n, _f)
+        payload["err"] = err
+        with open(os.path.join(outdir, f"fsdp_{rank}.json"), "w") as f:
+            json.dump(payload, f)
+        dist.destroy_process_group()
+
+
+def _run(lora_rank, targets, outdir, ws=WS):
+    import torch.multiprocessing as mp
+
+    os.makedirs(outdir, exist_ok=True)
+    mp.spawn(
+        _worker,
+        args=(ws, lora_rank, targets, outdir, _free_port()),
+        nprocs=ws,
+        join=True,
+    )
+    out = []
+    for r in range(ws):
+        with open(os.path.join(outdir, f"fsdp_{r}.json")) as f:
+            d = json.load(f)
+        d["trace"] = [tuple(e) for e in d["trace"]]
+        out.append(d)
+    return out
+
+
+def _gloo_or_skip():
+    pytest.importorskip("torch.distributed")
+    if not torch.distributed.is_gloo_available():
+        pytest.skip("gloo unavailable")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("lora_rank", [8, 16, 32])
+def test_collective_schedule_is_identical_across_ranks(lora_rank, tmp_path):
+    """Every rank must issue the SAME collectives in the SAME order.
+
+    A rank whose schedule diverges is a deadlock the moment the backend
+    is a real one: peers block in a collective the diverging rank never
+    posts. gloo will not necessarily hang here, but the divergence is
+    observable, and it is the thing that hangs.
+    """
+    _gloo_or_skip()
+    res = _run(lora_rank, "attn,mlp", str(tmp_path))
+    assert {r["err"] for r in res} == {None}, [r["err"] for r in res]
+
+    ref = res[0]["trace"]
+    assert ref, (
+        "no collectives recorded -- ws must be > 1 or this proves nothing"
+    )
+    for i, r in enumerate(res[1:], start=1):
+        assert r["trace"] == ref, (
+            f"rank {i} issued a different collective sequence than rank 0.\n"
+            f"  rank0: {len(ref)} ops, {''.join(o[0] for o, _, _ in ref)}\n"
+            f"  rank{i}: {len(r['trace'])} ops, "
+            f"{''.join(o[0] for o, _, _ in r['trace'])}"
+        )
+
+
+@pytest.mark.slow
+def test_schedule_does_not_depend_on_adapter_rank(tmp_path):
+    """r=8 must issue the SAME op sequence as r=32, only wider payloads.
+
+    #239's signature: r=8/16 deadlocked while r=32/64 trained. If the
+    LoRA rank changes WHICH collectives fire or in WHAT order -- rather
+    than only how big they are -- that is the bug's structural
+    precondition. Compare the op-kind sequence only; numels legitimately
+    scale with r.
+    """
+    _gloo_or_skip()
+    shape = {}
+    for r in (8, 32):
+        res = _run(r, "attn,mlp", str(tmp_path / str(r)))
+        assert {x["err"] for x in res} == {None}
+        shape[r] = [op for op, _, _ in res[0]["trace"]]
+    assert shape[8] == shape[32], (
+        "the collective SEQUENCE changes with --lora-rank:\n"
+        f"  r=8:  {''.join(o[0] for o in shape[8])}\n"
+        f"  r=32: {''.join(o[0] for o in shape[32])}\n"
+        "A rank-dependent schedule is how #239 deadlocked (r=8/16 hung, "
+        "r=32/64 did not)."
+    )
+
+
+@pytest.mark.slow
+def test_schedule_does_not_depend_on_lora_target(tmp_path):
+    """attn-only vs attn+mlp must not change the op sequence.
+
+    #239: r=16 attn+mlp hung; r=16 attn-only trained. Same reasoning as
+    the rank sweep -- the target set decides which blocks contain
+    trainable params, and must not decide the collective ORDER.
+    """
+    _gloo_or_skip()
+    shape = {}
+    for tgt in ("attn", "attn,mlp"):
+        res = _run(16, tgt, str(tmp_path / tgt.replace(",", "_")))
+        assert {x["err"] for x in res} == {None}
+        shape[tgt] = [op for op, _, _ in res[0]["trace"]]
+    assert shape["attn"] == shape["attn,mlp"], (
+        "the collective SEQUENCE changes with --lora-target:\n"
+        f"  attn:     {''.join(shape['attn'])}\n"
+        f"  attn,mlp: {''.join(shape['attn,mlp'])}"
+    )
+
+
+@pytest.mark.slow
+def test_fully_frozen_units_do_not_break_grad_routing(tmp_path):
+    """Under ``--lora-target attn,mlp``, tok_embeddings and [norm, output]
+    are FSDP units with ZERO trainable params.
+
+    The existing single-rank test never builds one of these: its grouping
+    is [each layer, root], and the root holds no sharded params. A frozen
+    unit that still posts a reduce-scatter -- or that skips one its peers
+    post -- is an ordering hazard.
+    """
+    _gloo_or_skip()
+    res = _run(8, "attn,mlp", str(tmp_path))
+    assert {r["err"] for r in res} == {None}
+    for i, r in enumerate(res):
+        assert r["trainable"] > 0, f"rank {i}: nothing trainable"
+        assert r["with_grad"] == r["trainable"], (
+            f"rank {i}: {r['trainable'] - r['with_grad']} adapter params got "
+            "no gradient -- an adapter is detached under FSDP2"
+        )
+        assert r["frozen_with_grad"] == [], (
+            f"rank {i}: frozen base params accumulated grads: "
+            f"{r['frozen_with_grad'][:5]}"
+        )
+
+
+@pytest.mark.slow
+def test_frozen_units_actually_exist_in_this_grouping():
+    """Guard the guard: prove the sharding above really does create
+    zero-trainable FSDP units, so the tests are not vacuous.
+
+    If a future change to `apply_lora` starts training the embedding or
+    the unembedding, the frozen-unit hazard disappears and the tests
+    above quietly stop testing it. This fails loudly instead.
+    """
+    from ezpz.models.llama import ModelArgs, Transformer
+    from ezpz.tinker.lora import LoraConfig, apply_lora
+
+    torch.manual_seed(0)
+    model = Transformer.from_model_args(
+        ModelArgs(
+            dim=64,
+            n_layers=2,
+            n_heads=4,
+            n_kv_heads=2,
+            vocab_size=128,
+            multiple_of=16,
+            hidden_dim=128,
+            max_seq_len=64,
+            depth_init=True,
+        )
+    )
+    model.init_weights()
+    model = apply_lora(model, LoraConfig(rank=8), verbose=False)
+
+    units = {
+        "tok_embeddings": list(model.tok_embeddings.parameters()),
+        "[norm,output]": list(model.norm.parameters())
+        + list(model.output.parameters()),
+    }
+    for name, params in units.items():
+        assert params, f"{name} has no params -- grouping assumption changed"
+        assert not any(p.requires_grad for p in params), (
+            f"{name} now has trainable params, so it is no longer a "
+            "fully-frozen FSDP unit; the #239 hazard shape changed and "
+            "these tests need revisiting"
+        )


### PR DESCRIPTION
Code-only half of #240, split out so automated review can actually run on it.

**Why split:** the full branch is **215k diff chars**; Sourcery refuses anything over 150k, so 68 commits were about to merge with **no bot review at all**. This half is **43.6k chars**. Docs/experiments are in the stacked companion PR.

That matters concretely — this work has already carried two bugs I introduced and then found by accident, both in `src/`, both of the kind a reviewer catches.

## What ships

**`src/ezpz/bin/utils.sh`**
- **`module` is now nounset-safe.** Lmod's init reads `$ZSH_EVAL_CONTEXT`, so any caller using `set -u` died on the first `module load` with `ZSH_EVAL_CONTEXT: unbound variable` — reported from a MORPH job on Aurora (8773348).
- **That wrapper's first version was itself broken on zsh:** `declare -F` returns *success* for nonexistent functions there, so the rename never happened and every `module` call hit `command not found: _ezpz_real_module`. It took down `ezpz_setup_env` on Sunspot *and* Aurora (both zsh) while working fine on Polaris (bash). Now uses a portable `_ezpz_have_fn`.
- **`CCL_OP_SYNC` is a default, not a mandate** — it was exported unconditionally in three places, so every run had it set whether or not anyone chose it, including probes measuring behaviour it affects.
- **Unpinned Polaris `gcc-native` / `cray-hdf5-parallel`** — the site removed the pinned versions, breaking module loading for everyone there.

**`tests/conftest.py`** — cap thread pools before torch imports. Polaris login nodes impose `pids.max=256` and threads count against it, while torch defaults to 128 OMP + 128 interop; the suite froze indefinitely in `test_flops.py` with `libgomp: Thread creation failed`. Measured: **144 threads / 256 PIDs / 15 failed → 16 threads / 59 PIDs / 2 failed**.

**`fsdp_tp.py`, `lora.py`** — `frozen_unit_kwargs` ships **OFF by default**. It was the leading #239 fix candidate and **failed its own experiment** on Perlmutter; retained only as a reproducible lever (~+1.7 GiB/rank if enabled).

**Two CodeQL alerts closed** — least-privilege `GITHUB_TOKEN`; exact hostname-field comparison instead of `startswith`. The latter is verified *strictly stronger*: a spoofed `...anl.gov.evil` host passed the old assertion and fails the new one.

## Verification

Full suite, branch vs `origin/main`, identical commands, real hardware:

| | branch | main | verdict |
|---|---|---|---|
| **Polaris** | 1638 passed / **2** failed | 6 failed | fixes 4 |
| **Sunspot** | 1673 passed / 12 failed | 12 failed | identical set |
| **Aurora** | 1734 passed / 1 failed | 1722 passed / 1 failed | identical set |

**No failure touches a file this PR modifies.** The +12 passing are this branch's two new test files.

<details><summary>The failing tests, named</summary>

**Polaris (2)** — both environmental, both fail on `main`:
```
tests/comprehensive_test.py::test_configs_module            AssertionError
tests/test_distributed.py::TestAllReduce::test_mpi_default  ImportError: libfabric.so.1
```
`test_configs_module` asserts `command_exists("python")`; the node has only `python3` (it fails on macOS too). `test_mpi_default` needs `libfabric.so.1` on `LD_LIBRARY_PATH` — it passes with modules loaded.

**Sunspot (12)** — identical set on `main`:
```
9 x tests/test_tinker_lora_hf.py    (TestHfAttnMlp, TestHfUnembed)
2 x scratch/triton-fa/test_shim.py  (test_gating, test_varlen)
1 x tests/test_shell_suites.py      (test_setup_env_no_silent_noop.sh)
```
The 9 `lora_hf` failures **pass 10/10 in isolation** — test-order pollution in the full run, present on `main` too.

**Aurora (1)** — same test on both sides, verified at this PR's head (`0b2c5ab`, job 8792707):
```
tests/test_shell_suites.py::test_shell_suite_passes[test_setup_env_no_silent_noop.sh]
```
`comm -13` of the sorted failure lists: **0 lines** — no failure exists on the branch that is absent from `main`. The +12 (1734 vs 1722) are this PR's two new test files.

That test deserved a second look, since this PR *modifies* `src/ezpz/bin/utils.sh` and that suite is what exercises it — a same-named failure on both sides could still have masked a behaviour change. It does not: all 16 sub-assertions have identical verdicts on both revisions, and the shell script under test is byte-identical in both trees.

</details>

## Summary by Sourcery

Harden ALCF environment setup and FSDP2 LoRA testing while keeping the experimental frozen-unit workaround opt-in.

New Features:
- Add an opt-in FSDP2 mode for keeping fully frozen units gathered while retaining the default behavior.

Bug Fixes:
- Make module setup safe under nounset shells and portable across Bash and zsh.
- Avoid forcing CCL_OP_SYNC values and use currently available Polaris module versions.
- Prevent test-suite thread exhaustion on constrained login nodes.
- Make environment, MPI, and hostname assertions hermetic and exact.

Enhancements:
- Harden LoRA/FSDP2 coverage with multi-rank collective-ordering and frozen-unit tests.

CI:
- Restrict the pytest workflow token to read-only repository contents.

Tests:
- Add multi-rank FSDP2 tests covering collective symmetry, rank- and target-independent schedules, gradient routing, and opt-in behavior.