### PR TITLE
docs(#239): investigation writeup, ALCF runbook, and experiment scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 Guidance for AI coding assistants (and humans) working in this repo.
 
+> [!IMPORTANT]
+> **Running anything on an HPC system (Aurora, Sunspot, Polaris,
+> Perlmutter)? Read [`SKILL.md`](SKILL.md) FIRST.**
+>
+> Job submission, environment setup, and — more importantly — the
+> failure modes that silently produce *wrong results* rather than
+> errors: batch-shell `MODULEPATH` no-ops, non-editable installs that
+> shadow your working tree, exit codes that misreport a successful run,
+> and collectives that vanish from a probe after a torch rename.
+
 ## Dev environment tips
 
 - Use `source <(curl -LsSf https://bit.ly/ezpz-utils) && ezpz_setup_env` to

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: ezpz
+description: Use when running, testing, or benchmarking ezpz on an HPC system (Aurora, Sunspot, Polaris, Perlmutter) — job submission, environment setup, and the failure modes that silently produce wrong results.
+---
+
+# Running `ezpz` on HPC
+
+Read this **before** writing a batch script or ssh'ing into a cluster.
+Everything here was learned by losing allocations to it.
+
+## The one-liner
+
+On **every** ALCF system, in the repo root:
+
+```bash
+source <(curl -fsSL https://bit.ly/ezpz-utils) && ezpz_setup_env
+ezpz launch python3 -m ezpz.examples.test
+```
+
+`ezpz_setup_env` is the whole setup: it selects the python/venv, loads
+the machine's module stack, and builds the hostfile. **Do not
+hand-assemble it** from `ezpz_load_modules_<machine>` +
+`ezpz_setup_conda_<machine>` + a venv activation. Four Sunspot
+allocations were burned doing that; each failed differently and none
+produced a result.
+
+To exercise a working tree instead of the installed package:
+
+```bash
+uvi -e .            # editable install
+# or, without installing:
+export PYTHONPATH="$PWD/src:$PYTHONPATH"
+```
+
+## Inside a batch script, three things change
+
+### 1. Compute nodes have no outbound internet
+
+`source <(curl -fsSL https://bit.ly/ezpz-utils)` **times out after
+~270 s** and then silently leaves the environment unconfigured. Source
+the repo's own copy — the same file:
+
+```bash
+source "${D}/src/ezpz/bin/utils.sh"
+ezpz_setup_env || { echo "FATAL: ezpz_setup_env failed"; exit 1; }
+```
+
+### 2. PBS runs your script under a NON-login shell
+
+`qsub ... -- /bin/bash script.sh` gives you a shell where `module` does
+not exist. Worse, sourcing Lmod's `init/bash` alone defines `module` but
+leaves **`MODULEPATH` empty**, so every `module load` becomes a silent
+no-op ("No modules loaded") and `ezpz_setup_env` fails downstream with
+the misleading `CONDA_PREFIX still not set`.
+
+Source the login profile, and assert it worked.
+
+**Do not use `set -u` in these scripts at all.** The module system is
+not `set -u`-clean, in two separate places:
+
+- `/etc/profile` references unset variables, so sourcing it under
+  `set -u` aborts the script on that line — walltime `00:00:00`,
+  `Exit_status=1`, **empty `.o` and `.e`**, not one line printed.
+- Deferring `set -u` past the profile is *still* not enough: Lmod's
+  `init/bash` reads `$ZSH_EVAL_CONTEXT`, and `ezpz_setup_env` re-enters
+  the module machinery long after the preamble, so it dies mid-setup
+  with `ZSH_EVAL_CONTEXT: unbound variable`.
+
+Reproduce both with `bash -c 'set -u; source /etc/profile'`.
+
+```bash
+set -o pipefail                       # and NOT set -u, anywhere
+source /etc/profile 2>/dev/null || true
+command -v module >/dev/null 2>&1 || { echo "FATAL: no module cmd"; exit 1; }
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH empty"; exit 1; }
+```
+
+Use `${VAR:-default}` everywhere and explicit `[ -n ... ]` checks
+instead — on these systems the shell strictness has to give way to the
+module system, not the other way round.
+
+An empty `.o`/`.e` with zero walltime always means the script died in
+its own preamble. Check `qstat -xf <jobid>` for `Exit_status` and
+`resources_used.walltime` before assuming anything about the run.
+
+**Dry-run the preamble before submitting.** Everything above the first
+`probe` call can be pasted into `ssh <host> bash -c '...'` and checked
+in seconds. Six Sunspot submissions were spent discovering preamble bugs
+one allocation at a time; each would have been caught by a five-second
+dry run.
+
+### 3. Login-node checks do not predict compute-node behaviour
+
+`ezpz_setup_env` **fails on the Sunspot login node** (`CONDA_PREFIX
+still not set`) because `module load frameworks` is a compute-node
+thing. A login-node smoke test is not evidence the job will work —
+and conversely, a login-node success is not evidence either: a
+Perlmutter module combination that verified clean on the login node
+still died with `ImportError: libcudart.so.13` on the compute nodes.
+
+## Machine specifics
+
+| | Sunspot | Aurora | Polaris | Perlmutter |
+|---|---|---|---|---|
+| accel | PVC (XPU) | PVC (XPU) | A100 | A100 |
+| collectives | xccl | xccl | NCCL | NCCL |
+| per node | 12 tiles | 12 tiles | 4 GPUs | 4 GPUs |
+| scheduler | PBS | PBS | PBS | SLURM |
+
+**Sunspot.** `qsub` is not on `$PATH` over plain ssh — use
+`/opt/pbs/bin/qsub`. All four flags are required:
+
+```
+/opt/pbs/bin/qsub -l select=2 -l walltime=01:00:00 \
+  -l filesystems=tegu:home -A datascience -q workq \
+  -o $D/job.o -e $D/job.e -- /bin/bash $D/script.sh
+```
+
+- `-A datascience` — `Aurora_deployment` has no active Sunspot allocation.
+- `-l filesystems=tegu:home` — required; `flare` is not valid here.
+- Scripts **and** `-o`/`-e` must live on a shared filesystem. The login
+  node's `/tmp` is not the compute node's `/tmp`.
+- `$HOME/datascience` → `/lus/tegu/projects/datascience` (same dir).
+
+**Perlmutter.** `module load nccl/2.24.3` or **NCCL silently falls back
+to TCP** — 8.3× slower inter-node, no error, nothing in the log. Also
+load `cudatoolkit/12.9` and do **not** swap it per torch build: the
+NERSC NCCL plugin links `libcudart.so.12`, so under `cudatoolkit/13.0`
+it fails with `Failed to initialize any NET plugin`.
+
+## Debugging a hang
+
+**Lower `TORCH_DDP_TIMEOUT`.** It defaults to 3600 s, so a deadlock
+outlives a debug allocation and looks like silence rather than a
+watchdog dump. This is the single highest-value diagnostic:
+
+```bash
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+```
+
+## Writing an experiment script
+
+Rules that come from real misreadings, not style preference:
+
+- **Never classify a run by exit code.** A cell can exit `rc=1` having
+  trained all 20 iterations (teardown failure), and hanging cells exit
+  124 *or* 134. Classify on evidence: a watchdog line means HANG,
+  reaching the plotting stage means TRAINED.
+- **Do not gate on an `iter=` marker** — `fsdp_tp` runs do not emit one,
+  and requiring it once labelled a clean 173 s pass INDETERMINATE.
+- **Have a third verdict.** A crash, OOM, or bad environment is
+  `INDETERMINATE` — it is *not* evidence for either arm. Print
+  `(log is EMPTY)` when a cell produced no output, so the next reader
+  knows the launch never started.
+- **Capture `rc` before any pipe.** `| head` SIGPIPEs `tee` and clobbers
+  `PIPESTATUS`, which once reported `rc=1` for a run that trained fine.
+- **Assert the code under test by behaviour, not by name.** Checking an
+  env var passes vacuously against a checkout that predates it — one
+  job silently measured the opposite experimental arm that way. Import
+  the function and assert what it returns.
+- **Run the control in the same allocation** as the arm it controls, so
+  a difference cannot be node or topology luck.
+
+## Gotchas that produce silently wrong results
+
+- **Non-editable installs.** The torchtitan venvs install `ezpz`
+  non-editable, so `python3 -c "import ezpz"` imports the *installed*
+  copy, not your working tree. Pytest is fine (`tests/conftest.py`
+  prepends `src/`), which makes this confusing: unit tests pass while an
+  inline probe raises `AttributeError` on a symbol you just added. Set
+  `PYTHONPATH=$PWD/src`, and print `ezpz.__file__` to prove it.
+- **`uv pip install torch` silently installs nothing.** `pyproject.toml`
+  pins torch/torchvision/torchaudio/mpi4py to `sys_platform == 'never'`
+  under `[tool.uv] override-dependencies`, and **uv applies that
+  override to `uv pip install` too** — so it reports `Audited 1 package`
+  and the venv still has no torch. Bootstrap pip and use bare pip, which
+  ignores uv config (same trick as `.github/workflows/pytest.yml`):
+
+  ```bash
+  uv pip install --python "$V/bin/python" pip
+  "$V/bin/python" -m pip install torch==2.13.0 \
+      --index-url https://download.pytorch.org/whl/cu129
+  ```
+
+- **Under PALS, nothing derived from the interpreter's own location
+  survives.** PBS/PALS copies the python binary into a per-job temp dir
+  before launching ranks, which breaks every relative lookup. Three
+  separate failures in one job, each looking unrelated:
+
+  | what breaks | symptom | fix |
+  |---|---|---|
+  | `libpython` via `$ORIGIN/../lib` | `error while loading shared libraries: .../files/0/../lib/libpython3.12.so.1.0` | use a python with a real `RUNPATH` |
+  | `site-packages` via `sys.prefix` → `pyvenv.cfg` | `ModuleNotFoundError: No module named 'torch'` *while the launcher clearly invoked the venv python* | put site-packages on `PYTHONPATH` |
+
+  Note the first symptom quotes a **relative** path — that is an
+  `$ORIGIN` lookup, and `LD_LIBRARY_PATH` cannot fix it. Reading it as a
+  generic "library not found" cost an allocation.
+
+  **Prefer Cray's python** (`/opt/cray/pe/python/3.12.12`) as the venv
+  base on Polaris: it has `RUNPATH /opt/cray/pe/python/3.12.12/lib` and
+  ships a working mpi4py, so it avoids both. A `uv`-managed CPython has
+  **no** RUNPATH. Then belt-and-braces:
+
+  ```bash
+  _SP="$(echo "${V}"/lib/python3.*/site-packages)"
+  export PYTHONPATH="${D}/src:${_SP}:${PYTHONPATH:-}"
+  ```
+
+- **On Polaris compute nodes, `import ezpz` hard-requires mpi4py.**
+  `src/ezpz/__init__.py:17` does `if socket.getfqdn().startswith("x3")`
+  → `from mpi4py import MPI`. Polaris compute nodes are `x3…`, login
+  nodes are not — so ezpz imports fine on the login node and dies on the
+  compute node with whatever is wrong with mpi4py. Do not conclude from
+  a clean login-node import that the job will run. (Tracked in TODO.md
+  §2 as a hardcoded hostname check.)
+
+- **mpi4py on Polaris must be built against the MPI that exists.** A
+  stock build can link `libmpi_gnu_123.so.12`, a soname absent from the
+  current Cray PE — only `libmpi_gnu.so.12` is present. Symptom:
+  `ImportError: libmpi_gnu_123.so.12: cannot open shared object file`.
+  Forcing the wrong lib via `LD_LIBRARY_PATH` gives
+  `*** stack smashing detected ***`, so rebuild rather than shim:
+
+  ```bash
+  module load craype cray-mpich PrgEnv-gnu
+  export LDFLAGS="-L${MPICH_DIR}/lib -L/opt/cray/pe/lib64 -lmpi_gnu"
+  export CFLAGS="-I${MPICH_DIR}/include"
+  MPICC=cc python -m pip install --no-binary mpi4py --no-build-isolation mpi4py
+  ```
+
+  Check `ldd .../mpi4py/MPI*.so | grep mpi` shows no `not found`.
+
+- **Downloads on ALCF need the proxy.** Nothing reaches the internet
+  from a login node without:
+
+  ```bash
+  export http_proxy=http://proxy.alcf.anl.gov:3128
+  export https_proxy=http://proxy.alcf.anl.gov:3128
+  export no_proxy=localhost,127.0.0.1,*.alcf.anl.gov,*.anl.gov
+  ```
+
+- **torch 2.13 renamed FSDP2's collectives.**
+  `all_gather_into_tensor` → `all_gather_single`,
+  `reduce_scatter_tensor` → `reduce_scatter_single`. Any test that
+  monkeypatches the old names records **zero** collectives on 2.13 — and
+  `0 == 0` is symmetric, so a "collectives are balanced" assertion
+  passes *vacuously*. Patch whichever pair exists, assert a hook landed,
+  and pin absolute counts alongside any equality.
+- **One SSH poller per cluster.** Parallel polling loops exhaust the
+  login node's auth-attempt limit and lock you out
+  (`Too many authentication failures`). An ssh-based watcher exiting
+  255 means *connection*, not job failure — re-check `qstat`/`squeue`
+  before reporting anything.
+
+## Known open issue
+
+**#239** — LoRA + FSDP2 deadlocks in the first backward on Perlmutter
+(A100/NCCL, torch 2.13). Boundary is exact: `--lora-rank 17` hangs,
+`18` trains. **Workaround: `--lora-rank 18` or higher.** Six hypotheses
+refuted so far; see `docs/guides/lora-fsdp-deadlock.md` before
+proposing a seventh.

--- a/docs/guides/fault-injection.md
+++ b/docs/guides/fault-injection.md
@@ -223,16 +223,46 @@ Attempt 2 is the result: a spare was rotated in, the victim was gone
 from the active hostfile, and the relaunch resumed from step 40 on a
 different node set. **Node-swapping works on real hardware.**
 
-!!! warning "It worked; it did not *identify* anything"
+!!! success "Identification now works — reconfirmed on job 12473912"
+
+    **This section is history.** As of Sunspot job `12473912`
+    (2026-08-26, rerun on current `main`) the loop **names the node that
+    actually died**, 7/7 including the discriminating check:
+
+    ```
+    PASS  the kill actually landed on x1922c7s5b0n0-hsn0...
+    PASS  the swap was scraper-IDENTIFIED (not a blind guess)
+    PASS  killed host is OUT of the active hostfile
+    PASS  final attempt did NOT run on the dead host
+    OVERALL: PASS
+
+    bad_nodes.txt: x1922c7s5b0n0-hsn0...  scraped  attempt=1
+    [auto-retry] bad nodes: ['x1922c7s5b0n0...'] — swapped 1
+    [auto-retry] FAILOVER STOP: success (attempt 2)
+    ```
+
+    That is `scraped`, not `blind`, and the harness now kills
+    **`active[1]`** — so a blind rotation, which always evicts
+    `active[0]`, cannot pass by luck. All four issues named below are
+    closed: [#231](https://github.com/saforem2/ezpz/issues/231),
+    [#232](https://github.com/saforem2/ezpz/issues/232),
+    [#233](https://github.com/saforem2/ezpz/issues/233),
+    [#234](https://github.com/saforem2/ezpz/issues/234).
+
+    The original write-up is kept below, because *why* it could not
+    identify anything is the more useful lesson.
+
+!!! warning "Original 12473704 finding: it worked; it did not *identify* anything"
 
     Note the verdict column: `BAD_NODE_BLIND` twice, never
     `BAD_NODE_KNOWN`. A `kill -9` leaves no scrapeable signature at all —
     `attempt-1.log` just stops mid-training — so both swaps were
     `swap_one_blind` evicting `active[0]`. `pbsdsh -n 0` happens to kill
     the first allocation node, which *is* `active[0]`, so the guess was
-    right by construction of the test. Kill `active[1]` instead and
-    today's code retires a healthy node and leaves the dead one in
-    ([#234](https://github.com/saforem2/ezpz/issues/234)).
+    right by construction of the test. Killing `active[1]` instead made
+    the old code retire a healthy node and leave the dead one in
+    ([#234](https://github.com/saforem2/ezpz/issues/234)) — **fixed**;
+    that is exactly the case job `12473912` now passes.
 
     Attempt 2 compounded it: an `OSError: [Errno 28] No space left on
     device` during a checkpoint save retired `s4b0n0`, a healthy node.

--- a/docs/guides/lora-fsdp-deadlock.md
+++ b/docs/guides/lora-fsdp-deadlock.md
@@ -1,0 +1,630 @@
+# LoRA + FSDP2: the frozen-unit collective asymmetry (#239)
+
+!!! danger "Open bug. There is no fix, and the leading candidate failed."
+
+    #239 is **unresolved**. The frozen-unit asymmetry described below is
+    real and measurable, but removing it on Perlmutter **did not stop the
+    deadlock** — see [Refuted: removing the asymmetry](#refuted-removing-the-asymmetry-fixes-it).
+    That intervention therefore ships **off by default**.
+
+    **Six** plausible-sounding explanations have now been tested and
+    refuted. They are documented here so nobody re-derives them.
+
+    Workaround: **`--lora-rank 18` or higher** completed normally in
+    every rank tested (18, 19, 20, 24, 28, 32, 64), with the boundary at
+    exactly **16 → 18** — r=17 hangs, r=18 trains.
+
+    Treat that as *measured*, not *guaranteed*. Every one of those runs
+    is the same configuration: `agpt-2b`, `tp=1`, `bs=1`, `seq_len=2048`,
+    `--lora-target attn,mlp`, `world_size=8`, torch 2.13.0+cu130 on
+    A100. The mechanism is still unknown, so a different model, target
+    set, or world size could put the boundary somewhere else entirely.
+    If you hit the hang above r=18, that is new information — please add
+    it to [#239](https://github.com/saforem2/ezpz/issues/239).
+
+    **It has not reproduced off Perlmutter.** The decisive test is
+    **Polaris — A100 + NCCL at the same `world_size=8`**, which runs the
+    identical hanging configuration clean at both hanging ranks. So this
+    is not an FSDP2 bug and not an NCCL bug; the live suspects are all
+    in Perlmutter's own stack. See
+    [the Polaris control](#it-does-not-reproduce-on-polaris-either-a100--nccl-ws8).
+
+    **XPU/xccl is clean at the matched world size too.** The first
+    Sunspot run was confounded (ws=24, shards not evenly divisible, so
+    FSDP2 bucketed differently). Rerun at **ws=8** — the exact
+    Perlmutter geometry — r8 and r17 still train (94 s / 72 s, XPU
+    dispatch, zero watchdog lines). So the earlier result was right for
+    the right reason after all.
+
+    The sharpest open clue on the NVIDIA side is that r17's stuck bucket
+    is **18 % larger than linear in r** while r8's is exactly linear —
+    so at r17 the stuck reduce-scatter is *not* one block's LoRA
+    parameters. See [the boundary section](#where-to-look-next).
+
+## What was observed
+
+On Perlmutter (2 nodes x 4 A100, `world_size=8`, torch 2.13.0+cu130),
+`agpt-2b` with `tp=1`, `bs=1`, `seq_len=2048`:
+
+| `--lora-rank` | `--lora-target` | result |
+|---|---|---|
+| 0 (no LoRA)   | —          | trains |
+| 8  | `attn,mlp` | **hang** in backward |
+| 16 | `attn,mlp` | **hang** in backward |
+| 16 | `attn`     | trains |
+| 17 | `attn,mlp` | **hang** in backward |
+| 18 | `attn,mlp` | trains |
+| 19 | `attn,mlp` | trains |
+| 20 | `attn,mlp` | trains |
+| 24 | `attn,mlp` | trains |
+| 28 | `attn,mlp` | trains |
+| 32 | `attn,mlp` | trains |
+| 64 | `attn,mlp` | trains |
+
+The r18–r28 rows come from the bisect (jobs `57604409`, `57604619`) and
+**put the boundary at exactly 16→18** — far below the r>=32 this guide
+originally implied. r=17 hangs and r=18 trains, one step apart, with r=19 also
+training; the passing cells each finished cleanly in 96–175 s.
+
+The r8/r16 `attn,mlp` hang has reproduced **5/5** (jobs `57601590` ×3,
+`57602201`, and the same-allocation control in `57604574` at
+rc=134/501 s). It is deterministic.
+
+The watchdog fingerprint was `NumelIn=419840, NumelOut=52480`.
+
+!!! note "How the working rows were classified"
+
+    The sweep job (`57540698`) exited non-zero on several cells for
+    reasons unrelated to training — `r64 attn,mlp` reports `rc=1` but
+    its per-cell log contains the full plotting output through
+    iteration 20, so it **trained** and failed afterwards in teardown.
+    The hanging cells produce no plots at all. Read those rows as
+    "reached end of training", not "exited 0"; `rc` alone misclassifies
+    them in both directions.
+
+## Identifying the stuck collective
+
+That fingerprint is not ambiguous. Per-`TransformerBlock` LoRA parameter
+count is `coef · r`, where `coef` follows from the `agpt-2b` geometry
+(`dim=2048`, `n_kv_heads=4`, `hidden_dim=11008`):
+
+```
+coef(attn)     = 13312
+coef(mlp)      = 39168
+coef(attn,mlp) = 52480
+```
+
+Sweeping `r ∈ [1, 2048]` against all three target sets yields **exactly
+one** configuration producing 419840: `r=8, attn,mlp`. And
+`419840 / 52480 = 8 = world_size`, consistent with a gradient
+reduce-scatter. So the trace came from an **r=8** run, not r=16.
+
+## The structural precondition
+
+`apply_lora` freezes every base parameter first, then re-enables only the
+adapter `A`/`B` pairs inside the targeted submodules
+(`src/ezpz/tinker/lora.py`). Under `--lora-target attn,mlp` every adapter
+therefore lands **inside a transformer block**. But `parallelize()` still
+creates four kinds of FSDP2 unit:
+
+| FSDP unit | trainable params |
+|---|---|
+| `tok_embeddings` | **0 — fully frozen** |
+| `layers.N` (x12) | 14 |
+| `[norm, output]` | **0 — fully frozen** |
+| root | 0 |
+
+A fully-frozen unit is asymmetric in backward. `reshard_after_forward`
+discarded its parameters after forward, so backward **re-gathers** them —
+but `post_backward` returns before the reduce-scatter when a group has no
+gradients. The unit emits an all-gather with no matching reduce-scatter.
+
+Measured on 2 real gloo ranks
+(`tests/test_fsdp_tp_frozen_unit_reshard.py`):
+
+```
+frozen units resharded:      bwd AG=14  bwd RS=12   <- asymmetric
+frozen units kept gathered:  bwd AG=12  bwd RS=12   <- symmetric
+```
+
+14 = 12 blocks + 2 frozen units. That shape matches the watchdog report:
+ranks blocked on a reduce-scatter at one sequence number while others ran
+ahead to an all-gather at a much later one.
+
+## The watchdog trace (job 57601590, torch 2.13.0+cu130)
+
+Lowering `TORCH_DDP_TIMEOUT` to 300s finally produced a dump. **All eight
+ranks report byte-identical state:**
+
+```
+Watchdog caught collective operation timeout:
+  WorkNCCL(SeqNum=18, OpType=_REDUCE_SCATTER_BASE,
+           NumelIn=419840, NumelOut=52480, Timeout(ms)=300000)
+
+Timeout at collective: _ALLGATHER_BASE, #39
+  [0,1,2,3,4,5,6,7] joined but didn't finish collective #39
+
+PG status: last enqueued work: 39,
+           last started work: 19 (_ALLGATHER_BASE),
+           last completed work: 17
+```
+
+Three things follow, and they change the diagnosis from hypothesis to
+observation:
+
+1. **This is not a rank divergence.** All 8 ranks joined #39 and report
+   the same stuck op. Nobody took a different code path — which rules
+   out the usual "one rank has a different collective order" story.
+
+2. **Work #18 was skipped.** The stream went `last completed: 17` →
+   `last started: 19`, and **#19 is an `_ALLGATHER_BASE`**. The stuck op
+   #18 is the reduce-scatter that the all-gather jumped ahead of. That
+   is the AG/RS asymmetry, caught in the act.
+
+3. **It dies in the first backward** — `last_iter=NONE`, no training step
+   ever completed. 39 ops enqueued against 17 completed.
+
+The stack trace lands in
+`torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:619`
+(`foreach_reduce`), the FSDP2 gradient reduce-scatter path.
+
+!!! note "What this still does not settle"
+
+    The trace confirms the *shape* of the failure is consistent with the
+    frozen-unit asymmetry. It does not explain why every r >= 18 — which
+    has the **same** asymmetry — completes normally. That gap was the
+    reason to test the intervention rather than assume it, and the test
+    came back negative.
+
+## Refuted: "the asymmetry is LoRA-specific"
+
+It is not. The asymmetry tracks **fully-frozen FSDP units**, not LoRA —
+freezing `tok_embeddings`/`norm`/`output` by hand with no adapters
+anywhere produces the identical 14/12.
+
+More decisively: it is **byte-identical at r=8 (hangs) and r=32
+(works)**. A feature present in 100% of the *working* configurations
+cannot by itself be the trigger.
+
+The converse also holds and is worth stating separately, because the two
+are easy to conflate: the *asymmetry* is not LoRA-specific, but the
+*hang* does require LoRA. A plain `--lora-rank 0` run — no adapters, so
+no fully-frozen units and no asymmetry — trains normally. So LoRA is
+necessary for the deadlock while the asymmetry is neither necessary nor
+sufficient for it.
+
+## Refuted: "small payloads take a different dispatch path"
+
+The idea that a reduce-scatter below some size threshold behaves
+differently fails on the data:
+
+```
+per-block RS numel   hang: [419840, 839680]
+                     ok:   [212992, 1679360, 3358720]
+separable by size?   NO
+```
+
+`r16 attn` at 212992 elements **is smaller than either hanging config**
+and trains fine. No monotone size threshold separates hang from ok at
+per-block or total scale. This hypothesis only survived initial scrutiny
+because it was never plotted against the working configurations.
+
+## What actually distinguishes hang from ok: unknown
+
+Nothing structural. Composition is identical — 14 trainable tensors per
+block at every rank; only widths scale, and the collective order is
+identical too (see the order refutation below).
+
+!!! warning "Corrected: this section previously overreached"
+
+    An earlier revision claimed "the hang does not reproduce on torch
+    2.12.1 at all". That is **not supported**. The 2.12.1 observations
+    are from a local 2-rank **gloo/CPU** probe, which cannot reproduce a
+    GPU NCCL deadlock under any torch version — absence there is not
+    evidence of absence. **No 2.12.1 run on real GPUs has been done.**
+    It remains lead #2 below, untried.
+
+    The same revision floated that `r8/r16 vs r32/r64` might be "a flaky
+    race that happened to land twice". That is now **disproven**: the r8
+    baseline hung 3/3 with `last_iter=NONE` (job `57601590`). The hang is
+    deterministic.
+
+A torch 2.13 FSDP2 scheduling regression is still plausible — #237 is
+also 2.13-only — but it is untested, and it now has to explain a
+*deterministic* r-dependence rather than a race. Do not cite it as the
+cause.
+
+## Refuted: "the collective *order* differs by rank"
+
+The trace shows work #18 skipped in favour of #19, so the obvious next
+guess is that the frozen-unit all-gather sits at a different position in
+the backward stream depending on `r`. It does not.
+
+Recording the exact backward collective sequence on 2 gloo ranks
+(`A` = all-gather, `R` = reduce-scatter, 6 layers). This probe runs on
+CPU under torch 2.12.1, so it establishes *ordering* only — it does not
+and cannot say anything about whether the deadlock reproduces:
+
+```
+r=8    bwd = AAARARARARARAR
+r=16   bwd = AAARARARARARAR   identical
+r=32   bwd = AAARARARARARAR   identical
+r=64   bwd = AAARARARARARAR   identical
+```
+
+Byte-identical at every rank, including the ones that work. The leading
+`AAA` is the asymmetry — three all-gathers before the first
+reduce-scatter — and it is present in *all four*.
+
+So the r-dependence is **not** an ordering difference. Combined with the
+size refutation above, no *static* property of the collective stream
+separates hanging from working configurations. That is what pushes the
+remaining explanation toward timing rather than structure.
+
+## Refuted: "removing the asymmetry fixes it"
+
+This was the leading candidate. It was tested directly and **failed**.
+
+`frozen_unit_kwargs()` in `src/ezpz/examples/fsdp_tp.py` keeps a
+fully-frozen unit gathered, so it never emits the unmatched all-gather:
+
+```python
+if any(p.requires_grad for m in ms for p in m.parameters()):
+    return fsdp_kwargs
+return {**fsdp_kwargs, "reshard_after_forward": False}
+```
+
+It is correctness-neutral (the parameters are never updated, so never
+resharding them changes no math, only residency) and it demonstrably
+does what it claims — the AG/RS counts go from 14/12 to 12/12, pinned by
+`tests/test_fsdp_tp_frozen_unit_reshard.py`.
+
+**The job still hung.** Perlmutter job `57602201`, same 8x A100 /
+torch 2.13.0+cu130, r8 and r16, both `last_iter=NONE`:
+
+| | baseline (`57601590`) | asymmetry removed (`57602201`) |
+|---|---|---|
+| stuck collective | `_REDUCE_SCATTER_BASE` | `_REDUCE_SCATTER_BASE` |
+| payload | `NumelIn=419840, NumelOut=52480` | **identical** |
+| SeqNum | 18 | 17 |
+| PG status | enq 39, started 19, completed 17 | enq 37, started 18, completed 16 |
+| r8 | `rc=134 secs=518/433/437` (3/3) | `rc=134 secs=532` |
+| r16 | — | `rc=124 secs=600` |
+
+The intervention *landed*: 39 → 37 enqueued ops is exactly the two
+removed all-gathers. And the failure is the same one, renumbered by
+exactly that amount — the same skipped-work signature, where the stream
+jumps over the reduce-scatter and stalls with an all-gather started
+ahead of it.
+
+So the asymmetry is not the cause, and — since the deadlock survives
+without it — not even a precondition.
+
+### Consequence for the code
+
+`frozen_unit_kwargs()` is retained, but **inverted to opt-in** and OFF by
+default: it costs ~+1.7 GiB/rank on `agpt-2b` at `world_size=8` in bf16
+(scaling with the 256128 vocab) and buys nothing. Shipping a memory
+regression that failed its own experiment would be worse than shipping
+nothing.
+
+```bash
+export EZPZ_FSDP_KEEP_FROZEN_GATHERED=1   # opt in; reproduces the negative result
+```
+
+It stays in the tree only so the experiment is re-runnable from a
+released build rather than a patch someone has to reconstruct.
+
+### What was never in scope either way
+
+- `--lora-target unembed` puts a trainable adapter in the `[norm,
+  output]` unit, so that unit is not frozen at all. Never reported hanging.
+- The HuggingFace path uses a different grouping.
+- #237, and torch 2.13 FSDP2 more broadly.
+
+## It does not reproduce on XPU/xccl (Sunspot)
+
+The first non-Perlmutter data point, and the strongest constraint yet.
+
+Sunspot job `12473856`: PVC (XPU), **xccl** rather than NCCL, torch
+`2.13.0a0+gitcf30153` from the `frameworks` module, `world_size=24`,
+same `agpt-2b` / `tp=1` / `bs=1` / `seq_len=2048` /
+`--lora-target attn,mlp`, same shipped default arm.
+
+| `--lora-rank` | Perlmutter (A100/NCCL) | Sunspot (PVC/xccl) |
+|---|---|---|
+| 8  | **hang**, 6/6 | **trains**, `rc=0`, 102 s |
+| 17 | **hang** | **trains**, `rc=0`, 76 s |
+| 18 | trains | **trains**, `rc=0`, 72 s |
+
+**Rerun at the matched `world_size=8`** (job `12473880`), removing the
+bucketing confound below — r8 `rc=0` 94 s, r17 `rc=0` 72 s, r18 `rc=0`
+68 s; XPU dispatch, plots written, zero watchdog lines, 3/3. The ws=24
+caveat that follows is therefore no longer load-bearing: **xccl is
+clean at Perlmutter's exact geometry**, so the backend really is not
+the variable.
+
+Both ranks that deadlock on NVIDIA train clean on XPU, so the r-boundary
+itself does not exist there — it is not that the boundary moved, it is
+that there is nothing to bound.
+
+Verified it is the intended configuration and not a silent skip: the log
+shows `dispatch key: XPU`, the full
+`--lora-rank 8 --lora-target attn,mlp` command line, and plotting output
+through end of training.
+
+!!! danger "This is NOT yet evidence that #239 is NCCL-specific"
+
+    It is tempting to read this as "the bug is in NCCL". **Four things
+    changed at once**, so the experiment does not isolate the backend:
+
+    | | Perlmutter | Sunspot |
+    |---|---|---|
+    | collectives | NCCL | xccl |
+    | `world_size` | 8 | **24** |
+    | torch | `2.13.0+cu130` | `2.13.0a0+gitcf30153` |
+    | hardware | A100 | PVC |
+
+    The `world_size` change is the damaging one. `coef(attn,mlp)·r`
+    does not divide evenly by 24 at the hanging ranks:
+
+    ```
+    ws=8   r8  419840 / 8  = 52480      integral
+    ws=24  r8  419840 / 24 = 17493.33   NOT integral
+    ws=24  r17 892160 / 24 = 37173.33   NOT integral
+    ```
+
+    So FSDP2 pads and buckets *differently* on Sunspot. Given that the
+    sharpest open clue is precisely that r17's stuck bucket is
+    **non-linear in r**, changing the bucket geometry is not a
+    controlled test of the collectives backend -- it may simply have
+    sidestepped whatever bucket shape triggers the hang.
+
+    **What this run does establish:** the deadlock is not universal
+    across backends and configurations, and the r-boundary is not a
+    property of the LoRA geometry alone.
+
+    **The controlled test still to run** is Polaris: A100 + **NCCL**
+    like Perlmutter, at `world_size=8`, which varies only the site and
+    software stack. Until then, "NCCL-localized" is a hypothesis, not a
+    finding.
+
+## It does not reproduce on Polaris either (A100 + NCCL, ws=8)
+
+**This is the controlled test, and it came back negative.**
+
+Polaris job `7563257` varies *only* the site and software stack:
+
+| | Perlmutter | Polaris |
+|---|---|---|
+| accelerator | A100 | A100 |
+| collectives | NCCL | NCCL |
+| `world_size` | 8 | 8 |
+| torch | 2.13.0+cu130 | 2.13.0+cu129 |
+| `--lora-rank 8` | **hang, 6/6** | **trains**, `rc=0`, 142 s |
+| `--lora-rank 17` | **hang** | **trains**, `rc=0`, 107 s |
+| `--lora-rank 18` | trains | **trains**, `rc=0`, 107 s |
+
+All three cells clean, 3/3. Verified it is the intended configuration:
+`device=cuda`, `--lora-rank 8 --lora-target attn,mlp`, plotting output
+written, and **zero watchdog lines**. Both ranks that deadlock on
+Perlmutter train here, so the boundary does not shift on Polaris -- it
+is absent.
+
+### What this kills
+
+The "#239 is an NCCL bug" hypothesis. A second, independent A100+NCCL
+site at the same world size, on the same torch minor, runs the exact
+configuration clean. If the deadlock were a property of NCCL's
+interaction with FSDP2's reduce-scatter scheduling, it should have
+reproduced here.
+
+**#239 has not reproduced anywhere except Perlmutter** -- where it is
+nonetheless rock-solid deterministic at 6/6. (The XPU/xccl arm is not
+yet conclusive; see the Sunspot section's ws=24 caveat.)
+
+### What that leaves
+
+Something in **Perlmutter's stack specifically**: its NCCL build
+(2.29.7), the `nccl/2.24.3` AWS-libfabric plugin, the Slingshot
+interconnect, its CUDA 13.0 / cu130 wheel pairing, or the
+2-nodes-x-4-GPU topology as realised there. Those are now the live
+suspects, not FSDP2 or NCCL-in-general.
+
+!!! warning "Do not over-read this either"
+
+    Polaris differs from Perlmutter in more than "site": cu129 vs
+    cu130, a different NCCL, a different interconnect, PBS vs Slurm.
+    This narrows the search to Perlmutter's stack; it does not identify
+    which component. The honest status is that the r-boundary is real
+    and deterministic **on one machine**, and no portable mechanism has
+    been found.
+
+    It also means an upstream torch issue is **not** currently
+    warranted -- see `docs/notes/upstream-fsdp2-lora-deadlock.md`, which
+    stays unsent.
+
+## Refuted: "the NCCL protocol selects the outcome"
+
+The 256 KiB story pointed at NCCL protocol selection (LL / LL128 /
+Simple). Rather than keep inferring protocol from payload size, job
+`57605154` set it directly with `NCCL_PROTO`, holding `r=8` fixed so the
+protocol is the *only* thing that varies:
+
+| `NCCL_PROTO` | result |
+|---|---|
+| (default) | **hang** — 5/5 |
+| `Simple` | **hang**, `rc=134`, 486 s |
+| `LL128` | **hang**, `rc=134`, 430 s |
+
+Both forced protocols hang, with the same `NumelIn=419840,
+NumelOut=52480` as the default run, and NCCL logged no `invalid` or
+`unknown proto` warning — so the setting was accepted rather than
+silently ignored.
+
+**The protocol is not the mechanism.** Not the 256 KiB threshold, and
+not protocol selection in general.
+
+## Cross-machine summary: it only happens on Perlmutter
+
+All rows at `world_size=8` (Perlmutter's exact geometry, so FSDP2
+buckets identically everywhere), `agpt-2b`, `tp=1`, `bs=1`,
+`seq_len=2048`, `--lora-target attn,mlp`, shipped default arm:
+
+| `--lora-rank` | Perlmutter<br>A100 / NCCL / 2.13 | Polaris<br>A100 / NCCL / 2.13 | Sunspot<br>PVC / xccl / 2.13 | Aurora<br>PVC / xccl / **2.10** |
+|---|---|---|---|---|
+| 8  | **hang**, 6/6 | trains 142 s | trains 94 s | trains 60 s |
+| 17 | **hang** | trains 107 s | trains 72 s | trains 59 s |
+| 18 | trains | trains 107 s | trains 68 s | trains |
+
+**Two backends, four stacks, every run clean except Perlmutter** --
+where the hang is deterministic at 6/6.
+
+The load-bearing comparisons are Polaris (matches Perlmutter on
+accelerator, collectives, world size and torch minor -- varies only the
+site) and Sunspot (matches on torch minor and world size -- varies the
+collectives backend). Aurora is weaker evidence because it ships torch
+**2.10**, and #239 has only been seen on 2.13; its value is that it did
+not hang, which would have meant the bug predates 2.13.
+
+!!! note "Read the exit codes carefully"
+
+    Several clean runs exit non-zero. Aurora's cells report `rc=1` from
+    a post-training `plotext` version mismatch, and Perlmutter's r64
+    cell did the same -- in both cases plots were written and no
+    watchdog fired. Judge these runs on evidence (watchdog line vs.
+    reaching the plotting stage), never on `rc`, or a pass gets
+    misfiled as INDETERMINATE.
+
+## Where to look next
+
+Every *static* property of the collective stream has now been ruled out:
+LoRA-specificity, payload size, per-rank order, and the AG/RS asymmetry
+itself. All eight ranks agree exactly on what they are waiting for. The
+remaining explanations are dynamic:
+
+1. **Where exactly does r flip?** Same asymmetry, same op sequence,
+   different outcome — so the difference is a *quantity*, not a
+   structure. `experiments/perlmutter/lora_239_rank_bisect.sbatch`
+   binary-searches it (a hang costs the full 300s watchdog, so only ~3
+   probes fit a debug allocation — hence bisect, not sweep).
+
+    **In progress.** r=24 and r=20 both train, so the boundary is
+    **17..20**, not r>=32. A second job (`57604619`) probes 18/17/19.
+
+    !!! failure "REFUTED by r=18 — the 256 KiB prediction was wrong"
+
+        Recorded below as written, unedited, because the point of
+        pre-registering it was to be able to lose. **r=18 trained**
+        (job `57604619`, 130 s, plots written, zero watchdog lines) —
+        its shard is 236 160 B, comfortably *below* 256 KiB, where the
+        prediction says it must hang.
+
+        So the NCCL protocol edge does not explain the r-dependence.
+
+    !!! success "But the boundary is now exact: r=17 hangs, r=18 trains"
+
+        Same job. **r=17 hangs; r=18 trains.** One step apart, so the
+        flip is precisely **16 → 18**, and any explanation has to
+        separate two adjacent ranks.
+
+        The r17 watchdog trace carries the most concrete new fact in the
+        investigation:
+
+        ```
+        r8   SeqNum=18  NumelIn=419840   NumelOut=52480
+        r17  SeqNum=18  NumelIn=1055232  NumelOut=131904
+        ```
+
+        r8's stuck bucket is exactly linear in r (`52480 · 8`). **r17's
+        is not**: linearity predicts `892160`, the trace says `1055232`
+        — 18 % larger. Both keep `NumelIn = NumelOut · 8`, so both are
+        still world-size reduce-scatters, but at r17 the stuck bucket is
+        **not one block's LoRA parameters**. Something is grouping or
+        padding differently at r17 than at r8, and *that* difference
+        tracks the boundary far better than any byte threshold.
+
+        Chasing this needs the real bucketing, not arithmetic: a first
+        attempt to reconstruct it from `agpt-2b` geometry did not even
+        reproduce r8's known `419840`, so the padding story stays
+        unwritten until FSDP2 is instrumented to report which
+        parameters land in each bucket (lead 3).
+
+        The direct `NCCL_PROTO` test settled the wider question — see
+        below. It does not matter at all.
+
+    !!! tip "Pre-registered prediction: the 256 KiB NCCL boundary"
+
+        Alignment cannot explain this — `coef·r` is divisible by 8 and
+        by 128 at *every* r. But the **per-rank reduce-scatter shard in
+        bytes** (`coef·r/ws · 2` for bf16) crosses **262144 B = 256 KiB**
+        exactly between the last known hang and the first known pass:
+
+        | r | shard bytes | vs 256 KiB | outcome |
+        |---|---|---|---|
+        | 16 | 209 920 | below | **hang** |
+        | 17 | 223 040 | below | *predict hang* |
+        | 18 | 236 160 | below | *predict hang* |
+        | 19 | 249 280 | below | *predict hang* |
+        | 20 | 262 400 | **above** | trains |
+
+        256 KiB is a real NCCL protocol/buffer boundary (LL / LL128 /
+        Simple selection). So the prediction is that **r=17, 18 and 19
+        all hang and the flip is exactly at r=20** — recorded here
+        *before* job `57604619` reports, so it cannot be retrofitted.
+
+        This also refutes payload size once more, from the other
+        direction: r=64's per-shard payload is `419840`, the very number
+        in r=8's *hanging* watchdog trace — identical byte counts land on
+        both sides of the boundary. What would matter is not the size
+        itself but which NCCL protocol it selects.
+
+        If instead r=17/18/19 train, the boundary is 16→17 and this
+        threshold story is wrong.
+
+    Classify these cells on **evidence** (watchdog line vs. reaching the
+    plotting stage), never on `rc` or an `iter=` marker: the first
+    bisect gated on `iter=`, which these runs never emit, and so
+    labelled a clean 173s r24 pass INDETERMINATE.
+2. **Is it a torch 2.13 regression?** #237 diverges across the same
+   boundary. `experiments/perlmutter/lora_239_torch_version.sbatch` runs
+   the real config on real GPUs under Perlmutter's older `.venv`
+   (**2.8.0+cu129** — there is no 2.12.1 build there, and a wider gap is
+   fine, since the question is "does an older torch hang", not "which
+   release introduced it"). Cell 1 is a **control** re-running r8 under
+   2.13 in the same allocation, so an older-torch pass cannot be
+   confounded by node or topology luck; cell 2 means nothing unless
+   cell 1 hangs. If 2.8.0 also hangs, this theory dies and the search
+   moves to FSDP2 semantics common to both.
+3. **The skipped work item.** The stream goes `completed 16` →
+   `started 18`, so #17 was enqueued and jumped. Instrumenting FSDP2's
+   `foreach_reduce` to log which unit owns each work id would name the
+   module involved instead of inferring it from payload arithmetic.
+
+## The usability bug underneath
+
+`TORCH_DDP_TIMEOUT` defaults to **3600s** (`src/ezpz/distributed.py`),
+so this failed as a silent one-hour hang rather than a watchdog dump.
+In a 29-minute debug allocation the watchdog can **never** fire — which
+means several early probes were silent for that reason alone, and that
+silence was briefly mistaken for evidence. Set it low when hunting a
+hang:
+
+```bash
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+```
+
+## Reproducing
+
+`experiments/perlmutter/lora_239_repro.sbatch` runs the **same baseline
+three times** before testing anything else. That ordering is deliberate:
+two prior jobs each hung once, which is equally consistent with a
+deterministic bug and with a coin flip. Two samples cannot tell those
+apart, and every downstream claim depends on which it is.
+
+The job also asserts `frozen_unit_kwargs` is actually present in the
+checkout before running, so an arm cannot silently test old code and
+report a result that belongs to a different build. That guard is why the
+negative result above is trustworthy: the intervention provably ran.

--- a/docs/guides/perlmutter.md
+++ b/docs/guides/perlmutter.md
@@ -228,9 +228,53 @@ separate 2-node run, so the sweep produces comparable numbers.
 
 ## Environment notes
 
-Three Perlmutter-specific hazards, each of which cost a job — or, in the
+Four Perlmutter-specific hazards, each of which cost a job — or, in the
 first case, five jobs and a set of published numbers — before being
 understood.
+
+!!! danger "Load `cudatoolkit/12.9` — and do not swap it per torch build"
+
+    **No venv here bundles `libcudart`**, so the loaded module supplies
+    it. The default is `cudatoolkit/13.2`, which is wrong for everything
+    below. Load 12.9 once; it serves **both** torch builds *and* the
+    NCCL plugin:
+
+    ```
+    2.13.0+cu130 (.venv-213) under cudatoolkit/12.9 -> cuda avail True
+    2.8.0+cu129  (.venv)     under cudatoolkit/12.9 -> cuda avail True
+    ```
+
+    Two jobs died establishing this, and the second is the trap:
+
+    - Running the cu129 venv under the **default 13.2** killed every
+      rank in ~27 s with `ImportError: libcudart.so.13`.
+    - "Fixing" that by swapping the module **per cell** was *worse*:
+      NERSC's NCCL plugin (`libnccl-net.so`) links `libcudart.so.12`
+      from the HPC SDK, so under `cudatoolkit/13.0` it cannot load and
+      every rank dies with `Failed to initialize any NET plugin` →
+      `DistBackendError: NCCL error ... invalid usage`.
+
+    Note the plugin's `LD_LIBRARY_PATH` entry **survives** the swap — it
+    is the `.so`'s CUDA 12 dependency that fails. Check with `ldd`
+    rather than inferring from the path; assuming the path told the
+    whole story cost a second job.
+
+    **A login-node import check will not catch any of this** — it runs
+    outside the job's module environment, so it passes while the job
+    dies. Assert inside each cell, or a broken environment gets misread
+    as a real experimental result:
+
+    ```bash
+    case ":${LD_LIBRARY_PATH:-}:" in
+        *nccl*plugin*) : ;;
+        *) echo 'verdict=INDETERMINATE reason=no-nccl-plugin'; return ;;
+    esac
+    "${py}" -c "
+    import torch, sys
+    if not torch.cuda.is_available():
+        sys.exit('CUDA unavailable -- environment, not a result')
+    " || { echo 'verdict=INDETERMINATE reason=env'; return; }
+    ```
 
 !!! danger "Load `nccl/2.24.3`, or NCCL silently uses TCP"
 

--- a/docs/notes/alcf-tickets.md
+++ b/docs/notes/alcf-tickets.md
@@ -1,0 +1,116 @@
+# Drafts: ALCF / NERSC support tickets
+
+**Both unsent.** Filing is the user's call — these are drafts so it is
+copy-paste rather than rewriting from scratch.
+
+---
+
+## 1. ALCF (Polaris): every conda module fails to load
+
+**Severity:** blocks all conda users on Polaris, not just this project.
+
+**Summary.** Every `conda` module on Polaris fails with
+`Lmod has detected the following error: The following module(s) are
+unknown`, because the modulefiles require two modules the system no
+longer provides.
+
+**Reproduce** (login node, 2026-08-26):
+
+```bash
+module use /soft/modulefiles
+module load conda/2025-09-25
+```
+
+Result:
+
+```
+The following module(s) are unknown: "gcc-native/14.2"
+                                     "cray-hdf5-parallel/1.14.3.5"
+```
+
+What the system actually has now:
+
+| modulefile requires | system provides |
+|---|---|
+| `gcc-native/14.2` | `gcc-native/14` |
+| `cray-hdf5-parallel/1.14.3.5` | `cray-hdf5-parallel/1.14.3.9` |
+
+**Affects every conda module**, not one: `conda/2024-04-29`,
+`conda/2025-09-25`, `conda/2025-09-26-aws-nccl-1.6.0`,
+`conda/2025-09-26-aws-nccl-1.9.1`.
+
+**Downstream symptom.** `conda` never lands on `PATH`, so anything
+depending on it fails much later with a misleading message — in our
+case `CONDA_PREFIX still not set`, several layers from the real cause.
+
+**Ask.** Update the conda modulefiles to the versions currently
+installed (or restore the pinned ones).
+
+**Workaround we used.** Build a standalone venv on Cray's python,
+`/opt/cray/pe/python/3.12.12` — it also has a proper `RUNPATH` and a
+working `mpi4py`, which a `uv`-managed CPython does not.
+
+---
+
+## 2. NERSC (Perlmutter): FSDP2 + LoRA deadlock, Perlmutter-only
+
+**Summary.** A PyTorch FSDP2 training job deadlocks deterministically in
+the first backward pass on Perlmutter, and the identical configuration
+runs clean on three other machines — including another A100 + NCCL
+system at the same world size. That points at something in Perlmutter's
+software stack rather than at PyTorch or NCCL as shipped.
+
+**Configuration.** 2 nodes x 4 A100-40GB, `world_size=8`,
+torch `2.13.0+cu130`, NCCL 2.29.7, `module load nccl/2.24.3`
+(AWS-libfabric plugin), `TORCH_DDP_TIMEOUT=300`.
+
+**Symptom.** All eight ranks report byte-identical watchdog state:
+
+```
+WorkNCCL(SeqNum=18, OpType=_REDUCE_SCATTER_BASE,
+         NumelIn=419840, NumelOut=52480, Timeout(ms)=300000)
+
+Timeout at collective: _ALLGATHER_BASE, #39
+  [0,1,2,3,4,5,6,7] joined but didn't finish collective #39
+
+PG status: last enqueued work: 39,
+           last started work: 19 (_ALLGATHER_BASE),
+           last completed work: 17
+```
+
+Note `last completed: 17` -> `last started: 19` — **work #18 is
+skipped**, and #19 is an all-gather. The stream ran ahead of the
+reduce-scatter it is now blocked on. Reproduced **6/6** across four
+jobs (`57601590` x3, `57602201`, `57604574`).
+
+**Why we believe it is Perlmutter-specific.** Same code, same model,
+same `world_size=8`:
+
+| | Perlmutter<br>A100/NCCL/2.13 | Polaris<br>A100/NCCL/2.13 | Sunspot<br>PVC/xccl/2.13 | Aurora<br>PVC/xccl/2.10 |
+|---|---|---|---|---|
+| hang? | **yes, 6/6** | no | no | no |
+
+Polaris matches Perlmutter on accelerator, collectives, world size and
+torch minor, varying only the site — and it trains clean.
+
+**Also ruled out on Perlmutter** (each tested, not assumed): the
+LoRA-specific hypothesis, payload size, per-rank collective ordering,
+the frozen-unit all-gather/reduce-scatter asymmetry, a 256 KiB protocol
+threshold, and NCCL protocol selection (`NCCL_PROTO=Simple` and `LL128`
+both still hang).
+
+**Remaining suspects, all Perlmutter-side.** NCCL 2.29.7, the
+`nccl/2.24.3` AWS-libfabric plugin, Slingshot, or the CUDA 13.0 / cu130
+pairing.
+
+**Questions.**
+
+1. Are there known issues with NCCL 2.29.7 or the current libfabric
+   plugin around reduce-scatter completion under FSDP2?
+2. Is a different NCCL or plugin version recommended for torch 2.13 +
+   cu130 on Perlmutter?
+3. Can you reproduce with the standalone script we can supply (torch +
+   torchrun only, no site dependencies)?
+
+**Detail.** Full write-up, including every refuted hypothesis, is in
+`docs/guides/lora-fsdp-deadlock.md` in this repo.

--- a/docs/notes/aurora-frameworks-2026.1.0-bugs.md
+++ b/docs/notes/aurora-frameworks-2026.1.0-bugs.md
@@ -1,0 +1,152 @@
+# Aurora `frameworks/2026.1.0`: verified bug report
+
+**One of these is an ALCF defect worth a ticket. The other is not — read
+the verdict table before filing.**
+
+## Reproduce it yourself — one line, no checkout needed
+
+```bash
+ssh aurora 'curl -fsSL https://raw.githubusercontent.com/saforem2/ezpz/main/experiments/aurora/frameworks_2026_1_0_bugs.pbs | /opt/pbs/bin/qsub'
+```
+
+> **Before #240 merges** the file is not on `main` yet — swap `main` for
+> `fix/239-frozen-unit-reshard` in that URL, or it 404s.
+
+`qsub` reads the script from stdin and parses the `#PBS` directives out of
+the piped text, so there is no temp file and no `bash -c` wrapper. Two
+things that will break it:
+
+- `/opt/pbs/bin/qsub` must be the **full path** — `qsub` is not on `$PATH`
+  over a plain `ssh` command.
+- The `curl` runs on the **login node**, which has internet. Compute nodes
+  do not, but they never need it: PBS has already captured the script.
+
+Output lands in `~/fw2026-bugs.o<jobid>`. Script:
+[`experiments/aurora/frameworks_2026_1_0_bugs.pbs`](../../experiments/aurora/frameworks_2026_1_0_bugs.pbs).
+
+## Verdict
+
+| | status | file a ticket? |
+|---|---|---|
+| **Bug 1** — `import torch` → `OSError: libglog.so.0` | genuine ALCF packaging defect, 2026.1.0-only | **yes** |
+| **Bug 2** — `import wandb` → `AttributeError` | wandb is simply not installed; the confusing symptom is a stray `~/wandb` shadowing it | **no** |
+
+## Bug 1 — the case, in one block
+
+`libtorchcomms.so`'s RUNPATH contains **no entry pointing at the install
+prefix** where `libglog.so.0` actually ships. It lists build-time paths
+under `/lus/tegu` — a Sunspot filesystem, not mounted on Aurora — and,
+oddly, two **Windows** library directories:
+
+```
+/opt/aurora/26.181.0/oneapi/mkl/latest/lib/intel64_win
+/opt/aurora/26.181.0/oneapi/mkl/latest/lib/win-x64
+```
+
+torch 2.13 imports `torchcomms` unconditionally (`distributed_c10d.py:151`),
+so this is fatal at `import torch`. `frameworks/2025.3.1` ships an
+identically mis-linked `libtorchcomms.so` but never imports it — which
+makes 2026.1.0 a regression rather than a long-standing quirk.
+
+**Workaround:** `export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"`
+
+## Bug 2 — why this is NOT ALCF's bug
+
+`wandb` is absent from 2026.1.0 (2025.3.1 has it, 35 entries +
+`wandb-0.24.2.dist-info`). That alone would give a clean
+`ModuleNotFoundError`. The confusing `AttributeError` comes from somewhere
+else: PBS starts jobs with `cwd=$HOME`, cwd is on `sys.path`, and the
+**wandb run-output directory** `~/wandb` (119 entries: `run-*/`,
+`latest-run`, `debug.log`) becomes an implicit namespace package.
+
+The script proves it by re-importing from `/tmp`, which yields the honest
+`ModuleNotFoundError`. Note this would shadow a *working* install too, so
+`pip install --user wandb` is not a reliable fix on its own — you also must
+not run from a directory containing a `wandb/` folder.
+
+## Verified output
+
+Job `8792487`, node `x4413c2s2b0n0`, `queue=validation`, `Exit_status=0`,
+walltime 8s — submitted with the exact one-liner above.
+
+```text
+==================================================================
+ node            : x4413c2s2b0n0
+ frameworks      : frameworks/2026.1.0
+ CONDA_PREFIX    : /opt/aurora/26.181.0/frameworks/aurora_frameworks-2026.1.0
+ python3         : /opt/aurora/26.181.0/frameworks/aurora_frameworks-2026.1.0/bin/python3
+==================================================================
+
+################ BUG 1: torch / libglog ################
+
+--- 1a. import torch WITHOUT the workaround (expect: OSError libglog.so.0)
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: libglog.so.0: cannot open shared object file: No such file or directory
+    rc=1
+
+--- 1b. the library DOES exist, it is just unreachable:
+lrwxrwxrwx 1 root root     16 Aug 14 23:58 /opt/aurora/26.181.0/frameworks/aurora_frameworks-2026.1.0/lib/libglog.so -> libglog.so.0.4.0
+lrwxrwxrwx 1 root root     16 Aug 14 23:58 /opt/aurora/26.181.0/frameworks/aurora_frameworks-2026.1.0/lib/libglog.so.0 -> libglog.so.0.4.0
+-rwxr-xr-x 1 root root 195368 Apr 17  2020 /opt/aurora/26.181.0/frameworks/aurora_frameworks-2026.1.0/lib/libglog.so.0.4.0
+
+--- 1c. the dangling RUNPATH that causes it:
+  RUNPATH              /opt/aurora/26.181.0/spack/unified/1.1.1/install/linux-x86_64/gcc-14.3.0-siitp7a/lib64:/lus/tegu/projects/datasets/software/26.181.0/wheelforge/envs/conda_envs/triton_3.7.1_torchcomms_0.3.1-rc1_vllm_0.25.1_nre_pt_2.13.0_rel_one_2026.1.0_np_2.3.5_python_3.12.12/lib:/opt/aurora/26.181.0/oneapi/mkl/latest/lib/intel64_win:/opt/aurora/26.181.0/oneapi/mkl/latest/lib/win-x64:/lus/tegu/projects/datasets/software/26.181.0/wheelforge/envs/conda_envs/triton_3.7.1_torchcomms_0.3.1-rc1_vllm_0.25.1_nre_pt_2.13.0_rel_one_2026.1.0_np_2.3.5_python_3.12.12/lib/python3.12/site-packages/torch/lib
+    -> missing libs per ldd:
+	libtorch.so => not found
+	libc10.so => not found
+	libc10_xpu.so => not found
+	libtorch_xpu.so => not found
+
+--- 1d. WITH the workaround (expect: torch imports)
+torch 2.13.0a0+gitcf30153
+
+################ BUG 2: empty wandb namespace package ################
+
+--- 2a. import wandb, user-site DISABLED (expect: AttributeError)
+  File "<string>", line 1, in <module>
+AttributeError: module 'wandb' has no attribute '__version__'
+    rc=1   (python3 -s == ignore ~/.local)
+
+--- 2a2. same import WITH user-site (shows whether you already fixed it)
+wandb 0.29.0
+
+--- 2b. why: the directory is EMPTY and has no dist-info
+    site-packages/wandb entries : 0
+    dist-info                   : NONE (pip believes nothing is installed)
+
+--- 2c. contrast with 2025.3.1, which is fine:
+    2025.3.1 wandb entries      : 35
+    2025.3.1 dist-info          : wandb-0.24.2.dist-info
+
+--- 2c2. IS THE REAL SHADOW A STRAY ./wandb IN CWD? (PBS cwd = $HOME)
+    cwd: /home/foremans
+    FOUND /home/foremans/wandb  -- 119 entries
+    looks like wandb RUN OUTPUT, not a package:
+      debug-internal.log
+      debug.log
+      latest-run
+    -> cwd is on sys.path, so this becomes a namespace package
+    -> proof: same import from a clean dir:
+ModuleNotFoundError: No module named 'wandb'
+
+--- 2d. it imports as a namespace package (no __file__ of its own):
+    __file__: None
+    __path__: ['/home/foremans/wandb']
+    n attrs : 0
+
+==================================================================
+ SUMMARY
+==================================================================
+ BUG 1 torch/libglog reproduced : YES
+ BUG 2 empty wandb reproduced   : YES
+
+ Workarounds:
+   export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+   python3 -m pip install --user wandb
+
+ NOTE: BUG 2 is probed with `python3 -s` (user site-packages disabled)
+ so a previously-installed ~/.local wandb cannot mask it. Step 2a2 shows
+ the un-suppressed import, i.e. what your own environment actually sees.
+==================================================================
+```

--- a/docs/notes/repro_fsdp2_lora_deadlock.py
+++ b/docs/notes/repro_fsdp2_lora_deadlock.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Standalone reproducer for the FSDP2 + frozen-unit backward deadlock.
+
+**Deliberately has no ezpz dependency** -- upstream maintainers will not
+run someone else's training framework. torch + torchrun only.
+
+    TORCH_DDP_TIMEOUT=300 torchrun --nproc_per_node=8 repro_fsdp2_lora_deadlock.py --rank 8
+
+Observed on 2x4 A100 (world_size=8), torch 2.13.0+cu130, NCCL:
+
+    --rank 8   hangs in the first backward
+    --rank 17  hangs
+    --rank 18  completes
+
+The hang is a reduce-scatter that never finishes while the stream runs
+ahead to a later all-gather::
+
+    WorkNCCL(SeqNum=18, OpType=_REDUCE_SCATTER_BASE,
+             NumelIn=419840, NumelOut=52480)
+    PG status: last enqueued 39, last started 19 (_ALLGATHER_BASE),
+               last completed 17
+
+Note ``last completed 17`` -> ``last started 19``: work #18 is skipped.
+
+Geometry is verified against the real model, not assumed: with these
+constants the per-block trainable count is 419840 at r=8, 892160 at
+r=17 and 944640 at r=18, matching ``apply_lora`` on the actual
+``agpt-2b`` preset exactly (14 trainable tensors per block). That
+matters -- the boundary is a function of the bucket element count, so a
+reproducer with the wrong width would prove nothing.
+
+Smoke-tested single-rank on CPU: one Block reports 419840 trainable
+parameters across 14 tensors, and **all 14 receive gradients** after a
+backward -- so no adapter is stranded off the autograd path, which would
+change the bucket layout and invalidate the whole comparison.
+
+STATUS: structure verified; **the multi-rank deadlock itself has not yet
+been reproduced with this file**. Run it on 8 GPUs before citing it
+upstream -- if it does not hang at r=8, the difference from the real
+workload is itself the clue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import fully_shard
+
+# agpt-2b geometry -- the sizes matter, since the boundary is a
+# function of the per-bucket element count.
+DIM = 2048
+N_LAYERS = 12
+N_HEADS = 16  # agpt-2b: 16, NOT 32 -- head_dim 128, kv width 512
+N_KV_HEADS = 4
+HIDDEN = 11008
+VOCAB = 256128
+
+
+class Block(nn.Module):
+    """Attention + MLP with LoRA adapters; base weights frozen."""
+
+    def __init__(self, r: int) -> None:
+        super().__init__()
+        hd = DIM // N_HEADS
+        kv = N_KV_HEADS * hd
+        base = {
+            "wq": (DIM, DIM),
+            "wk": (kv, DIM),
+            "wv": (kv, DIM),
+            "wo": (DIM, DIM),
+            "w1": (HIDDEN, DIM),
+            "w2": (DIM, HIDDEN),
+            "w3": (HIDDEN, DIM),
+        }
+        self.base = nn.ModuleDict(
+            {k: nn.Linear(i, o, bias=False) for k, (o, i) in base.items()}
+        )
+        # A/B adapter pair per base weight -- the only trainable tensors.
+        self.lora_a = nn.ModuleDict(
+            {k: nn.Linear(i, r, bias=False) for k, (o, i) in base.items()}
+        )
+        self.lora_b = nn.ModuleDict(
+            {k: nn.Linear(r, o, bias=False) for k, (o, i) in base.items()}
+        )
+        for p in self.base.parameters():
+            p.requires_grad_(False)
+
+    def _lora(self, k: str, x: torch.Tensor) -> torch.Tensor:
+        """base(x) + B(A(x)) -- the standard LoRA residual."""
+        return self.base[k](x) + self.lora_b[k](self.lora_a[k](x))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # EVERY adapter must be on the autograd path. Routing only some
+        # of them leaves the rest gradient-less, which changes both the
+        # trainable count and the bucket layout -- i.e. it would no
+        # longer be the configuration that deadlocks.
+        q = self._lora("wq", x)
+        k_ = self._lora("wk", x)
+        v = self._lora("wv", x)
+        # Stand-in for attention: keep q/k/v live without needing masks
+        # or RoPE. Shapes differ (kv width < dim), so reduce k/v to
+        # scalars and scale -- the collective sizes are what matter here,
+        # not the numerics.
+        h = x + self._lora("wo", q) * (1.0 + k_.mean() + v.mean())
+        # SwiGLU-shaped MLP: w1 and w3 in, w2 back out.
+        m = self._lora("w2", self._lora("w1", h) * self._lora("w3", h))
+        return h + m
+
+
+class Model(nn.Module):
+    def __init__(self, r: int) -> None:
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(VOCAB, DIM)
+        self.layers = nn.ModuleList([Block(r) for _ in range(N_LAYERS)])
+        self.norm = nn.LayerNorm(DIM)
+        self.output = nn.Linear(DIM, VOCAB, bias=False)
+        # Everything outside the blocks is frozen, so tok_embeddings and
+        # [norm, output] become FSDP units with ZERO trainable params.
+        self.tok_embeddings.weight.requires_grad_(False)
+        self.output.weight.requires_grad_(False)
+        for p in self.norm.parameters():
+            p.requires_grad_(False)
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        h = self.tok_embeddings(ids)
+        for blk in self.layers:
+            h = blk(h)
+        return self.output(self.norm(h))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rank", type=int, default=8, help="LoRA rank")
+    ap.add_argument("--seq-len", type=int, default=2048)
+    args = ap.parse_args()
+
+    dist.init_process_group("nccl")
+    local = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local)
+    ws = dist.get_world_size()
+
+    torch.manual_seed(0)
+    model = Model(args.rank).to(torch.bfloat16).cuda()
+
+    mesh = init_device_mesh("cuda", (ws,))
+    kw = {"mesh": mesh, "reshard_after_forward": True}
+    # The grouping that matters: embeddings and [norm, output] are their
+    # own units and hold no trainable parameters.
+    fully_shard(model.tok_embeddings, **kw)
+    for blk in model.layers:
+        fully_shard(blk, **kw)
+    fully_shard([model.norm, model.output], **kw)
+    fully_shard(model, **kw)
+
+    if dist.get_rank() == 0:
+        n = sum(p.numel() for p in model.layers[0].parameters() if p.requires_grad)
+        print(f"world_size={ws} lora_rank={args.rank} trainable/block={n}", flush=True)
+        print("starting backward -- hangs here at rank 8/17", flush=True)
+
+    ids = torch.randint(0, VOCAB, (1, args.seq_len), device="cuda")
+    model(ids).float().pow(2).mean().backward()
+
+    dist.barrier()
+    if dist.get_rank() == 0:
+        print("COMPLETED -- no deadlock", flush=True)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/notes/shell-environment.md
+++ b/docs/notes/shell-environment.md
@@ -370,7 +370,7 @@ This is roughly equivalent to:
 module load oneapi/release hdf5 pti-gpu
 export ZE_FLAT_DEVICE_HIERARCHY=FLAT
 export CCL_PROCESS_LAUNCHER=pmix
-export CCL_OP_SYNC=1
+export CCL_OP_SYNC="${CCL_OP_SYNC:-1}"   # default 1; override respected
 export ONEAPI_DEVICE_SELECTOR="opencl:gpu;level_zero:gpu"
 export TORCH_CPP_LOG_LEVEL=ERROR
 ```
@@ -399,7 +399,7 @@ export TORCH_CPP_LOG_LEVEL=ERROR
 |----------|---------|
 | `ZE_FLAT_DEVICE_HIERARCHY=FLAT` | Expose each PVC tile as a separate device |
 | `CCL_PROCESS_LAUNCHER=pmix` | Use PMIx for oneCCL bootstrap (matches `mpiexec`) |
-| `CCL_OP_SYNC=1` | Synchronous oneCCL ops (avoids deadlocks in some workloads) |
+| `CCL_OP_SYNC=1` | Synchronous oneCCL ops (avoids deadlocks in some workloads). **Overridable** — `export CCL_OP_SYNC=0` before calling and the helper honours it. It used to be exported unconditionally in three places, so every run had it set whether or not anyone chose it. |
 | `ONEAPI_DEVICE_SELECTOR` | Restrict to GPU devices (skip CPU OpenCL backend) |
 | `TORCH_CPP_LOG_LEVEL=ERROR` | Suppress noisy PyTorch C++ logs |
 

--- a/docs/notes/upstream-fsdp2-lora-deadlock.md
+++ b/docs/notes/upstream-fsdp2-lora-deadlock.md
@@ -1,0 +1,166 @@
+# Draft: upstream PyTorch issue for #239
+
+**Status: DRAFT, unsent -- and now probably SHOULD NOT be sent.**
+
+The Polaris control (job `7563257`) ran this exact configuration on a
+second A100 + NCCL site at `world_size=8` under torch 2.13, and it
+**trained clean** (`rc=0`, 142 s, zero watchdog lines). Sunspot
+(XPU/xccl) is clean too. So #239 has never reproduced anywhere except
+Perlmutter.
+
+An upstream torch issue is therefore not warranted on the current
+evidence: nothing here shows a defect in FSDP2 or NCCL as shipped. The
+live suspects are all Perlmutter-specific -- its NCCL 2.29.7 build, the
+AWS-libfabric plugin, Slingshot, or the cu130 pairing.
+
+This draft is kept because the *analysis* remains valid and reusable: if
+the deadlock is later reproduced off Perlmutter, most of the report is
+already written. Until then, the right venue is an NERSC ticket, not
+pytorch/pytorch.
+
+Two things should land before this goes out:
+
+1. **The Polaris control** (A100 + NCCL at `world_size=8`). Without it
+   the report cannot say whether this is NCCL-specific, and the first
+   question any reviewer asks is "does it reproduce elsewhere?"
+2. **A minimal repro that does not import ezpz.** A maintainer will not
+   run our example module. The reproducer below is sketched, not yet
+   executed.
+
+---
+
+## Title
+
+FSDP2: deterministic backward deadlock on a reduce-scatter when whole
+units are frozen (LoRA), at some parameter counts but not others
+
+## Environment
+
+- torch `2.13.0+cu130`, CUDA 13.0
+- 2 nodes x 4 A100-40GB, `world_size=8`, NCCL
+- FSDP2 (`fully_shard`), `tp=1`, bf16 with fp32 reduce
+- Model: 12-layer decoder, `dim=2048`, `n_kv_heads=4`, `hidden_dim=11008`,
+  `vocab=256128`
+
+## What happens
+
+Training deadlocks in the **first** backward pass. No step completes.
+All eight ranks report byte-identical watchdog state:
+
+```
+WorkNCCL(SeqNum=18, OpType=_REDUCE_SCATTER_BASE,
+         NumelIn=419840, NumelOut=52480, Timeout(ms)=300000)
+
+Timeout at collective: _ALLGATHER_BASE, #39
+  [0,1,2,3,4,5,6,7] joined but didn't finish collective #39
+
+PG status: last enqueued work: 39,
+           last started work: 19 (_ALLGATHER_BASE),
+           last completed work: 17
+```
+
+Stack lands in
+`torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:619`
+(`foreach_reduce`).
+
+Note `last completed: 17` -> `last started: 19`: **work #18 was
+skipped**, and #19 is an all-gather. The stream ran ahead of the
+reduce-scatter it is now blocked on.
+
+## Setup
+
+LoRA adapters are applied to attention + MLP inside every transformer
+block; everything else is frozen. Because the adapters live only inside
+blocks, two FSDP2 units end up with **zero trainable parameters**:
+
+| FSDP unit | trainable params |
+|---|---|
+| `tok_embeddings` | 0 |
+| `layers.N` (x12) | 14 |
+| `[norm, output]` | 0 |
+| root | 0 |
+
+A fully-frozen unit is asymmetric in backward: `reshard_after_forward`
+discarded its parameters, so backward re-gathers them, but
+`post_backward` returns before the reduce-scatter when the group has no
+gradients. Measured on 2 gloo ranks: **14 backward all-gathers against
+12 reduce-scatters**.
+
+## Why that asymmetry is probably NOT the cause
+
+Removing it does not fix the hang. Forcing the frozen units to stay
+gathered (`reshard_after_forward=False`) makes the counts 12/12 — the
+enqueued-op count drops 39 -> 37, exactly the two removed all-gathers —
+and the deadlock is unchanged in kind:
+
+| | default | asymmetry removed |
+|---|---|---|
+| stuck collective | `_REDUCE_SCATTER_BASE` | same |
+| payload | `419840 -> 52480` | **identical** |
+| SeqNum | 18 | 17 |
+| PG status | enq 39 / start 19 / done 17 | enq 37 / 18 / 16 |
+
+Same skipped-work signature, renumbered by exactly the intervention's
+own delta.
+
+## The strongest clue: an adapter-rank boundary
+
+The outcome depends on LoRA rank, **deterministically** (r8 reproduced
+6/6), with an exact boundary:
+
+```
+hang:   r = 8, 16, 17
+trains: r = 18, 19, 20, 24, 28, 32, 64   (and r=0, no adapters)
+```
+
+And the stuck bucket is **not linear in r**:
+
+```
+r8   SeqNum=18  NumelIn=419840   NumelOut=52480    = 52480 * 8   (linear)
+r17  SeqNum=18  NumelIn=1055232  NumelOut=131904   (linear would be 892160)
+```
+
+r17's stuck bucket is **18% larger** than one block's LoRA parameters,
+while r8's matches exactly. Both keep `NumelIn = NumelOut * world_size`,
+so both are genuine world-size reduce-scatters — but at r17 the bucket
+is evidently **not** a single unit's gradients. Something groups or pads
+differently right at the boundary, and that tracks the hang better than
+any other property we found.
+
+## Ruled out
+
+Each tested, not assumed:
+
+1. **LoRA-specific** — no; hand-freezing embeddings/norm/output with no
+   adapters gives the identical 14/12 asymmetry.
+2. **Payload size threshold** — no; hanging sizes `[419840, 839680]` vs
+   working `[212992, 1679360, 3358720]` are not separable, and the
+   smallest working case is *smaller* than the smallest hanging one.
+3. **Per-rank collective order** — no; the backward sequence is
+   byte-identical (`AAARARARARARAR`) at r=8/16/32/64, and all 8 ranks
+   agree on the stuck op.
+4. **The AG/RS asymmetry itself** — no; see above.
+5. **NCCL protocol selection** — no; `NCCL_PROTO=Simple` and `LL128`
+   both hang with `r=8` (486 s / 430 s), same payload, no
+   `invalid`/`unknown proto` warning.
+
+## Questions for maintainers
+
+1. What determines reduce-scatter bucket membership in `foreach_reduce`
+   when some units in the module tree have no gradients? Is there a
+   path where a bucket spans more than one unit?
+2. Is `post_backward` returning early for a gradient-less group safe
+   with respect to the all-gather/reduce-scatter ordering the stream
+   depends on?
+3. Is there a supported way to log bucket membership per work id? The
+   payload arithmetic identifies *sizes* but cannot name the parameters
+   in the bucket, which is exactly what is missing here.
+
+## Minimal reproducer
+
+**Not yet written.** Must not depend on ezpz. Shape:
+
+- 12-layer decoder with the geometry above
+- freeze everything, add rank-8 A/B adapters inside each block only
+- `fully_shard(tok_embeddings)`, each block, `[norm, output]`, root
+- one forward/backward at `world_size=8`, `TORCH_DDP_TIMEOUT=300`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -142,6 +142,8 @@ communication problem between ranks.
 | All ranks freeze during init | Master address unreachable | Verify hostfile, check `MASTER_ADDR` is reachable from all nodes |
 | Hangs during `backward()` or `all_reduce()` | One rank crashed silently | Set `NCCL_DEBUG=INFO` to see communication logs; check all ranks are alive |
 | Freezes after several steps | Network timeout | Increase timeout: `TORCH_DDP_TIMEOUT=7200` |
+| Hangs with no watchdog dump at all | Timeout (default 3600s) outlives the allocation | **Lower** it: `TORCH_DDP_TIMEOUT=300 TORCH_NCCL_DESYNC_DEBUG=1` |
+| Hangs in `backward()` with LoRA + FSDP2 | Fully-frozen FSDP unit all-gathers without a matching reduce-scatter | See [LoRA + FSDP2 deadlock](guides/lora-fsdp-deadlock.md) (#239) |
 | Only hangs at scale (>1 node) | Mismatched world_size or hostfile | Verify `PBS_NODEFILE` / `SLURM_NODELIST` matches expected node count |
 | Intermittent hangs | Firewall or NIC misconfiguration | Set `NCCL_SOCKET_IFNAME` to the correct interface (check with `ip link show`) |
 | **FSDP2 hangs on FIRST `all_gather_into_tensor`** on Aurora/Sunspot (XPU) | Process group bound to wrong device — fixed in `ezpz>=0.18.4` | See [XPU FSDP2 First-Step Hang](#xpu-fsdp2-first-step-hang) below |
@@ -296,7 +298,26 @@ LOG_FROM_ALL_RANKS=1 ezpz launch --line-buffer -- python3 train.py
 
 # 3. Increase the timeout to rule out slow initialization
 TORCH_DDP_TIMEOUT=7200 ezpz launch -- python3 train.py
+
+# 4. ...but LOWER it to diagnose a hang you already believe is real
+TORCH_DDP_TIMEOUT=300 TORCH_NCCL_DESYNC_DEBUG=1 \
+    TORCH_NCCL_TRACE_BUFFER_SIZE=2000 \
+    ezpz launch -- python3 train.py
 ```
+
+!!! tip "Lower the timeout when you are hunting a hang"
+
+    `TORCH_DDP_TIMEOUT` defaults to **3600s**. In a 29-minute debug
+    allocation the watchdog can therefore **never fire** — the job hits
+    the wall clock first, and you get a silent kill with no collective
+    trace instead of a dump naming the stuck operation and its
+    mismatched sequence numbers.
+
+    That silence is not evidence of anything. Raise the timeout when you
+    suspect a *slow* launch; lower it when you suspect a *stuck* one.
+    `TORCH_NCCL_DESYNC_DEBUG=1` then reports which ranks disagree.
+
+    Worked example: [LoRA + FSDP2 deadlock](guides/lora-fsdp-deadlock.md).
 
 ### FSDP-Specific Errors
 

--- a/experiments/aurora/frameworks_2026_1_0_bugs.pbs
+++ b/experiments/aurora/frameworks_2026_1_0_bugs.pbs
@@ -1,0 +1,183 @@
+#!/bin/bash
+#PBS -l select=1
+#PBS -l walltime=00:20:00
+#PBS -l filesystems=flare:home
+#PBS -A datascience
+#PBS -q validation
+#PBS -N fw2026-bugs
+#
+# ============================================================================
+# Two independent packaging bugs in Aurora's `frameworks/2026.1.0`
+# ============================================================================
+#
+# Submit:
+#     qsub experiments/aurora/frameworks_2026_1_0_bugs.pbs
+#
+# Both are COMPUTE-NODE ONLY. Login nodes offer `frameworks/2025.3.1`, where
+# neither bug exists -- so neither reproduces from a login shell, and a
+# login-node check is not evidence that a compute job will work.
+#
+# ---------------------------------------------------------------------------
+# BUG 1 -- `import torch` fails: libglog.so.0 cannot be found
+# ---------------------------------------------------------------------------
+# torch 2.13 unconditionally imports `torchcomms` (distributed_c10d.py:151).
+# Its `libtorchcomms.so` has a RUNPATH pointing ONLY at a build-time path
+# under /lus/tegu -- a Sunspot filesystem that is not mounted on Aurora -- and
+# has no $ORIGIN-relative or install-prefix entry. So its DT_NEEDED
+# libglog.so.0 cannot resolve, even though the library ships two directories
+# up in $CONDA_PREFIX/lib.
+#
+#   Workaround:  export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+#
+# 2025.3.1's torchcomms is mis-linked identically but is never imported, so
+# only 2026.1.0 is affected. That makes this a regression, not a long-standing
+# quirk.
+#
+# BUG 2 -- `import wandb` succeeds but yields an EMPTY module
+# ---------------------------------------------------------------------------
+# TWO separate things conspire here. Both are real; the second is the one
+# that actually bites, and it is NOT an ALCF bug.
+#
+#   (a) frameworks/2026.1.0 ships an EMPTY site-packages/wandb/ with no
+#       dist-info, where 2025.3.1 ships 35 entries + wandb-0.24.2.dist-info.
+#       So the module genuinely is not installed in 2026.1.0.
+#
+#   (b) THE ACTUAL SHADOW: `~/wandb` -- the run-output directory wandb
+#       itself creates (it holds run-*/, latest-run, debug.log). PBS jobs
+#       start with cwd=$HOME, cwd is on sys.path, and an ordinary directory
+#       on sys.path becomes an implicit NAMESPACE PACKAGE. So `import wandb`
+#       binds that log directory, succeeds, and yields a module with ZERO
+#       attributes:
+#
+#           AttributeError: module 'wandb' has no attribute '__version__'
+#           __path__: ['/home/<user>/wandb']    <- the giveaway
+#
+# This is nastier than a missing package: the import does not fail, so the
+# error surfaces later as a confusing "module 'wandb' has no attribute 'api'".
+# Note (b) would shadow a WORKING site install too -- so `pip install` alone
+# does not reliably fix it; you must also not run from a directory containing
+# a `wandb/` folder.
+#
+#   Workarounds:  python3 -m pip install --user wandb   (fixes (a))
+#                 cd somewhere without a ./wandb dir    (fixes (b))
+#
+# ---------------------------------------------------------------------------
+# NOTE on `set -u`: deliberately NOT used. /etc/profile references unset
+# variables and Lmod's init reads $ZSH_EVAL_CONTEXT; either aborts the script
+# instantly, giving walltime 00:00:00 and completely EMPTY .o/.e files.
+# ---------------------------------------------------------------------------
+set -o pipefail
+
+source /etc/profile 2>/dev/null || true
+
+# Do NOT pipe `module load` -- a pipeline runs in a subshell and every
+# environment change it makes is discarded, which looks exactly like the
+# module silently doing nothing.
+module load frameworks
+
+echo "=================================================================="
+echo " node            : $(hostname)"
+echo " frameworks      : $(module -t list 2>&1 | grep -i frameworks)"
+echo " CONDA_PREFIX    : ${CONDA_PREFIX:-<unset>}"
+echo " python3         : $(command -v python3)"
+echo "=================================================================="
+
+SP="${CONDA_PREFIX}/lib/python3.12/site-packages"
+rc_torch_before=0
+rc_wandb_before=0
+
+echo
+echo "################ BUG 1: torch / libglog ################"
+echo
+echo "--- 1a. import torch WITHOUT the workaround (expect: OSError libglog.so.0)"
+python3 -c "import torch; print('torch', torch.__version__)" 2>&1 | tail -3
+rc_torch_before=${PIPESTATUS[0]}
+echo "    rc=${rc_torch_before}"
+
+echo
+echo "--- 1b. the library DOES exist, it is just unreachable:"
+ls -l "${CONDA_PREFIX}/lib/libglog.so"* 2>/dev/null | head -3 || echo "    (not found -- premise changed!)"
+
+echo
+echo "--- 1c. the dangling RUNPATH that causes it:"
+TC="$(python3 -c "import os,sys; sys.path.insert(0,'${SP}'); print(os.path.join('${SP}','torchcomms','libtorchcomms.so'))" 2>/dev/null)"
+if [ -f "${TC}" ]; then
+    objdump -p "${TC}" 2>/dev/null | grep -iE "RUNPATH|RPATH" | head -2
+    echo "    -> missing libs per ldd:"
+    ldd "${TC}" 2>/dev/null | grep -i "not found" | head -4
+else
+    echo "    (libtorchcomms.so not at ${TC})"
+fi
+
+echo
+echo "--- 1d. WITH the workaround (expect: torch imports)"
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+python3 -c "import torch; print('torch', torch.__version__)" 2>&1 | tail -1
+
+echo
+echo "################ BUG 2: empty wandb namespace package ################"
+echo
+# `-s` disables the user site-packages dir. Without it, a previously
+# installed ~/.local wandb (i.e. the workaround) SHADOWS the broken site
+# one and the bug appears fixed -- which is exactly what happened on the
+# first verification run of this script.
+echo "--- 2a. import wandb, user-site DISABLED (expect: AttributeError)"
+python3 -s -c "import wandb; print('wandb', wandb.__version__)" 2>&1 | tail -2
+rc_wandb_before=${PIPESTATUS[0]}
+echo "    rc=${rc_wandb_before}   (python3 -s == ignore ~/.local)"
+
+echo
+echo "--- 2a2. same import WITH user-site (shows whether you already fixed it)"
+python3 -c "import wandb; print('wandb', wandb.__version__)" 2>&1 | tail -1
+
+echo
+echo "--- 2b. why: the directory is EMPTY and has no dist-info"
+echo "    site-packages/wandb entries : $(ls -A "${SP}/wandb" 2>/dev/null | wc -l)"
+printf "    dist-info                   : "
+ls -d "${SP}"/wandb*.dist-info 2>/dev/null | head -1 || echo "NONE (pip believes nothing is installed)"
+
+echo
+echo "--- 2c. contrast with 2025.3.1, which is fine:"
+OLD=/opt/aurora/26.26.0/frameworks/aurora_frameworks-2025.3.1/lib/python3.12/site-packages
+echo "    2025.3.1 wandb entries      : $(ls -A "${OLD}/wandb" 2>/dev/null | wc -l)"
+printf "    2025.3.1 dist-info          : "
+ls -d "${OLD}"/wandb*.dist-info 2>/dev/null | xargs -r basename || echo "NONE"
+
+echo
+echo "--- 2c2. IS THE REAL SHADOW A STRAY ./wandb IN CWD? (PBS cwd = \$HOME)"
+echo "    cwd: $(pwd)"
+if [ -d "$(pwd)/wandb" ]; then
+    echo "    FOUND $(pwd)/wandb  -- $(ls -A "$(pwd)/wandb" 2>/dev/null | wc -l) entries"
+    echo "    looks like wandb RUN OUTPUT, not a package:"
+    ls -A "$(pwd)/wandb" 2>/dev/null | head -3 | sed "s/^/      /"
+    echo "    -> cwd is on sys.path, so this becomes a namespace package"
+    echo "    -> proof: same import from a clean dir:"
+    ( cd /tmp && python3 -s -c "import wandb; print('      from /tmp:', getattr(wandb,'__version__','NO __version__'))" 2>&1 | tail -1 )
+else
+    echo "    no ./wandb in cwd -- the empty site-packages dir is the only cause"
+fi
+
+echo
+echo "--- 2d. it imports as a namespace package (no __file__ of its own):"
+python3 -s -c "
+import wandb
+print('    __file__:', getattr(wandb, '__file__', None))
+print('    __path__:', list(getattr(wandb, '__path__', [])))
+print('    n attrs :', len([a for a in dir(wandb) if not a.startswith('_')]))
+" 2>&1 | tail -3
+
+echo
+echo "=================================================================="
+echo " SUMMARY"
+echo "=================================================================="
+echo " BUG 1 torch/libglog reproduced : $([ "${rc_torch_before}" -ne 0 ] && echo YES || echo "NO -- may be fixed")"
+echo " BUG 2 empty wandb reproduced   : $([ "${rc_wandb_before}" -ne 0 ] && echo YES || echo "NO -- may be fixed")"
+echo
+echo " Workarounds:"
+echo '   export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"'
+echo "   python3 -m pip install --user wandb"
+echo
+echo " NOTE: BUG 2 is probed with \`python3 -s\` (user site-packages disabled)"
+echo " so a previously-installed ~/.local wandb cannot mask it. Step 2a2 shows"
+echo " the un-suppressed import, i.e. what your own environment actually sees."
+echo "=================================================================="

--- a/experiments/aurora/lora_239_xpu.sh
+++ b/experiments/aurora/lora_239_xpu.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# #239 on AURORA (PVC/XPU + xccl). Companion to the Sunspot script.
+#
+# CAVEAT, read before interpreting: Aurora's frameworks module ships
+# torch **2.10.0a0**, not 2.13. #239 has only ever been seen on 2.13,
+# so a clean result here is confounded by the version and is NOT
+# independent evidence that xccl is unaffected -- Sunspot (torch 2.13
+# XPU, ws=8) is the load-bearing XPU data point. A HANG here would be
+# far more interesting than a pass, since it would mean the bug predates
+# 2.13.
+#
+# Everything in #239 so far is Perlmutter: A100 + NCCL. Aurora is PVC +
+# **xccl**, running torch 2.13.0.dev+xpu -- the same major version as the
+# hang, on an entirely different collectives stack. So:
+#
+#   r8 hangs here  -> the bug is in FSDP2's bucketing/scheduling, not in
+#                     NCCL, and #239 is much broader than reported.
+#   r8 trains here -> it is NVIDIA/NCCL-specific, which is itself a strong
+#                     constraint on the mechanism.
+#
+# Either outcome is worth an allocation. Cells mirror the Perlmutter
+# matrix around the measured boundary (r8 hang / r17 hang / r18 train).
+#
+# Submit (qsub is NOT on $PATH over plain ssh -- absolute path required,
+# and all four flags are mandatory):
+#
+#   /opt/pbs/bin/qsub -l select=2 -l walltime=00:60:00 \
+#     -l filesystems=flare:home -A datascience -q workq \
+#     -o $D/lora239.o -e $D/lora239.e -- /bin/bash $D/experiments/aurora/lora_239_xpu.sh
+
+set -o pipefail
+# `set -u` is deliberately deferred until AFTER /etc/profile is sourced:
+# the profile references unset variables, so under `set -u` it aborts
+# the script instantly. Job 12473854 died that way -- walltime 00:00:00,
+# Exit_status=1, EMPTY .o and .e, not one line printed. Reproduced:
+#   bash -c 'set -u; source /etc/profile'   -> silent death
+
+# PBS runs this under a NON-login /bin/bash, where `module` does not
+# exist -- job 12473851 got all the way to the training cells and then
+# every one of them failed in ~1 s with `module: command not found`,
+# because ezpz_load_modules_aurora could not load oneapi. Initialise
+# Lmod explicitly before anything tries to use it.
+# Sourcing Lmod's init/bash alone is NOT enough: it defines `module` but
+# leaves MODULEPATH EMPTY, so `module load frameworks` silently no-ops
+# ("No modules loaded") and ezpz_setup_env then fails with
+# "CONDA_PREFIX still not set". That cost job 12473853. Source the login
+# profile, which sets MODULEPATH to the ALCF tree.
+# shellcheck disable=SC1091
+source /etc/profile 2>/dev/null || true
+if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "${MODULESHOME:-/usr/share/lmod/lmod}/init/bash" 2>/dev/null \
+        || { echo "FATAL: cannot initialise Lmod"; exit 1; }
+fi
+command -v module >/dev/null 2>&1 || { echo "FATAL: module still missing"; exit 1; }
+# Assert the PATH is populated too -- an empty MODULEPATH makes every
+# subsequent `module load` a silent no-op, which is worse than an error.
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH is empty; module loads would silently no-op"; exit 1; }
+
+# NOTE: `set -u` stays OFF for the whole script. Re-enabling it after the
+# profile was not enough -- ezpz_setup_env calls `module load frameworks`,
+# and Lmod's own init/bash reads $ZSH_EVAL_CONTEXT, which is unbound under
+# `set -u`:
+#   /usr/share/lmod/lmod/init/bash: line 237: ZSH_EVAL_CONTEXT: unbound variable
+# That killed job 12473855 mid-setup. The module machinery is simply not
+# `set -u`-clean, so this script relies on explicit checks and
+# `${VAR:-default}` everywhere instead. `set -o pipefail` is kept.
+
+D="${EZPZ_DIR:-$HOME/datascience/foremans/projects/saforem2/ezpz-239}"
+TT="${TT_DIR:-$HOME/datascience/foremans/projects/saforem2/torchtitan}"
+cd "${D}" || exit 1
+
+# THE canonical ALCF setup, exactly as used by hand:
+#
+#   source <(curl -fsSL https://bit.ly/ezpz-utils) && ezpz_setup_env
+#
+# ezpz_setup_env does everything -- python/venv selection, the module
+# stack, and the hostfile -- so do NOT hand-assemble
+# ezpz_load_modules_aurora + a venv activation. Three submissions
+# (12473850/51/52) were lost doing exactly that.
+#
+# Compute nodes have no outbound internet, so the curl form cannot be
+# used from inside a batch job (it times out after ~270 s and silently
+# leaves the environment unconfigured). Source the repo's own copy,
+# which is the same file.
+# shellcheck disable=SC1091
+source "${D}/src/ezpz/bin/utils.sh" || { echo "FATAL: no utils.sh"; exit 1; }
+ezpz_setup_env || { echo "FATAL: ezpz_setup_env failed"; exit 1; }
+
+# ezpz_setup_env activates a framework env that may already contain an
+# INSTALLED ezpz, which then shadows this checkout -- Aurora job 8784595
+# imported ezpz from ~/.local/aurora/frameworks/... instead of ${D}/src
+# and tested stale code. PYTHONPATH must come AFTER ezpz_setup_env so it
+# takes precedence over the env's site-packages.
+export PYTHONPATH="${D}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# LOWERING this is the hang diagnostic -- the 3600 s default turns a
+# deadlock into a silent timeout that outlives the allocation.
+export TORCH_DDP_TIMEOUT=300
+
+PY_BIN="$(command -v python3)"
+OUT="${D}/outputs/lora-239-aurora-${PBS_JOBID%%.*}"
+mkdir -p "${OUT}"
+# WORLD SIZE MATTERS -- do not just take every tile. coef(attn,mlp)*r
+# must divide evenly by ws or FSDP2 pads and buckets differently, which
+# makes the run non-comparable to Perlmutter:
+#     ws=8   r8 419840/8  = 52480      integral
+#     ws=24  r8 419840/24 = 17493.33   NOT integral
+# The first Sunspot run (12473856) used all 24 tiles and was therefore
+# confounded: it could not distinguish "xccl does not hang" from
+# "a different bucket layout does not hang".
+# Default to 8 to match Perlmutter exactly; override with NP= to sweep.
+NP="${NP:-8}"
+ITERS="${ITERS:-20}"
+
+echo "=== host: $(hostname) ==="
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null) ==="
+echo "=== NP=${NP} ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+# Verify we are on the SHIPPED DEFAULT arm by probing behaviour, not by
+# checking an env var -- an env check passes vacuously against a checkout
+# that predates the variable (that mistake cost Perlmutter job 57604070).
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed; ezpz from', __import__('ezpz').__file__, '===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+# $1 = lora rank
+probe () {
+    local r="$1"
+    local label="r${r}"
+    echo
+    echo "########## --lora-rank ${r} (Aurora XPU/xccl) ##########"
+    local t0=$SECONDS
+    timeout 900 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp 1 --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${r}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, not rc: on Perlmutter the r64 cell exited
+    # rc=1 having trained all 20 iters, and these runs emit no `iter=`
+    # marker at all (gating on it once mislabelled a clean pass).
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout|ProcessGroup.*[Tt]imeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    # An INDETERMINATE cell that produced NO output at all means the
+    # launch never started -- surface that instead of leaving a bare
+    # verdict with no cause to chase (12473851 left three empty logs).
+    if [ "${verdict}" = "INDETERMINATE" ] && [ ! -s "${OUT}/${label}.log" ]; then
+        echo "    (log is EMPTY -- the launch itself failed, not the run)"
+    fi
+    grep -aE "Watchdog|Timeout|last enqueued|Traceback|Error|command not found" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# r8 first: the most-reproduced Perlmutter hang (6/6). r17/r18 straddle
+# the measured NVIDIA boundary, so if r8 hangs here they say whether the
+# boundary lands in the same place on a different collectives stack.
+for r in ${RANKS:-8 17 18}; do
+    probe "${r}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== verdicts are the '### ' lines above ==="

--- a/experiments/aurora/lora_tp_xpu.sh
+++ b/experiments/aurora/lora_tp_xpu.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# #239 on AURORA (PVC/XPU + xccl). Companion to the Sunspot script.
+#
+# CAVEAT, read before interpreting: Aurora's frameworks module ships
+# torch **2.10.0a0**, not 2.13. #239 has only ever been seen on 2.13,
+# so a clean result here is confounded by the version and is NOT
+# independent evidence that xccl is unaffected -- Sunspot (torch 2.13
+# XPU, ws=8) is the load-bearing XPU data point. A HANG here would be
+# far more interesting than a pass, since it would mean the bug predates
+# 2.13.
+#
+# Everything in #239 so far is Perlmutter: A100 + NCCL. Aurora is PVC +
+# **xccl**, running torch 2.13.0.dev+xpu -- the same major version as the
+# hang, on an entirely different collectives stack. So:
+#
+#   r8 hangs here  -> the bug is in FSDP2's bucketing/scheduling, not in
+#                     NCCL, and #239 is much broader than reported.
+#   r8 trains here -> it is NVIDIA/NCCL-specific, which is itself a strong
+#                     constraint on the mechanism.
+#
+# Either outcome is worth an allocation. Cells mirror the Perlmutter
+# matrix around the measured boundary (r8 hang / r17 hang / r18 train).
+#
+# Submit (qsub is NOT on $PATH over plain ssh -- absolute path required,
+# and all four flags are mandatory):
+#
+#   /opt/pbs/bin/qsub -l select=2 -l walltime=00:60:00 \
+#     -l filesystems=flare:home -A datascience -q workq \
+#     -o $D/lora239.o -e $D/lora239.e -- /bin/bash $D/experiments/aurora/lora_239_xpu.sh
+
+set -o pipefail
+# `set -u` is deliberately deferred until AFTER /etc/profile is sourced:
+# the profile references unset variables, so under `set -u` it aborts
+# the script instantly. Job 12473854 died that way -- walltime 00:00:00,
+# Exit_status=1, EMPTY .o and .e, not one line printed. Reproduced:
+#   bash -c 'set -u; source /etc/profile'   -> silent death
+
+# PBS runs this under a NON-login /bin/bash, where `module` does not
+# exist -- job 12473851 got all the way to the training cells and then
+# every one of them failed in ~1 s with `module: command not found`,
+# because ezpz_load_modules_aurora could not load oneapi. Initialise
+# Lmod explicitly before anything tries to use it.
+# Sourcing Lmod's init/bash alone is NOT enough: it defines `module` but
+# leaves MODULEPATH EMPTY, so `module load frameworks` silently no-ops
+# ("No modules loaded") and ezpz_setup_env then fails with
+# "CONDA_PREFIX still not set". That cost job 12473853. Source the login
+# profile, which sets MODULEPATH to the ALCF tree.
+# shellcheck disable=SC1091
+source /etc/profile 2>/dev/null || true
+if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "${MODULESHOME:-/usr/share/lmod/lmod}/init/bash" 2>/dev/null \
+        || { echo "FATAL: cannot initialise Lmod"; exit 1; }
+fi
+command -v module >/dev/null 2>&1 || { echo "FATAL: module still missing"; exit 1; }
+# Assert the PATH is populated too -- an empty MODULEPATH makes every
+# subsequent `module load` a silent no-op, which is worse than an error.
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH is empty; module loads would silently no-op"; exit 1; }
+
+# NOTE: `set -u` stays OFF for the whole script. Re-enabling it after the
+# profile was not enough -- ezpz_setup_env calls `module load frameworks`,
+# and Lmod's own init/bash reads $ZSH_EVAL_CONTEXT, which is unbound under
+# `set -u`:
+#   /usr/share/lmod/lmod/init/bash: line 237: ZSH_EVAL_CONTEXT: unbound variable
+# That killed job 12473855 mid-setup. The module machinery is simply not
+# `set -u`-clean, so this script relies on explicit checks and
+# `${VAR:-default}` everywhere instead. `set -o pipefail` is kept.
+
+D="${EZPZ_DIR:-$HOME/datascience/foremans/projects/saforem2/ezpz-239}"
+TT="${TT_DIR:-$HOME/datascience/foremans/projects/saforem2/torchtitan}"
+cd "${D}" || exit 1
+
+# THE canonical ALCF setup, exactly as used by hand:
+#
+#   source <(curl -fsSL https://bit.ly/ezpz-utils) && ezpz_setup_env
+#
+# ezpz_setup_env does everything -- python/venv selection, the module
+# stack, and the hostfile -- so do NOT hand-assemble
+# ezpz_load_modules_aurora + a venv activation. Three submissions
+# (12473850/51/52) were lost doing exactly that.
+#
+# Compute nodes have no outbound internet, so the curl form cannot be
+# used from inside a batch job (it times out after ~270 s and silently
+# leaves the environment unconfigured). Source the repo's own copy,
+# which is the same file.
+# shellcheck disable=SC1091
+source "${D}/src/ezpz/bin/utils.sh" || { echo "FATAL: no utils.sh"; exit 1; }
+ezpz_setup_env || { echo "FATAL: ezpz_setup_env failed"; exit 1; }
+
+# ezpz_setup_env activates a framework env that may already contain an
+# INSTALLED ezpz, which then shadows this checkout -- Aurora job 8784595
+# imported ezpz from ~/.local/aurora/frameworks/... instead of ${D}/src
+# and tested stale code. PYTHONPATH must come AFTER ezpz_setup_env so it
+# takes precedence over the env's site-packages.
+export PYTHONPATH="${D}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# LOWERING this is the hang diagnostic -- the 3600 s default turns a
+# deadlock into a silent timeout that outlives the allocation.
+export TORCH_DDP_TIMEOUT=300
+
+PY_BIN="$(command -v python3)"
+OUT="${D}/outputs/lora-tp-aurora-${PBS_JOBID%%.*}"
+mkdir -p "${OUT}"
+# WORLD SIZE MATTERS -- do not just take every tile. coef(attn,mlp)*r
+# must divide evenly by ws or FSDP2 pads and buckets differently, which
+# makes the run non-comparable to Perlmutter:
+#     ws=8   r8 419840/8  = 52480      integral
+#     ws=24  r8 419840/24 = 17493.33   NOT integral
+# The first Sunspot run (12473856) used all 24 tiles and was therefore
+# confounded: it could not distinguish "xccl does not hang" from
+# "a different bucket layout does not hang".
+# Default to 8 to match Perlmutter exactly; override with NP= to sweep.
+NP="${NP:-$(( $(wc -l < "${PBS_NODEFILE}") * 12 ))}"   # 12 tiles/node
+ITERS="${ITERS:-20}"
+LORA_RANK="${LORA_RANK:-18}"
+
+echo "=== host: $(hostname) ==="
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null) ==="
+echo "=== NP=${NP} ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+# Verify we are on the SHIPPED DEFAULT arm by probing behaviour, not by
+# checking an env var -- an env check passes vacuously against a checkout
+# that predates the variable (that mistake cost Perlmutter job 57604070).
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed; ezpz from', __import__('ezpz').__file__, '===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+# $1 = tp degree
+probe () {
+    local tp="$1"
+    local label="tp${tp}"
+    echo
+    echo "########## --tp ${tp} --lora-rank ${LORA_RANK} ##########"
+    local t0=$SECONDS
+    timeout 900 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp "${tp}" --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${LORA_RANK}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, not rc: on Perlmutter the r64 cell exited
+    # rc=1 having trained all 20 iters, and these runs emit no `iter=`
+    # marker at all (gating on it once mislabelled a clean pass).
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout|ProcessGroup.*[Tt]imeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    # An INDETERMINATE cell that produced NO output at all means the
+    # launch never started -- surface that instead of leaving a bare
+    # verdict with no cause to chase (12473851 left three empty logs).
+    if [ "${verdict}" = "INDETERMINATE" ] && [ ! -s "${OUT}/${label}.log" ]; then
+        echo "    (log is EMPTY -- the launch itself failed, not the run)"
+    fi
+    grep -aE "Watchdog|Timeout|last enqueued|Traceback|Error|command not found" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# r8 first: the most-reproduced Perlmutter hang (6/6). r17/r18 straddle
+# the measured NVIDIA boundary, so if r8 hangs here they say whether the
+# boundary lands in the same place on a different collectives stack.
+# tp=1 FIRST: it is the control. If the known-good path fails in this
+# allocation, the tp>1 cells say nothing about TP.
+for tp in ${TPS:-1 2 4}; do
+    probe "${tp}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== verdicts are the '### ' lines above ==="

--- a/experiments/lora_tp_validation.md
+++ b/experiments/lora_tp_validation.md
@@ -1,0 +1,123 @@
+# FSDP + LoRA + **TP** validation matrix
+
+## What has NOT been validated
+
+Everything run for #239 used **`--tp 1`** — that is FSDP + LoRA with
+tensor parallelism *disabled*. The XPU runs were also single-node.
+
+| | nodes | `tp` | FSDP+LoRA | FSDP+LoRA+**TP** |
+|---|---|---|---|---|
+| Perlmutter | 2 | 1 | hangs (#239) | **not tested** |
+| Polaris | 2 | 1 | ✅ | **not tested** |
+| Sunspot | 1 | 1 | ✅ single-node | **not tested** |
+| Aurora | 1 | 1 | ✅ single-node | **not tested** |
+
+So "LoRA works on Polaris/Sunspot/Aurora" is true only for the
+`tp=1`, and only multi-node on Polaris.
+
+## Why `tp>1` is a genuinely different path, not a bigger version
+
+1. **A 2D mesh.** `tp=1` gives one flat sharded dp dim; `tp>1` builds
+   `(dp_shard, tp)` with `dp_replicate * dp_shard * tp == world_size`.
+   Different collective groups, different reduce-scatter topology.
+2. **The TP plan targets modules by NAME, and LoRA breaks it.**
+   `fsdp_tp.parallelize` maps `"attention.wq" -> ColwiseParallel()`.
+   Swapping `wq` for a LoRA wrapper raises
+   `NotImplementedError: ColwiseParallel currently only support
+   nn.Linear and nn.Embedding!`. `lora_tp_plan` rewrites those keys to
+   point at the inner `nn.Linear`. **Without it, `tp>1` dies** — and
+   that rewrite has only ever been checked at `world_size=1`, where a
+   mesh satisfies every placement trivially.
+
+That second point is the reason this matters: the one piece of code
+specifically written to make LoRA and TP coexist has never run on a
+real multi-rank mesh.
+
+## RESULTS
+
+**Sunspot (PVC/xccl, torch 2.13, 2 nodes, `world_size=24`)** — job
+`12473890`, 3/3 pass:
+
+| `tp` | mesh | result |
+|---|---|---|
+| 1 | `dp_shard=24, tp=1` | trains, 106 s |
+| 2 | `dp_shard=12, tp=2` | trains, 86 s |
+| 4 | `dp_shard=6,  tp=4` | trains, 82 s |
+
+**Polaris (A100/NCCL, torch 2.13, 2 nodes, `world_size=8`)** — job
+`7563719`, 3/3 pass:
+
+| `tp` | mesh | result |
+|---|---|---|
+| 1 | `dp_shard=8, tp=1` | trains, 156 s |
+| 2 | `dp_shard=4, tp=2` | trains, 90 s |
+| 4 | `dp_shard=2, tp=4` | trains, 84 s |
+
+**Aurora (PVC/xccl, torch 2.10, 2 nodes, `world_size=24`)** — job
+`8784784`, 3/3 pass:
+
+| `tp` | mesh | result |
+|---|---|---|
+| 1 | `dp_shard=24, tp=1` | trains, 82 s |
+| 2 | `dp_shard=12, tp=2` | trains, 84 s |
+| 4 | `dp_shard=6,  tp=4` | trains, 80 s |
+
+### Complete: 9/9
+
+| | `tp=1` | `tp=2` | `tp=4` |
+|---|---|---|---|
+| Polaris (A100/NCCL, ws=8) | 8/1 | 4/2 | 2/4 |
+| Sunspot (PVC/xccl, ws=24) | 24/1 | 12/2 | 6/4 |
+| Aurora (PVC/xccl, ws=24) | 24/1 | 12/2 | 6/4 |
+
+(cells show `dp_shard`/`tp`; every product equals that machine's world
+size, so TP was genuinely applied rather than silently downgraded)
+
+**Zero `NotImplementedError` across all six `tp>1` cells.**
+
+Aurora's cells all exit `rc=1` from a post-training `plotext` version
+mismatch — plots written, zero watchdog lines. Judging on `rc` would
+misfile three clean passes, which is why the classifier reads
+watchdog-vs-plots instead.
+
+Each cell verified from the log, not from the exit code: the
+`DeviceMesh(...)` line confirms TP was actually applied (a silent
+downgrade to `tp=1` would otherwise read as a pass), plus plots written
+and zero watchdog lines.
+
+**No `NotImplementedError: ColwiseParallel currently only support
+nn.Linear and nn.Embedding!`** — the specific failure expected if
+`lora_tp_plan`'s key rewrite were wrong. So that rewrite, which had
+only ever run at `world_size=1`, works on real multi-rank 2D meshes on
+**both** collectives backends.
+
+Two gaps closed at once: multi-node XPU (Sunspot had only ever run
+single-node) and TP>1 with LoRA anywhere.
+
+## The matrix to run
+
+Per machine, multi-node, at the world size each provides:
+
+| cell | `tp` | what it proves |
+|---|---|---|
+| `tp1-baseline` | 1 | control — the known-good path, same allocation |
+| `tp2` | 2 | `lora_tp_plan` rewrite works on a real 2D mesh |
+| `tp4` | 4 | TP degree beyond the minimum |
+
+`--lora-rank 18` throughout: on Perlmutter that avoids #239, and
+everywhere else it is simply a working rank, so a hang would be new
+information rather than a rediscovery.
+
+Run `tp1-baseline` **first** in every job. If the control fails, the
+`tp>1` cells say nothing about TP.
+
+## Expected world sizes
+
+| | nodes | per node | `world_size` | valid `tp` |
+|---|---|---|---|---|
+| Polaris | 2 | 4 | 8 | 1, 2, 4 |
+| Sunspot | 2 | 12 | 24 | 1, 2, 4 (dp must divide) |
+| Aurora | 2 | 12 | 24 | 1, 2, 4 |
+
+`dp_shard * tp == world_size` must hold, so on 24 ranks `tp=4` gives
+`dp_shard=6`.

--- a/experiments/perlmutter/lora_239_collective_order.py
+++ b/experiments/perlmutter/lora_239_collective_order.py
@@ -1,0 +1,114 @@
+"""Does the backward collective ORDER change with LoRA rank?
+
+The #239 trace shows work #18 (a reduce-scatter) skipped while #19 (an
+all-gather) started. If the frozen-unit all-gather lands at a different
+position relative to the block reduce-scatter chain depending on r, that
+would be the rank-dependence the trace otherwise lacks.
+"""
+import os, torch, torch.nn as nn, torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.device_mesh import init_device_mesh
+
+D, L, V = 64, 6, 512
+
+
+def mk(r):
+    class Blk(nn.Module):
+        def __init__(s):
+            super().__init__()
+            s.wq = nn.Linear(D, D, bias=False); s.wo = nn.Linear(D, D, bias=False)
+            s.A = nn.Linear(D, r, bias=False);  s.B = nn.Linear(r, D, bias=False)
+            for p in (s.wq.weight, s.wo.weight):
+                p.requires_grad_(False)
+
+        def forward(s, x):
+            return x + s.wo(s.wq(x)) + s.B(s.A(x))
+
+    class M(nn.Module):
+        def __init__(s):
+            super().__init__()
+            s.tok_embeddings = nn.Embedding(V, D)
+            s.layers = nn.ModuleList([Blk() for _ in range(L)])
+            s.norm = nn.LayerNorm(D); s.output = nn.Linear(D, V, bias=False)
+
+        def forward(s, i):
+            h = s.tok_embeddings(i)
+            for b in s.layers:
+                h = b(h)
+            return s.output(s.norm(h))
+
+    return M()
+
+
+def run(rank, ws, r, q):
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT="29601",
+                      RANK=str(rank), WORLD_SIZE=str(ws))
+    torch.set_default_device("cpu")
+    dist.init_process_group("gloo", rank=rank, world_size=ws)
+    m = mk(r)
+    m.tok_embeddings.weight.requires_grad_(False)
+    m.output.weight.requires_grad_(False)
+    for p in m.norm.parameters():
+        p.requires_grad_(False)
+    seq = []; ph = ["fwd"]
+    # torch 2.13 renamed the primitives FSDP2 calls:
+    #   all_gather_into_tensor -> all_gather_single
+    #   reduce_scatter_tensor  -> reduce_scatter_single
+    # Patching only the 2.12 pair records an EMPTY sequence on 2.13 --
+    # and an empty string compares equal across ranks, so the ordering
+    # check would pass vacuously. Patch whichever names exist and assert
+    # we hooked something.
+    AG_NAMES = ("all_gather_into_tensor", "all_gather_single")
+    RS_NAMES = ("reduce_scatter_tensor", "reduce_scatter_single")
+    saved = {n: getattr(dist, n) for n in AG_NAMES + RS_NAMES
+             if getattr(dist, n, None) is not None}
+    assert saved, "patched no collective at all -- torch renamed them again"
+    oag = next(saved[n] for n in AG_NAMES if n in saved)
+    ors = next(saved[n] for n in RS_NAMES if n in saved)
+
+    def ag(*a, **k):
+        seq.append((ph[0], "A")); return oag(*a, **k)
+
+    def rs(*a, **k):
+        i = k.get("input", a[1] if len(a) > 1 else None)
+        seq.append((ph[0], "R", i.numel() if i is not None else -1)); return ors(*a, **k)
+
+    for n in AG_NAMES:
+        if n in saved:
+            setattr(dist, n, ag)
+    for n in RS_NAMES:
+        if n in saved:
+            setattr(dist, n, rs)
+    mesh = init_device_mesh("cpu", (ws,)); kw = dict(mesh=mesh, reshard_after_forward=True)
+    fully_shard(m.tok_embeddings, **kw)
+    for b in m.layers:
+        fully_shard(b, **kw)
+    fully_shard([m.norm, m.output], **kw); fully_shard(m, **kw)
+    ph[0] = "fwd"
+    out = m(torch.randint(0, V, (2, 8)))
+    ph[0] = "bwd"
+    out.float().pow(2).mean().backward()
+    for n, f in saved.items():
+        setattr(dist, n, f)
+    if rank == 0:
+        assert seq, "recorded no collectives -- ws must be > 1 or this proves nothing"
+        allseq = "".join(x[1] for x in seq)
+        bwd = "".join(x[1] for x in seq if x[0] == "bwd")
+        q.put((allseq, bwd))
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    ref = None
+    for r in (8, 16, 32, 64):
+        q = mp.get_context("spawn").SimpleQueue()
+        mp.spawn(run, args=(2, r, q), nprocs=2, join=True)
+        allseq, bwd = q.get()
+        tag = ""
+        if ref is None:
+            ref = (allseq, bwd)
+        else:
+            tag = "  <-- DIFFERS" if (allseq, bwd) != ref else "  (identical to r=8)"
+        print(f"r={r:<3} full={allseq}")
+        print(f"      bwd ={bwd}{tag}")

--- a/experiments/perlmutter/lora_239_nccl_proto.sbatch
+++ b/experiments/perlmutter/lora_239_nccl_proto.sbatch
@@ -1,0 +1,139 @@
+#!/bin/bash --login
+#SBATCH --account=amsc013_g
+#SBATCH --constraint=gpu
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=4
+#SBATCH --ntasks-per-node=4
+#SBATCH --qos=debug
+#SBATCH --time=00:29:00
+#SBATCH --job-name=lora-239-proto
+#SBATCH --output=%x-%j.log
+#
+# #239: the DIRECT test of the 256 KiB NCCL-protocol hypothesis.
+#
+# The rank bisect established the boundary is 17..20, and the per-rank
+# reduce-scatter shard crosses 262144 B = 256 KiB exactly between r16
+# (209920, hangs) and r20 (262400, trains) -- an NCCL LL/LL128/Simple
+# selection boundary.
+#
+# Rank-bisecting tests that boundary only indirectly: changing r changes
+# the payload, the protocol, AND the adapter geometry all at once. This
+# job changes ONLY the protocol, holding r=8 fixed, via NCCL_PROTO.
+# That isolates the variable the bisect cannot.
+#
+#   if r8 + a forced protocol TRAINS -> the protocol is the mechanism,
+#       and users get a workaround that costs no adapter capacity.
+#   if r8 hangs under EVERY forced protocol -> the 256 KiB story is
+#       wrong or incomplete, and the r-dependence means something else.
+#
+# BUDGET. r8 hangs in ~430-500 s (5/5 so far). Two cells worst-case is
+# ~1000 s; three would risk being killed mid-cell at 29 min. So: Simple
+# first (furthest from the small-payload LL path, most likely to
+# differ), then LL128. LL is deliberately omitted -- it is the protocol
+# the failing config is already presumed to select, so it is the least
+# informative of the three.
+#
+# No control cell: r8-hangs-by-default is established 5/5 across jobs
+# 57601590 (x3), 57602201 and 57604574. Spend the allocation on new
+# information instead.
+
+set -u
+set -o pipefail
+
+D="${EZPZ_DIR:-/pscratch/sd/f/foremans/projects/ezpz}"
+cd "${D}" || exit 1
+
+VENV="${VENV:-.venv-213}"
+PY_BIN="${D}/${VENV}/bin/python"
+[ -x "${PY_BIN}" ] || { echo "FATAL: no interpreter at ${PY_BIN}"; exit 1; }
+
+export PYTHONPATH="${D}/src:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+export MPICH_GPU_SUPPORT_ENABLED=0
+
+# LOWERING this is the hang diagnostic; see docs/troubleshooting.md.
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+
+# Without this NCCL silently falls back to TCP: 8.3x slower inter-node,
+# no error. See docs/guides/perlmutter.md.
+set +u; module load nccl/2.24.3 2>/dev/null || echo "WARN: nccl module failed"; set -u
+echo "=== NCCL_NET=${NCCL_NET:-<unset>} ==="
+case ":${LD_LIBRARY_PATH:-}:" in
+    *nccl*plugin*) echo "=== nccl plugin: yes ===" ;;
+    *) echo "WARNING: no nccl plugin — expect TCP fallback" ;;
+esac
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null || echo unknown) ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+# Probe BEHAVIOUR, not an env var: assert this checkout's default really
+# reshards frozen units, so a stale checkout cannot silently swap which
+# arm is measured. (Job 57604070 was lost to exactly that mistake.)
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed: frozen units reshard ===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+OUT="${D}/outputs/lora-239-proto-${SLURM_JOB_ID}"
+mkdir -p "${OUT}"
+NP=$(( SLURM_NNODES * 4 ))
+ITERS="${ITERS:-20}"
+
+# $1 = NCCL_PROTO value
+probe () {
+    local proto="$1"
+    local label="proto-${proto}"
+    echo
+    echo "########## NCCL_PROTO=${proto}  (r8 attn,mlp) ##########"
+    local t0=$SECONDS
+    NCCL_PROTO="${proto}" NCCL_DEBUG=WARN \
+    timeout 600 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp 1 --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank 8 --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, never on rc or an `iter=` marker: these runs
+    # emit no `iter=` (that mistake reported a clean r24 pass as
+    # INDETERMINATE), and the original sweep's r64 cell exited rc=1
+    # having trained all 20 iterations.
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+
+    # An invalid/ignored NCCL_PROTO would silently make this a rerun of
+    # the default. Surface whatever NCCL said about protocol selection.
+    grep -aiE "invalid|unknown proto|NCCL_PROTO" "${OUT}/${label}.log" | head -2
+    grep -aE "Watchdog|Timeout at collective|last enqueued|Traceback|Error" \
+        "${OUT}/${label}.log" | head -3
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+for p in ${PROTOS:-Simple LL128}; do
+    probe "${p}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== r8 hangs by DEFAULT 5/5; any TRAINED above implicates the protocol ==="

--- a/experiments/perlmutter/lora_239_rank_bisect.sbatch
+++ b/experiments/perlmutter/lora_239_rank_bisect.sbatch
@@ -1,0 +1,152 @@
+#!/bin/bash --login
+#SBATCH --account=amsc013_g
+#SBATCH --constraint=gpu
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=4
+#SBATCH --ntasks-per-node=4
+#SBATCH --qos=debug
+#SBATCH --time=00:29:00
+#SBATCH --job-name=lora-239-bisect
+#SBATCH --output=%x-%j.log
+#
+# #239 lead #1: is "r8/r16 hang, r32/r64 work" a THRESHOLD, or is r just
+# a poor proxy for something else?
+#
+# Everything static about the collective stream is now ruled out --
+# LoRA-specificity, payload size, per-rank order, and the frozen-unit
+# AG/RS asymmetry itself (jobs 57601590 / 57602201). What survives is
+# that the outcome depends on r, deterministically, with an identical
+# op sequence. So find where it flips.
+#
+# BUDGET. A hang costs the full 300s watchdog plus ~90s startup; a
+# working run finishes in ~90-120s. In 29 minutes that is at most ~3
+# hangs. So this bisects rather than sweeps: binary search on the
+# boundary, at most 4 probes, widest-information-first.
+#
+#   known HANG: 16      known OK: 32       -> probe 24
+#   then 20 or 28 depending, then one more.
+#
+# Overriding: RANKS="24 20 28" sbatch lora_239_rank_bisect.sbatch
+#
+# A cell that neither hangs nor trains (crash, OOM, import error) is
+# reported as INDETERMINATE and must NOT be read as either arm.
+
+set -u
+set -o pipefail
+
+D="${EZPZ_DIR:-/pscratch/sd/f/foremans/projects/ezpz}"
+cd "${D}" || exit 1
+
+VENV="${VENV:-.venv-213}"
+PY_BIN="${D}/${VENV}/bin/python"
+[ -x "${PY_BIN}" ] || { echo "FATAL: no interpreter at ${PY_BIN}"; exit 1; }
+
+export PYTHONPATH="${D}/src:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+export MPICH_GPU_SUPPORT_ENABLED=0
+
+# 5-minute watchdog instead of the 3600s default. See
+# docs/troubleshooting.md: LOWERING this is the hang diagnostic.
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+
+# Without this NCCL silently falls back to TCP: 8.3x slower inter-node,
+# no error. See docs/guides/perlmutter.md.
+set +u; module load nccl/2.24.3 2>/dev/null || echo "WARN: nccl module failed"; set -u
+echo "=== NCCL_NET=${NCCL_NET:-<unset>} ==="
+case ":${LD_LIBRARY_PATH:-}:" in
+    *nccl*plugin*) echo "=== nccl plugin: yes ===" ;;
+    *) echo "WARNING: no nccl plugin — expect TCP fallback" ;;
+esac
+
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null || echo unknown) ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+# This job tests the SHIPPED DEFAULT path. Assert that by asking the
+# code what it actually does, not by checking an env var -- an env
+# check passes vacuously against a checkout that predates the variable.
+#
+# That is not hypothetical: job 57604070 was launched against a stale
+# checkout where frozen_unit_kwargs still defaulted to ON, so it was
+# silently bisecting the FAILED-intervention arm while reporting itself
+# as the default arm. Cancelled and relaunched. Probe the behaviour.
+EZPZ_FSDP_KEEP_FROZEN_GATHERED="${EZPZ_FSDP_KEEP_FROZEN_GATHERED:-0}" \
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+base = {'reshard_after_forward': True}
+if frozen_unit_kwargs(f, base)['reshard_after_forward'] is not True:
+    sys.exit('frozen unit is NOT resharding by default -- this checkout '
+             'predates the opt-in inversion, so it would measure the '
+             'failed-intervention arm')
+print('=== default arm confirmed: frozen units reshard ===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+OUT="${D}/outputs/lora-239-bisect-${SLURM_JOB_ID}"
+mkdir -p "${OUT}"
+NP=$(( SLURM_NNODES * 4 ))
+ITERS="${ITERS:-20}"
+
+# $1 = lora rank
+probe () {
+    local r="$1"
+    local label="r${r}"
+    echo
+    echo "########## --lora-rank ${r} ##########"
+    local t0=$SECONDS
+    timeout 600 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp 1 --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${r}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify explicitly. "did not hang" is NOT the same as "trained".
+    #
+    # Do NOT gate on an `iter=` marker: these runs do not emit one, so
+    # requiring it labelled a clean 173s r24 pass INDETERMINATE. Gate on
+    # "reached the plotting stage", which only happens after the
+    # training loop completes. Do not gate on rc either -- the original
+    # sweep's r64 cell exited rc=1 having trained all 20 iters.
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    grep -aE "Watchdog|Timeout at collective|last enqueued|Traceback|Error" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# Anchors are already established (r8/r16 HANG 4/4 across jobs 57601590
+# and 57602201; r32/r64 reported OK), so spend the allocation entirely
+# on the unexplored interval. Order is binary-search, not ascending.
+for r in ${RANKS:-24 20 28}; do
+    probe "${r}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== VERDICT TABLE ==="
+# The SLURM log is `%x-%j.log` in the SUBMIT dir, which this script
+# cannot reliably name from inside the job (and `"$0".log` / a guessed
+# job-name path both point at files that do not exist -- the repro job
+# printed an empty VERDICT TABLE for exactly that reason). The per-cell
+# verdicts are already echoed above and are captured in the SLURM log
+# itself, so just say where to look.
+echo "(verdicts are the '### ' lines above; per-cell logs in ${OUT})"

--- a/experiments/perlmutter/lora_239_repro.sbatch
+++ b/experiments/perlmutter/lora_239_repro.sbatch
@@ -1,0 +1,125 @@
+#!/bin/bash --login
+#SBATCH --account=amsc013_g
+#SBATCH --constraint=gpu
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=4
+#SBATCH --ntasks-per-node=4
+#SBATCH --qos=debug
+#SBATCH --time=00:29:00
+#SBATCH --job-name=lora-239
+#SBATCH --output=%x-%j.log
+#
+# #239: does the r8/r16 attn,mlp hang reproduce, and is it deterministic?
+#
+# The single most valuable output of this job is NOT whether the fix
+# works -- it is whether the baseline hangs all three times. Two prior
+# jobs (57540698, 57541459) each hung once, which is consistent with a
+# deterministic bug AND with a coin-flip race. Those two cannot be told
+# apart from two samples, and every downstream claim depends on which
+# it is. If baseline hangs 3/3, rank is a real variable; if it hangs
+# 1/3 or 2/3, "r8/r16 hang, r32/r64 work" was never a real boundary and
+# the whole framing needs rebuilding.
+#
+# TORCH_DDP_TIMEOUT=300 so a hang dumps in 5 min, not 60. The original
+# runs used the 3600s default, which is why they looked like silent
+# hangs instead of watchdog aborts.
+
+set -u
+set -o pipefail
+
+D="${EZPZ_DIR:-/pscratch/sd/f/foremans/projects/ezpz}"
+cd "${D}" || exit 1
+
+VENV="${VENV:-.venv-213}"
+PY_BIN="${D}/${VENV}/bin/python"
+[ -x "${PY_BIN}" ] || { echo "FATAL: no interpreter at ${PY_BIN}"; exit 1; }
+
+export PYTHONPATH="${D}/src:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+export MPICH_GPU_SUPPORT_ENABLED=0
+
+# 5-minute watchdog instead of the 3600s default: a hang must announce
+# itself inside a debug allocation.
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+
+# Without this NCCL silently falls back to TCP: 8.3x slower inter-node,
+# no error. See docs/guides/perlmutter.md.
+set +u; module load nccl/2.24.3 2>/dev/null || echo "WARN: nccl module failed"; set -u
+echo "=== NCCL_NET=${NCCL_NET:-<unset>} ==="
+case ":${LD_LIBRARY_PATH:-}:" in
+    *nccl*plugin*) echo "=== nccl plugin: yes ===" ;;
+    *) echo "WARNING: no nccl plugin — expect TCP fallback" ;;
+esac
+
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null || echo unknown) ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+OUT="${D}/outputs/lora-239-${SLURM_JOB_ID}"
+mkdir -p "${OUT}"
+NP=$(( SLURM_NNODES * 4 ))
+ITERS="${ITERS:-20}"
+
+# Proves the lever is actually in this checkout AND honours the opt-in.
+# Without this a job can silently test the wrong code and report a
+# result belonging to a different build.
+EZPZ_FSDP_KEEP_FROZEN_GATHERED=1 "${PY_BIN}" -c "
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+got = frozen_unit_kwargs(f, {'reshard_after_forward': True})
+assert got['reshard_after_forward'] is False, got
+print('=== frozen_unit_kwargs PRESENT + opt-in honoured ===')
+" || { echo "FATAL: frozen_unit_kwargs missing/inert -- refusing to run"; exit 1; }
+
+# $1 label, $2 = 0|1 for EZPZ_FSDP_KEEP_FROZEN_GATHERED (1 = keep frozen
+# units gathered, i.e. the asymmetry-removal arm; 0 = shipped default)
+run () {
+    local label="$1"; local keepgathered="$2"; shift 2
+    echo
+    echo "########## ${label}  (EZPZ_FSDP_KEEP_FROZEN_GATHERED=${keepgathered}) ##########"
+    local t0=$SECONDS
+    EZPZ_FSDP_KEEP_FROZEN_GATHERED="${keepgathered}" \
+    timeout 600 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp 1 --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --outdir "${OUT}/${label}" "$@" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+    grep -aE "iter=(1|10|20) |Watchdog|Timeout|NCCL|Traceback|Error" \
+        "${OUT}/${label}.log" | head -12 || true
+    echo "### ${label} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# Cells 1a/1b/1c: the SAME shipped-default baseline three times. This is
+# the point of the job -- determinism first, intervention second.
+# RESULT (job 57601590): rc=134 3/3, last_iter=NONE. Deterministic.
+run "1a-baseline-r8"  0 --lora-rank 8
+run "1b-baseline-r8"  0 --lora-rank 8
+run "1c-baseline-r8"  0 --lora-rank 8
+
+# Cells 2-3: asymmetry removed, against the two reported-hanging configs.
+# RESULT (job 57602201): still hung. rc=134 (r8) / rc=124 (r16),
+# last_iter=NONE. Same collective, same 419840->52480 payload, merely
+# renumbered. This is a REFUTATION, kept runnable, not a fix.
+run "2-nofrozenreshard-r8"   1 --lora-rank 8
+run "3-nofrozenreshard-r16"  1 --lora-rank 16
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== VERDICT TABLE ==="
+# The SLURM log is `%x-%j.log` in the SUBMIT dir, which this script
+# cannot reliably name from inside the job (and `"$0".log` / a guessed
+# job-name path both point at files that do not exist -- the repro job
+# printed an empty VERDICT TABLE for exactly that reason). The per-cell
+# verdicts are already echoed above and are captured in the SLURM log
+# itself, so just say where to look.
+echo "(verdicts are the '### ' lines above; per-cell logs in ${OUT})"

--- a/experiments/polaris/lora_239_a100.sh
+++ b/experiments/polaris/lora_239_a100.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# #239 on ALCF NVIDIA hardware: Polaris (A100 + NCCL, PBS).
+#
+# Perlmutter is also A100+NCCL, so this is NOT a new collectives stack --
+# it is an independent *site*: different MPI, different NCCL build,
+# different node topology (4x A100 per node vs Perlmutter's 4x, but a
+# different interconnect), and a different torch build. If the boundary
+# lands in the same place here, it is a property of FSDP2 + NCCL rather
+# than of one machine's software stack.
+#
+# Pairs with experiments/sunspot/lora_239_xpu.sh, which tests the other
+# axis (same torch major, completely different collectives: xccl).
+#
+# Submit:
+#   qsub -l select=2 -l walltime=01:00:00 -l filesystems=eagle:home \
+#     -A datascience_collab -q debug \
+#     -o $D/lora239.o -e $D/lora239.e -- /bin/bash $D/experiments/polaris/lora_239_a100.sh
+
+set -o pipefail
+# `set -u` is deliberately deferred until AFTER /etc/profile is sourced:
+# the profile references unset variables, so under `set -u` it aborts
+# the script instantly. Job 12473854 died that way -- walltime 00:00:00,
+# Exit_status=1, EMPTY .o and .e, not one line printed. Reproduced:
+#   bash -c 'set -u; source /etc/profile'   -> silent death
+
+# PBS runs this under a NON-login /bin/bash, where `module` does not
+# exist. Sunspot job 12473851 lost a whole allocation to exactly that:
+# it reached the training cells, then failed every one in ~1 s with
+# `module: command not found`. Initialise Lmod first, and hard-fail
+# rather than run cells in an unconfigured environment.
+# Lmod's init/bash alone defines `module` but leaves MODULEPATH EMPTY,
+# so every `module load` silently no-ops ("No modules loaded") and the
+# conda setup then fails with "CONDA_PREFIX still not set" -- that cost
+# Sunspot job 12473853. Source the login profile, which populates
+# MODULEPATH with the ALCF tree.
+# shellcheck disable=SC1091
+source /etc/profile 2>/dev/null || true
+if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "${MODULESHOME:-/usr/share/lmod/lmod}/init/bash" 2>/dev/null \
+        || { echo "FATAL: cannot initialise Lmod"; exit 1; }
+fi
+command -v module >/dev/null 2>&1 || { echo "FATAL: module still missing"; exit 1; }
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH is empty; module loads would silently no-op"; exit 1; }
+
+# NOTE: `set -u` stays OFF for the whole script. Re-enabling it after the
+# profile was not enough -- ezpz_setup_env calls `module load frameworks`,
+# and Lmod's own init/bash reads $ZSH_EVAL_CONTEXT, which is unbound under
+# `set -u`:
+#   /usr/share/lmod/lmod/init/bash: line 237: ZSH_EVAL_CONTEXT: unbound variable
+# That killed job 12473855 mid-setup. The module machinery is simply not
+# `set -u`-clean, so this script relies on explicit checks and
+# `${VAR:-default}` everywhere instead. `set -o pipefail` is kept.
+
+D="${EZPZ_DIR:-/lus/eagle/projects/datascience_collab/foremans/torchcomms-test/ezpz}"
+cd "${D}" || exit 1
+
+# THE canonical ALCF setup: ezpz_setup_env does python/venv selection,
+# the module stack AND the hostfile in one call. Do not hand-assemble
+# ezpz_load_modules_polaris + ezpz_setup_conda_polaris -- that is how
+# four Sunspot allocations were lost. Compute nodes have no outbound
+# internet, so source the repo's own copy of utils.sh rather than the
+# usual `source <(curl -fsSL https://bit.ly/ezpz-utils)`.
+# NOT ezpz_setup_env here. Polaris' own conda modulefiles currently
+# hard-require gcc-native/14.2 and cray-hdf5-parallel/1.14.3.5, both of
+# which the site has REMOVED, so every conda module fails to load and
+# ezpz_setup_env dies with "CONDA_PREFIX still not set" (job 7560666).
+# Use the standalone uv venv built per the polaris-fresh-venv guide.
+V="${EZPZ_VENV:-${D}/.venv-cray}"
+[ -x "${V}/bin/python" ] || { echo "FATAL: no venv at ${V}"; exit 1; }
+module load craype cray-mpich PrgEnv-nvidia cuda/12.9 2>/dev/null
+module swap PrgEnv-nvidia PrgEnv-gnu 2>/dev/null   # mpi4py was built here
+# shellcheck disable=SC1091
+source "${V}/bin/activate" || { echo "FATAL: cannot activate ${V}"; exit 1; }
+# utils.sh still wanted for ezpz_setup_job (hostfile/PBS discovery).
+# shellcheck disable=SC1091
+source "${D}/src/ezpz/bin/utils.sh" 2>/dev/null && ezpz_setup_job 2>/dev/null
+
+# PALS stages the interpreter into a per-job temp dir, so sys.prefix is
+# derived from the STAGED location, pyvenv.cfg is never found, and the
+# venv's site-packages silently drops off sys.path -- every rank then
+# dies with `ModuleNotFoundError: No module named 'torch'` even though
+# the launcher invoked the venv python and torch is installed in it
+# (job 7563242). Put site-packages on PYTHONPATH so imports survive
+# staging.
+_SP="$(echo "${V}"/lib/python3.*/site-packages)"
+export PYTHONPATH="${D}/src:${_SP}:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# LOWERING this is the hang diagnostic -- the 3600 s default turns a
+# deadlock into a silent timeout that outlives the allocation.
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+
+# Take python from the venv EXPLICITLY. $(command -v python3) resolved
+# to /usr/bin/python3 in earlier attempts and produced three
+# INDETERMINATE cells.
+PY_BIN="${V}/bin/python"
+
+# The venv MUST be built on Cray's python (/opt/cray/pe/python/3.12.12),
+# not a uv-managed one. PALS stages the interpreter into a per-job temp
+# dir, and the uv build has NO RUNPATH -- it finds libpython via
+# $ORIGIN/../lib, which stops resolving once staged:
+#   python: error while loading shared libraries:
+#     .../files/0/../lib/libpython3.12.so.1.0
+# LD_LIBRARY_PATH cannot rescue a failed $ORIGIN lookup, which is why
+# jobs 7563180 and 7563189 both died there in ~5 s. Cray's python has
+#   RUNPATH /opt/cray/pe/python/3.12.12/lib
+# and ships a working mpi4py, fixing both problems at once.
+# The libdir export below is belt-and-braces for the same class.
+_PYHOME="$(grep '^home' "${V}/pyvenv.cfg" 2>/dev/null | cut -d= -f2 | tr -d ' ')"
+if [ -n "${_PYHOME}" ] && [ -d "${_PYHOME}/../lib" ]; then
+    export LD_LIBRARY_PATH="$(cd "${_PYHOME}/../lib" && pwd)${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
+# Cray MPI + libfabric for the Cray-built mpi4py copied into this venv.
+_FAB="$(ls -d /opt/cray/libfabric/*/lib64 2>/dev/null | tail -1)"
+export LD_LIBRARY_PATH="/opt/cray/pe/lib64${_FAB:+:${_FAB}}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+echo "=== host: $(hostname) ==="
+echo "=== python3: ${PY_BIN} ==="
+
+# PREFLIGHT. On the login node `conda activate base` leaves
+# /usr/bin/python3 with no torch; if that is also true on the compute
+# node, say so and stop -- do NOT run cells that will all report
+# INDETERMINATE and waste the allocation.
+"${PY_BIN}" -c "
+import sys, torch
+print('=== torch', torch.__version__, '/ cuda avail', torch.cuda.is_available(), '===')
+if not torch.cuda.is_available():
+    sys.exit('CUDA unavailable -- environment, not a result')
+" || { echo "FATAL: no usable torch on this node (python3=${PY_BIN})"; exit 1; }
+
+# Verify the SHIPPED DEFAULT arm by probing behaviour, not an env var --
+# an env check passes vacuously against a checkout predating the
+# variable (that cost Perlmutter job 57604070).
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed; ezpz from', __import__('ezpz').__file__, '===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+OUT="${D}/outputs/lora-239-polaris-${PBS_JOBID%%.*}"
+mkdir -p "${OUT}"
+NP=$(( $(wc -l < "${PBS_NODEFILE}") * 4 ))   # 4x A100 per Polaris node
+ITERS="${ITERS:-20}"
+echo "=== NP=${NP} ==="
+
+# $1 = lora rank
+probe () {
+    local r="$1"
+    local label="r${r}"
+    echo
+    echo "########## --lora-rank ${r} (Polaris A100/NCCL) ##########"
+    local t0=$SECONDS
+    timeout 900 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp 1 --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${r}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, not rc: Perlmutter's r64 cell exited rc=1
+    # having trained all 20 iters, and these runs emit no `iter=` marker
+    # (gating on it once mislabelled a clean pass INDETERMINATE).
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    if [ "${verdict}" = "INDETERMINATE" ] && [ ! -s "${OUT}/${label}.log" ]; then
+        echo "    (log is EMPTY -- the launch itself failed, not the run)"
+    fi
+    grep -aE "Watchdog|Timeout at collective|last enqueued|Traceback|Error|command not found" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# r8 is the most-reproduced Perlmutter hang (6/6); r17/r18 straddle the
+# measured boundary there.
+for r in ${RANKS:-8 17 18}; do
+    probe "${r}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== verdicts are the '### ' lines above ==="

--- a/experiments/polaris/lora_tp_a100.sh
+++ b/experiments/polaris/lora_tp_a100.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# FSDP + LoRA + **TENSOR PARALLELISM** validation (Polaris, A100/NCCL).
+#
+# Everything run for #239 used --tp 1, i.e. TP disabled. This exercises
+# the path that has never been tested on a real multi-rank mesh:
+# fsdp_tp.parallelize maps "attention.wq" -> ColwiseParallel(), which
+# raises NotImplementedError on a LoRA wrapper; lora_tp_plan rewrites
+# those keys to the inner nn.Linear. That rewrite has only ever been
+# checked at world_size=1, where any placement is satisfied trivially.
+#
+# Perlmutter is also A100+NCCL, so this is NOT a new collectives stack --
+# it is an independent *site*: different MPI, different NCCL build,
+# different node topology (4x A100 per node vs Perlmutter's 4x, but a
+# different interconnect), and a different torch build. If the boundary
+# lands in the same place here, it is a property of FSDP2 + NCCL rather
+# than of one machine's software stack.
+#
+# Pairs with experiments/sunspot/lora_239_xpu.sh, which tests the other
+# axis (same torch major, completely different collectives: xccl).
+#
+# Submit:
+#   qsub -l select=2 -l walltime=01:00:00 -l filesystems=eagle:home \
+#     -A datascience_collab -q debug \
+#     -o $D/lora239.o -e $D/lora239.e -- /bin/bash $D/experiments/polaris/lora_239_a100.sh
+
+set -o pipefail
+# `set -u` is deliberately deferred until AFTER /etc/profile is sourced:
+# the profile references unset variables, so under `set -u` it aborts
+# the script instantly. Job 12473854 died that way -- walltime 00:00:00,
+# Exit_status=1, EMPTY .o and .e, not one line printed. Reproduced:
+#   bash -c 'set -u; source /etc/profile'   -> silent death
+
+# PBS runs this under a NON-login /bin/bash, where `module` does not
+# exist. Sunspot job 12473851 lost a whole allocation to exactly that:
+# it reached the training cells, then failed every one in ~1 s with
+# `module: command not found`. Initialise Lmod first, and hard-fail
+# rather than run cells in an unconfigured environment.
+# Lmod's init/bash alone defines `module` but leaves MODULEPATH EMPTY,
+# so every `module load` silently no-ops ("No modules loaded") and the
+# conda setup then fails with "CONDA_PREFIX still not set" -- that cost
+# Sunspot job 12473853. Source the login profile, which populates
+# MODULEPATH with the ALCF tree.
+# shellcheck disable=SC1091
+source /etc/profile 2>/dev/null || true
+if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "${MODULESHOME:-/usr/share/lmod/lmod}/init/bash" 2>/dev/null \
+        || { echo "FATAL: cannot initialise Lmod"; exit 1; }
+fi
+command -v module >/dev/null 2>&1 || { echo "FATAL: module still missing"; exit 1; }
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH is empty; module loads would silently no-op"; exit 1; }
+
+# NOTE: `set -u` stays OFF for the whole script. Re-enabling it after the
+# profile was not enough -- ezpz_setup_env calls `module load frameworks`,
+# and Lmod's own init/bash reads $ZSH_EVAL_CONTEXT, which is unbound under
+# `set -u`:
+#   /usr/share/lmod/lmod/init/bash: line 237: ZSH_EVAL_CONTEXT: unbound variable
+# That killed job 12473855 mid-setup. The module machinery is simply not
+# `set -u`-clean, so this script relies on explicit checks and
+# `${VAR:-default}` everywhere instead. `set -o pipefail` is kept.
+
+D="${EZPZ_DIR:-/lus/eagle/projects/datascience_collab/foremans/torchcomms-test/ezpz}"
+cd "${D}" || exit 1
+
+# THE canonical ALCF setup: ezpz_setup_env does python/venv selection,
+# the module stack AND the hostfile in one call. Do not hand-assemble
+# ezpz_load_modules_polaris + ezpz_setup_conda_polaris -- that is how
+# four Sunspot allocations were lost. Compute nodes have no outbound
+# internet, so source the repo's own copy of utils.sh rather than the
+# usual `source <(curl -fsSL https://bit.ly/ezpz-utils)`.
+# NOT ezpz_setup_env here. Polaris' own conda modulefiles currently
+# hard-require gcc-native/14.2 and cray-hdf5-parallel/1.14.3.5, both of
+# which the site has REMOVED, so every conda module fails to load and
+# ezpz_setup_env dies with "CONDA_PREFIX still not set" (job 7560666).
+# Use the standalone uv venv built per the polaris-fresh-venv guide.
+V="${EZPZ_VENV:-${D}/.venv-cray}"
+[ -x "${V}/bin/python" ] || { echo "FATAL: no venv at ${V}"; exit 1; }
+module load craype cray-mpich PrgEnv-nvidia cuda/12.9 2>/dev/null
+module swap PrgEnv-nvidia PrgEnv-gnu 2>/dev/null   # mpi4py was built here
+# shellcheck disable=SC1091
+source "${V}/bin/activate" || { echo "FATAL: cannot activate ${V}"; exit 1; }
+# utils.sh still wanted for ezpz_setup_job (hostfile/PBS discovery).
+# shellcheck disable=SC1091
+source "${D}/src/ezpz/bin/utils.sh" 2>/dev/null && ezpz_setup_job 2>/dev/null
+
+# PALS stages the interpreter into a per-job temp dir, so sys.prefix is
+# derived from the STAGED location, pyvenv.cfg is never found, and the
+# venv's site-packages silently drops off sys.path -- every rank then
+# dies with `ModuleNotFoundError: No module named 'torch'` even though
+# the launcher invoked the venv python and torch is installed in it
+# (job 7563242). Put site-packages on PYTHONPATH so imports survive
+# staging.
+_SP="$(echo "${V}"/lib/python3.*/site-packages)"
+export PYTHONPATH="${D}/src:${_SP}:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# LOWERING this is the hang diagnostic -- the 3600 s default turns a
+# deadlock into a silent timeout that outlives the allocation.
+export TORCH_DDP_TIMEOUT=300
+export TORCH_NCCL_DESYNC_DEBUG=1
+export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
+
+# Take python from the venv EXPLICITLY. $(command -v python3) resolved
+# to /usr/bin/python3 in earlier attempts and produced three
+# INDETERMINATE cells.
+PY_BIN="${V}/bin/python"
+
+# The venv MUST be built on Cray's python (/opt/cray/pe/python/3.12.12),
+# not a uv-managed one. PALS stages the interpreter into a per-job temp
+# dir, and the uv build has NO RUNPATH -- it finds libpython via
+# $ORIGIN/../lib, which stops resolving once staged:
+#   python: error while loading shared libraries:
+#     .../files/0/../lib/libpython3.12.so.1.0
+# LD_LIBRARY_PATH cannot rescue a failed $ORIGIN lookup, which is why
+# jobs 7563180 and 7563189 both died there in ~5 s. Cray's python has
+#   RUNPATH /opt/cray/pe/python/3.12.12/lib
+# and ships a working mpi4py, fixing both problems at once.
+# The libdir export below is belt-and-braces for the same class.
+_PYHOME="$(grep '^home' "${V}/pyvenv.cfg" 2>/dev/null | cut -d= -f2 | tr -d ' ')"
+if [ -n "${_PYHOME}" ] && [ -d "${_PYHOME}/../lib" ]; then
+    export LD_LIBRARY_PATH="$(cd "${_PYHOME}/../lib" && pwd)${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
+# Cray MPI + libfabric for the Cray-built mpi4py copied into this venv.
+_FAB="$(ls -d /opt/cray/libfabric/*/lib64 2>/dev/null | tail -1)"
+export LD_LIBRARY_PATH="/opt/cray/pe/lib64${_FAB:+:${_FAB}}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+echo "=== host: $(hostname) ==="
+echo "=== python3: ${PY_BIN} ==="
+
+# PREFLIGHT. On the login node `conda activate base` leaves
+# /usr/bin/python3 with no torch; if that is also true on the compute
+# node, say so and stop -- do NOT run cells that will all report
+# INDETERMINATE and waste the allocation.
+"${PY_BIN}" -c "
+import sys, torch
+print('=== torch', torch.__version__, '/ cuda avail', torch.cuda.is_available(), '===')
+if not torch.cuda.is_available():
+    sys.exit('CUDA unavailable -- environment, not a result')
+" || { echo "FATAL: no usable torch on this node (python3=${PY_BIN})"; exit 1; }
+
+# Verify the SHIPPED DEFAULT arm by probing behaviour, not an env var --
+# an env check passes vacuously against a checkout predating the
+# variable (that cost Perlmutter job 57604070).
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed; ezpz from', __import__('ezpz').__file__, '===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+OUT="${D}/outputs/lora-tp-polaris-${PBS_JOBID%%.*}"
+mkdir -p "${OUT}"
+NP=$(( $(wc -l < "${PBS_NODEFILE}") * 4 ))   # 4x A100 per Polaris node
+ITERS="${ITERS:-20}"
+# rank 18 avoids #239 on Perlmutter and is a plain working rank
+# elsewhere, so a hang here would be NEW information.
+LORA_RANK="${LORA_RANK:-18}"
+echo "=== NP=${NP} ==="
+
+# $1 = tp degree
+probe () {
+    local tp="$1"
+    local label="tp${tp}"
+    echo
+    echo "########## --tp ${tp} --lora-rank ${LORA_RANK} ##########"
+    local t0=$SECONDS
+    timeout 900 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp "${tp}" --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${LORA_RANK}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, not rc: Perlmutter's r64 cell exited rc=1
+    # having trained all 20 iters, and these runs emit no `iter=` marker
+    # (gating on it once mislabelled a clean pass INDETERMINATE).
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    if [ "${verdict}" = "INDETERMINATE" ] && [ ! -s "${OUT}/${label}.log" ]; then
+        echo "    (log is EMPTY -- the launch itself failed, not the run)"
+    fi
+    grep -aE "Watchdog|Timeout at collective|last enqueued|Traceback|Error|command not found" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# tp=1 FIRST: it is the control. If the known-good path fails in this
+# allocation, the tp>1 cells say nothing about TP.
+for tp in ${TPS:-1 2 4}; do
+    probe "${tp}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== verdicts are the '### ' lines above ==="

--- a/experiments/sunspot/lora_239_xpu.sh
+++ b/experiments/sunspot/lora_239_xpu.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# #239 on ALCF XPU hardware: does the LoRA r8 deadlock reproduce off NVIDIA?
+#
+# Everything in #239 so far is Perlmutter: A100 + NCCL. Sunspot is PVC +
+# **xccl**, running torch 2.13.0.dev+xpu -- the same major version as the
+# hang, on an entirely different collectives stack. So:
+#
+#   r8 hangs here  -> the bug is in FSDP2's bucketing/scheduling, not in
+#                     NCCL, and #239 is much broader than reported.
+#   r8 trains here -> it is NVIDIA/NCCL-specific, which is itself a strong
+#                     constraint on the mechanism.
+#
+# Either outcome is worth an allocation. Cells mirror the Perlmutter
+# matrix around the measured boundary (r8 hang / r17 hang / r18 train).
+#
+# Submit (qsub is NOT on $PATH over plain ssh -- absolute path required,
+# and all four flags are mandatory):
+#
+#   /opt/pbs/bin/qsub -l select=2 -l walltime=00:60:00 \
+#     -l filesystems=tegu:home -A datascience -q workq \
+#     -o $D/lora239.o -e $D/lora239.e -- /bin/bash $D/experiments/sunspot/lora_239_xpu.sh
+
+set -o pipefail
+# `set -u` is deliberately deferred until AFTER /etc/profile is sourced:
+# the profile references unset variables, so under `set -u` it aborts
+# the script instantly. Job 12473854 died that way -- walltime 00:00:00,
+# Exit_status=1, EMPTY .o and .e, not one line printed. Reproduced:
+#   bash -c 'set -u; source /etc/profile'   -> silent death
+
+# PBS runs this under a NON-login /bin/bash, where `module` does not
+# exist -- job 12473851 got all the way to the training cells and then
+# every one of them failed in ~1 s with `module: command not found`,
+# because ezpz_load_modules_sunspot could not load oneapi. Initialise
+# Lmod explicitly before anything tries to use it.
+# Sourcing Lmod's init/bash alone is NOT enough: it defines `module` but
+# leaves MODULEPATH EMPTY, so `module load frameworks` silently no-ops
+# ("No modules loaded") and ezpz_setup_env then fails with
+# "CONDA_PREFIX still not set". That cost job 12473853. Source the login
+# profile, which sets MODULEPATH to the ALCF tree.
+# shellcheck disable=SC1091
+source /etc/profile 2>/dev/null || true
+if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "${MODULESHOME:-/usr/share/lmod/lmod}/init/bash" 2>/dev/null \
+        || { echo "FATAL: cannot initialise Lmod"; exit 1; }
+fi
+command -v module >/dev/null 2>&1 || { echo "FATAL: module still missing"; exit 1; }
+# Assert the PATH is populated too -- an empty MODULEPATH makes every
+# subsequent `module load` a silent no-op, which is worse than an error.
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH is empty; module loads would silently no-op"; exit 1; }
+
+# NOTE: `set -u` stays OFF for the whole script. Re-enabling it after the
+# profile was not enough -- ezpz_setup_env calls `module load frameworks`,
+# and Lmod's own init/bash reads $ZSH_EVAL_CONTEXT, which is unbound under
+# `set -u`:
+#   /usr/share/lmod/lmod/init/bash: line 237: ZSH_EVAL_CONTEXT: unbound variable
+# That killed job 12473855 mid-setup. The module machinery is simply not
+# `set -u`-clean, so this script relies on explicit checks and
+# `${VAR:-default}` everywhere instead. `set -o pipefail` is kept.
+
+D="${EZPZ_DIR:-$HOME/datascience/foremans/projects/saforem2/ezpz}"
+TT="${TT_DIR:-$HOME/datascience/foremans/projects/saforem2/torchtitan}"
+cd "${D}" || exit 1
+
+# THE canonical ALCF setup, exactly as used by hand:
+#
+#   source <(curl -fsSL https://bit.ly/ezpz-utils) && ezpz_setup_env
+#
+# ezpz_setup_env does everything -- python/venv selection, the module
+# stack, and the hostfile -- so do NOT hand-assemble
+# ezpz_load_modules_sunspot + a venv activation. Three submissions
+# (12473850/51/52) were lost doing exactly that.
+#
+# Compute nodes have no outbound internet, so the curl form cannot be
+# used from inside a batch job (it times out after ~270 s and silently
+# leaves the environment unconfigured). Source the repo's own copy,
+# which is the same file.
+# shellcheck disable=SC1091
+source "${D}/src/ezpz/bin/utils.sh" || { echo "FATAL: no utils.sh"; exit 1; }
+ezpz_setup_env || { echo "FATAL: ezpz_setup_env failed"; exit 1; }
+
+# ezpz_setup_env activates a framework env that may already contain an
+# INSTALLED ezpz, which then shadows this checkout -- Aurora job 8784595
+# imported ezpz from ~/.local/aurora/frameworks/... instead of ${D}/src
+# and tested stale code. PYTHONPATH must come AFTER ezpz_setup_env so it
+# takes precedence over the env's site-packages.
+export PYTHONPATH="${D}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# LOWERING this is the hang diagnostic -- the 3600 s default turns a
+# deadlock into a silent timeout that outlives the allocation.
+export TORCH_DDP_TIMEOUT=300
+
+PY_BIN="$(command -v python3)"
+OUT="${D}/outputs/lora-239-xpu-${PBS_JOBID%%.*}"
+mkdir -p "${OUT}"
+# WORLD SIZE MATTERS -- do not just take every tile. coef(attn,mlp)*r
+# must divide evenly by ws or FSDP2 pads and buckets differently, which
+# makes the run non-comparable to Perlmutter:
+#     ws=8   r8 419840/8  = 52480      integral
+#     ws=24  r8 419840/24 = 17493.33   NOT integral
+# The first Sunspot run (12473856) used all 24 tiles and was therefore
+# confounded: it could not distinguish "xccl does not hang" from
+# "a different bucket layout does not hang".
+# Default to 8 to match Perlmutter exactly; override with NP= to sweep.
+NP="${NP:-8}"
+ITERS="${ITERS:-20}"
+
+echo "=== host: $(hostname) ==="
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null) ==="
+echo "=== NP=${NP} ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+# Verify we are on the SHIPPED DEFAULT arm by probing behaviour, not by
+# checking an env var -- an env check passes vacuously against a checkout
+# that predates the variable (that mistake cost Perlmutter job 57604070).
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed; ezpz from', __import__('ezpz').__file__, '===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+# $1 = lora rank
+probe () {
+    local r="$1"
+    local label="r${r}"
+    echo
+    echo "########## --lora-rank ${r} (XPU/xccl) ##########"
+    local t0=$SECONDS
+    timeout 900 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp 1 --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${r}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, not rc: on Perlmutter the r64 cell exited
+    # rc=1 having trained all 20 iters, and these runs emit no `iter=`
+    # marker at all (gating on it once mislabelled a clean pass).
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout|ProcessGroup.*[Tt]imeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    # An INDETERMINATE cell that produced NO output at all means the
+    # launch never started -- surface that instead of leaving a bare
+    # verdict with no cause to chase (12473851 left three empty logs).
+    if [ "${verdict}" = "INDETERMINATE" ] && [ ! -s "${OUT}/${label}.log" ]; then
+        echo "    (log is EMPTY -- the launch itself failed, not the run)"
+    fi
+    grep -aE "Watchdog|Timeout|last enqueued|Traceback|Error|command not found" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# r8 first: the most-reproduced Perlmutter hang (6/6). r17/r18 straddle
+# the measured NVIDIA boundary, so if r8 hangs here they say whether the
+# boundary lands in the same place on a different collectives stack.
+for r in ${RANKS:-8 17 18}; do
+    probe "${r}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== verdicts are the '### ' lines above ==="

--- a/experiments/sunspot/lora_tp_xpu.sh
+++ b/experiments/sunspot/lora_tp_xpu.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# #239 on ALCF XPU hardware: does the LoRA r8 deadlock reproduce off NVIDIA?
+#
+# Everything in #239 so far is Perlmutter: A100 + NCCL. Sunspot is PVC +
+# **xccl**, running torch 2.13.0.dev+xpu -- the same major version as the
+# hang, on an entirely different collectives stack. So:
+#
+#   r8 hangs here  -> the bug is in FSDP2's bucketing/scheduling, not in
+#                     NCCL, and #239 is much broader than reported.
+#   r8 trains here -> it is NVIDIA/NCCL-specific, which is itself a strong
+#                     constraint on the mechanism.
+#
+# Either outcome is worth an allocation. Cells mirror the Perlmutter
+# matrix around the measured boundary (r8 hang / r17 hang / r18 train).
+#
+# Submit (qsub is NOT on $PATH over plain ssh -- absolute path required,
+# and all four flags are mandatory):
+#
+#   /opt/pbs/bin/qsub -l select=2 -l walltime=00:60:00 \
+#     -l filesystems=tegu:home -A datascience -q workq \
+#     -o $D/lora239.o -e $D/lora239.e -- /bin/bash $D/experiments/sunspot/lora_239_xpu.sh
+
+set -o pipefail
+# `set -u` is deliberately deferred until AFTER /etc/profile is sourced:
+# the profile references unset variables, so under `set -u` it aborts
+# the script instantly. Job 12473854 died that way -- walltime 00:00:00,
+# Exit_status=1, EMPTY .o and .e, not one line printed. Reproduced:
+#   bash -c 'set -u; source /etc/profile'   -> silent death
+
+# PBS runs this under a NON-login /bin/bash, where `module` does not
+# exist -- job 12473851 got all the way to the training cells and then
+# every one of them failed in ~1 s with `module: command not found`,
+# because ezpz_load_modules_sunspot could not load oneapi. Initialise
+# Lmod explicitly before anything tries to use it.
+# Sourcing Lmod's init/bash alone is NOT enough: it defines `module` but
+# leaves MODULEPATH EMPTY, so `module load frameworks` silently no-ops
+# ("No modules loaded") and ezpz_setup_env then fails with
+# "CONDA_PREFIX still not set". That cost job 12473853. Source the login
+# profile, which sets MODULEPATH to the ALCF tree.
+# shellcheck disable=SC1091
+source /etc/profile 2>/dev/null || true
+if ! command -v module >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "${MODULESHOME:-/usr/share/lmod/lmod}/init/bash" 2>/dev/null \
+        || { echo "FATAL: cannot initialise Lmod"; exit 1; }
+fi
+command -v module >/dev/null 2>&1 || { echo "FATAL: module still missing"; exit 1; }
+# Assert the PATH is populated too -- an empty MODULEPATH makes every
+# subsequent `module load` a silent no-op, which is worse than an error.
+[ -n "${MODULEPATH:-}" ] || { echo "FATAL: MODULEPATH is empty; module loads would silently no-op"; exit 1; }
+
+# NOTE: `set -u` stays OFF for the whole script. Re-enabling it after the
+# profile was not enough -- ezpz_setup_env calls `module load frameworks`,
+# and Lmod's own init/bash reads $ZSH_EVAL_CONTEXT, which is unbound under
+# `set -u`:
+#   /usr/share/lmod/lmod/init/bash: line 237: ZSH_EVAL_CONTEXT: unbound variable
+# That killed job 12473855 mid-setup. The module machinery is simply not
+# `set -u`-clean, so this script relies on explicit checks and
+# `${VAR:-default}` everywhere instead. `set -o pipefail` is kept.
+
+D="${EZPZ_DIR:-$HOME/datascience/foremans/projects/saforem2/ezpz}"
+TT="${TT_DIR:-$HOME/datascience/foremans/projects/saforem2/torchtitan}"
+cd "${D}" || exit 1
+
+# THE canonical ALCF setup, exactly as used by hand:
+#
+#   source <(curl -fsSL https://bit.ly/ezpz-utils) && ezpz_setup_env
+#
+# ezpz_setup_env does everything -- python/venv selection, the module
+# stack, and the hostfile -- so do NOT hand-assemble
+# ezpz_load_modules_sunspot + a venv activation. Three submissions
+# (12473850/51/52) were lost doing exactly that.
+#
+# Compute nodes have no outbound internet, so the curl form cannot be
+# used from inside a batch job (it times out after ~270 s and silently
+# leaves the environment unconfigured). Source the repo's own copy,
+# which is the same file.
+# shellcheck disable=SC1091
+source "${D}/src/ezpz/bin/utils.sh" || { echo "FATAL: no utils.sh"; exit 1; }
+ezpz_setup_env || { echo "FATAL: ezpz_setup_env failed"; exit 1; }
+
+# ezpz_setup_env activates a framework env that may already contain an
+# INSTALLED ezpz, which then shadows this checkout -- Aurora job 8784595
+# imported ezpz from ~/.local/aurora/frameworks/... instead of ${D}/src
+# and tested stale code. PYTHONPATH must come AFTER ezpz_setup_env so it
+# takes precedence over the env's site-packages.
+export PYTHONPATH="${D}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+export PYTHONUNBUFFERED=1 WANDB_MODE=disabled
+export HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+# LOWERING this is the hang diagnostic -- the 3600 s default turns a
+# deadlock into a silent timeout that outlives the allocation.
+export TORCH_DDP_TIMEOUT=300
+
+PY_BIN="$(command -v python3)"
+OUT="${D}/outputs/lora-tp-sunspot-${PBS_JOBID%%.*}"
+mkdir -p "${OUT}"
+# WORLD SIZE MATTERS -- do not just take every tile. coef(attn,mlp)*r
+# must divide evenly by ws or FSDP2 pads and buckets differently, which
+# makes the run non-comparable to Perlmutter:
+#     ws=8   r8 419840/8  = 52480      integral
+#     ws=24  r8 419840/24 = 17493.33   NOT integral
+# The first Sunspot run (12473856) used all 24 tiles and was therefore
+# confounded: it could not distinguish "xccl does not hang" from
+# "a different bucket layout does not hang".
+# Default to 8 to match Perlmutter exactly; override with NP= to sweep.
+NP="${NP:-$(( $(wc -l < "${PBS_NODEFILE}") * 12 ))}"   # 12 tiles/node
+ITERS="${ITERS:-20}"
+LORA_RANK="${LORA_RANK:-18}"
+
+echo "=== host: $(hostname) ==="
+echo "=== ezpz commit: $(git -C "${D}" rev-parse --short HEAD 2>/dev/null) ==="
+echo "=== NP=${NP} ==="
+"${PY_BIN}" -c "import torch; print('=== torch', torch.__version__, '===')"
+
+# Verify we are on the SHIPPED DEFAULT arm by probing behaviour, not by
+# checking an env var -- an env check passes vacuously against a checkout
+# that predates the variable (that mistake cost Perlmutter job 57604070).
+"${PY_BIN}" -c "
+import os, sys
+os.environ.pop('EZPZ_FSDP_KEEP_FROZEN_GATHERED', None)
+from ezpz.examples.fsdp_tp import frozen_unit_kwargs
+import torch.nn as nn
+f = nn.Linear(4, 4, bias=False); f.weight.requires_grad_(False)
+if frozen_unit_kwargs(f, {'reshard_after_forward': True})['reshard_after_forward'] is not True:
+    sys.exit('checkout predates the opt-in inversion -- wrong arm')
+print('=== default arm confirmed; ezpz from', __import__('ezpz').__file__, '===')
+" || { echo "FATAL: wrong code under test -- refusing to run"; exit 1; }
+
+# $1 = tp degree
+probe () {
+    local tp="$1"
+    local label="tp${tp}"
+    echo
+    echo "########## --tp ${tp} --lora-rank ${LORA_RANK} ##########"
+    local t0=$SECONDS
+    timeout 900 "${PY_BIN}" -m ezpz.launch --np "${NP}" -- \
+        "${PY_BIN}" -m ezpz.examples.fsdp_tp \
+            --model agpt-2b --tp "${tp}" --dataset random \
+            --train-iters "${ITERS}" --batch-size 1 --seq-len 2048 \
+            --lora-rank "${LORA_RANK}" --lora-target attn,mlp \
+            --outdir "${OUT}/${label}" \
+        > "${OUT}/${label}.log" 2>&1
+    local rc=$?
+    local dt=$(( SECONDS - t0 ))
+    # rc captured BEFORE any pipe: `| head` SIGPIPEs tee and clobbers
+    # PIPESTATUS, which once reported rc=1 for a run that trained fine.
+    local last
+    last=$(grep -aoE "iter=[0-9]+" "${OUT}/${label}.log" | tail -1)
+
+    # Classify on evidence, not rc: on Perlmutter the r64 cell exited
+    # rc=1 having trained all 20 iters, and these runs emit no `iter=`
+    # marker at all (gating on it once mislabelled a clean pass).
+    local verdict
+    if grep -qaE "Watchdog caught collective operation timeout|ProcessGroup.*[Tt]imeout" "${OUT}/${label}.log"; then
+        verdict=HANG
+    elif grep -qa "Saving plots" "${OUT}/${label}.log" || [ -n "${last}" ]; then
+        verdict=TRAINED
+    else
+        verdict=INDETERMINATE
+    fi
+    # An INDETERMINATE cell that produced NO output at all means the
+    # launch never started -- surface that instead of leaving a bare
+    # verdict with no cause to chase (12473851 left three empty logs).
+    if [ "${verdict}" = "INDETERMINATE" ] && [ ! -s "${OUT}/${label}.log" ]; then
+        echo "    (log is EMPTY -- the launch itself failed, not the run)"
+    fi
+    grep -aE "Watchdog|Timeout|last enqueued|Traceback|Error|command not found" \
+        "${OUT}/${label}.log" | head -4
+    echo "### ${label} verdict=${verdict} rc=${rc} secs=${dt} last_iter=${last:-NONE}"
+}
+
+# r8 first: the most-reproduced Perlmutter hang (6/6). r17/r18 straddle
+# the measured NVIDIA boundary, so if r8 hangs here they say whether the
+# boundary lands in the same place on a different collectives stack.
+# tp=1 FIRST: it is the control. If the known-good path fails in this
+# allocation, the tp>1 cells say nothing about TP.
+for tp in ${TPS:-1 2 4}; do
+    probe "${tp}"
+done
+
+echo
+echo "=== artifacts: ${OUT} ==="
+echo "=== verdicts are the '### ' lines above ==="

--- a/zensical.toml
+++ b/zensical.toml
@@ -55,6 +55,7 @@ nav = [
         { "💾 Checkpoint & Restart Under Failure" = "guides/checkpoint-restart.md" },
         { "🧪 Fault Injection & --auto-retry" = "guides/fault-injection.md" },
         { "🔪 Node-Kill Postmortem" = "guides/autoretry-nodekill.md" },
+        { "🧬 LoRA + FSDP2 Deadlock (#239)" = "guides/lora-fsdp-deadlock.md" },
         { "🖥️ Perlmutter (SLURM/A100)" = "guides/perlmutter.md" },
         { "📊 agpt-2b across machines" = "guides/xmachine-agpt2b.md" },
         "recipes.md",


### PR DESCRIPTION
Docs/experiments half of #240, stacked on #241 (**merge #241 first**). No source changes — `release:skip`.

Split so the code half fits under the 150k-char automated-review limit; this half is the part bots would not have read anyway.

## `docs/guides/lora-fsdp-deadlock.md` — the #239 investigation

**Seven** hypotheses tested and refuted, each kept with its evidence so nobody re-derives them:

1. LoRA-specificity — no; hand-freezing gives the identical 14/12 asymmetry
2. Payload size — no; hanging and working sizes are not separable
3. Per-rank collective order — no; byte-identical at r=8/16/32/64
4. The AG/RS asymmetry itself — no; removing it left the deadlock unchanged
5. A 256 KiB NCCL protocol edge — **pre-registered, then falsified by r=18**
6. Protocol selection generally — no; `Simple` and `LL128` both hang
7. NCCL/FSDP2 as such — no; Polaris runs the identical config clean

**Conclusion: #239 is Perlmutter-specific** — deterministic 6/6 there, absent across nine cells on Polaris, Sunspot and Aurora. Boundary is exact: `--lora-rank 17` hangs, `18` trains. Workaround: **`--lora-rank 18` or higher**.

The refuted hypotheses are kept deliberately, including the one I pre-registered and lost. A writeup that deletes its wrong guesses teaches the next reader nothing about what was already tried.

## `SKILL.md` — how to actually run ezpz on HPC

Written from the failure modes hit getting the above, not from theory:

- `ezpz_setup_env` is **the** setup call — hand-assembling it cost four allocations
- Compute nodes have **no outbound internet**
- PBS runs a **non-login shell**: `module` is absent, and Lmod's init alone leaves `MODULEPATH` **empty** — a silent no-op, worse than an error
- `set -u` is **unusable** (profile + Lmod both abort under it)
- **`uv pip install torch` silently installs nothing** (`sys_platform == 'never'` override)
- A clean **login-node check predicts nothing** about a compute node — the class that cost the most

## `docs/notes/aurora-frameworks-2026.1.0-bugs.md`

Verified bug report with a one-line reproducer. Leads with a verdict table because **only one of the two is an ALCF defect**:

- **Bug 1 — real.** `libtorchcomms.so`'s RUNPATH points at unmounted `/lus/tegu` build paths (and, oddly, `intel64_win` / `win-x64`), so `libglog.so.0` cannot resolve despite shipping in `$CONDA_PREFIX/lib`. 2026.1.0-only regression.
- **Bug 2 — not theirs.** wandb simply is not installed; the confusing `AttributeError` comes from a stray `~/wandb` *run-output* directory shadowing it as a namespace package, since PBS starts jobs in `$HOME`.

## Also

- **Experiment scripts** for all four machines — including the ones that produced **negative** results, so the refutations stay reproducible.
- **`upstream-fsdp2-lora-deadlock.md`** — a torch issue draft marked **DO-NOT-SEND**: the Polaris control shows nothing here is a defect in FSDP2 or NCCL as shipped.
- **`troubleshooting.md`** — **lowering** `TORCH_DDP_TIMEOUT` is the hang diagnostic. Every prior mention said raise it, which is why #239 looked like silence for weeks.
- **`fault-injection.md`** — its "it worked; it did not *identify* anything" admonition is now false: reconfirmed **7/7** with `scraped` provenance on job 12473912. Original kept below the correction, since *why* it could not identify anything is the more useful lesson.

## Summary by Sourcery

Document the Perlmutter-specific LoRA/FSDP2 deadlock investigation, provide reproducible multi-system experiments, and add practical HPC troubleshooting and support notes.

New Features:
- Add a comprehensive HPC usage guide covering environment setup, batch execution, machine-specific configuration, debugging, and reproducibility pitfalls.
- Document the Perlmutter-specific LoRA/FSDP2 deadlock investigation, its measured rank boundary and workaround, cross-machine results, and refuted hypotheses.
- Add reproducible experiment scripts and a standalone FSDP2/LoRA reproducer for Aurora, Sunspot, Polaris, and Perlmutter.
- Add verified Aurora framework bug findings and draft support-ticket documentation.

Bug Fixes:
- Correct the fault-injection documentation to reflect successful node identification and preserve the original negative result as historical context.
- Clarify hang diagnosis by recommending a lower distributed timeout and improve guidance around experiment-result classification.

Enhancements:
- Document multi-node LoRA plus tensor-parallel validation and expand troubleshooting guidance for HPC environment and runtime failures.
- Make the documented CCL synchronization setting overridable instead of unconditionally enabled.
- Add navigation and repository guidance for the new HPC and deadlock documentation.

Documentation:
- Publish the #239 investigation, HPC runbook, Aurora framework bug report, support-ticket drafts, upstream issue draft, and experiment validation notes.

Tests:
- Add reproducible experiment coverage for LoRA/FSDP2 behavior across ranks, collective ordering, NCCL protocols, accelerator backends, sites, and tensor-parallel configurations.

Chores:
- Mark the upstream PyTorch issue draft as unsent pending evidence that the problem is Perlmutter-specific.